### PR TITLE
feat: add support for personal book ratings

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/BookMetadata.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/BookMetadata.java
@@ -43,6 +43,7 @@ public class BookMetadata {
     private String hardcoverId;
     private Double hardcoverRating;
     private Integer hardcoverReviewCount;
+    private Double personalRating;
     private String googleId;
 
     private Instant coverUpdatedOn;

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/BookMetadataEntity.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/BookMetadataEntity.java
@@ -90,6 +90,9 @@ public class BookMetadataEntity {
     @Column(name = "hardcover_review_count")
     private Integer hardcoverReviewCount;
 
+    @Column(name = "personal_rating")
+    private Double personalRating;
+
     @Column(name = "asin", length = 10)
     private String asin;
 
@@ -151,6 +154,9 @@ public class BookMetadataEntity {
 
     @Column(name = "hardcover_review_count_locked")
     private Boolean hardcoverReviewCountLocked = Boolean.FALSE;
+
+    @Column(name = "personal_rating_locked")
+    private Boolean personalRatingLocked = Boolean.FALSE;
 
     @Column(name = "cover_locked")
     private Boolean coverLocked = Boolean.FALSE;
@@ -225,6 +231,7 @@ public class BookMetadataEntity {
         this.goodreadsReviewCountLocked = lock;
         this.hardcoverRatingLocked = lock;
         this.hardcoverReviewCountLocked = lock;
+        this.personalRatingLocked = lock;
         this.goodreadsIdLocked = lock;
         this.hardcoverIdLocked = lock;
         this.googleIdLocked = lock;
@@ -253,6 +260,7 @@ public class BookMetadataEntity {
                 && Boolean.TRUE.equals(this.goodreadsReviewCountLocked)
                 && Boolean.TRUE.equals(this.hardcoverRatingLocked)
                 && Boolean.TRUE.equals(this.hardcoverReviewCountLocked)
+                && Boolean.TRUE.equals(this.personalRatingLocked)
                 && Boolean.TRUE.equals(this.goodreadsIdLocked)
                 && Boolean.TRUE.equals(this.hardcoverIdLocked)
                 && Boolean.TRUE.equals(this.googleIdLocked)

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataService.java
@@ -225,6 +225,7 @@ public class BookMetadataService {
             metadataCombined.setAmazonReviewCount(metadata.getAmazonReviewCount() != null ? metadata.getAmazonReviewCount() : metadataCombined.getAmazonReviewCount());
             metadataCombined.setHardcoverRating(metadata.getHardcoverRating() != null ? metadata.getHardcoverRating() : metadataCombined.getHardcoverRating());
             metadataCombined.setHardcoverReviewCount(metadata.getHardcoverReviewCount() != null ? metadata.getHardcoverReviewCount() : metadataCombined.getHardcoverReviewCount());
+            metadataCombined.setPersonalRating(metadata.getPersonalRating() != null ? metadata.getPersonalRating() : metadataCombined.getPersonalRating());
             metadataCombined.setSeriesName(metadata.getSeriesName() != null ? metadata.getSeriesName() : metadataCombined.getSeriesName());
             metadataCombined.setSeriesNumber(metadata.getSeriesNumber() != null ? metadata.getSeriesNumber() : metadataCombined.getSeriesNumber());
             metadataCombined.setSeriesTotal(metadata.getSeriesTotal() != null ? metadata.getSeriesTotal() : metadataCombined.getSeriesTotal());

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataUpdater.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataUpdater.java
@@ -113,6 +113,7 @@ public class BookMetadataUpdater {
         updateFieldIfUnlocked(metadata::getGoodreadsReviewCountLocked, newMetadata.getGoodreadsReviewCount(), metadata::setGoodreadsReviewCount);
         updateFieldIfUnlocked(metadata::getHardcoverRatingLocked, newMetadata.getHardcoverRating(), metadata::setHardcoverRating);
         updateFieldIfUnlocked(metadata::getHardcoverReviewCountLocked, newMetadata.getHardcoverReviewCount(), metadata::setHardcoverReviewCount);
+        updateFieldIfUnlocked(metadata::getPersonalRatingLocked, newMetadata.getPersonalRating(), metadata::setPersonalRating);
         updateFieldIfUnlocked(metadata::getSeriesNameLocked, newMetadata.getSeriesName(), metadata::setSeriesName);
         updateFieldIfUnlocked(metadata::getSeriesNumberLocked, newMetadata.getSeriesNumber(), metadata::setSeriesNumber);
         updateFieldIfUnlocked(metadata::getSeriesTotalLocked, newMetadata.getSeriesTotal(), metadata::setSeriesTotal);

--- a/booklore-api/src/main/resources/db/migration/V32__Add_personal_rating_column.sql
+++ b/booklore-api/src/main/resources/db/migration/V32__Add_personal_rating_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE book_metadata
+    ADD COLUMN personal_rating         FLOAT,
+    ADD COLUMN personal_rating_locked BOOLEAN DEFAULT FALSE

--- a/booklore-ui/src/app/book/components/book-browser/book-browser.component.ts
+++ b/booklore-ui/src/app/book/components/book-browser/book-browser.component.ts
@@ -41,7 +41,6 @@ import {Popover} from 'primeng/popover';
 import {Slider} from 'primeng/slider';
 import {Select} from 'primeng/select';
 import {FilterSortPreferenceService} from './filters/filter-sorting-preferences.service';
-import {TieredMenu} from 'primeng/tieredmenu';
 import {Divider} from 'primeng/divider';
 
 export enum EntityType {
@@ -75,7 +74,7 @@ const SORT_DIRECTION = {
   standalone: true,
   templateUrl: './book-browser.component.html',
   styleUrls: ['./book-browser.component.scss'],
-  imports: [Button, VirtualScrollerModule, BookCardComponent, AsyncPipe, ProgressSpinner, Menu, InputText, FormsModule, BookTableComponent, BookFilterComponent, Tooltip, NgClass, Fluid, PrimeTemplate, NgStyle, OverlayPanelModule, DropdownModule, Checkbox, Popover, Slider, Select, TieredMenu, Divider],
+  imports: [Button, VirtualScrollerModule, BookCardComponent, AsyncPipe, ProgressSpinner, Menu, InputText, FormsModule, BookTableComponent, BookFilterComponent, Tooltip, NgClass, Fluid, PrimeTemplate, NgStyle, OverlayPanelModule, DropdownModule, Checkbox, Popover, Slider, Select, Divider],
   providers: [SeriesCollapseFilter],
   animations: [
     trigger('slideInOut', [

--- a/booklore-ui/src/app/book/components/book-browser/book-filter/book-filter.component.ts
+++ b/booklore-ui/src/app/book/components/book-browser/book-filter/book-filter.component.ts
@@ -17,60 +17,79 @@ import {FilterSortPreferenceService} from '../filters/filter-sorting-preferences
 type Filter<T> = { value: T; bookCount: number };
 
 export const ratingRanges = [
-  {id: '0to1', label: '0 to 1', min: 0, max: 1},
-  {id: '1to2', label: '1 to 2', min: 1, max: 2},
-  {id: '2to3', label: '2 to 3', min: 2, max: 3},
-  {id: '3to4', label: '3 to 4', min: 3, max: 4},
-  {id: '4to4.5', label: '4 to 4.5', min: 4, max: 4.5},
-  {id: '4.5plus', label: '4.5+', min: 4.5, max: Infinity}
+  {id: '0to1', label: '0 to 1', min: 0, max: 1, sortIndex: 0},
+  {id: '1to2', label: '1 to 2', min: 1, max: 2, sortIndex: 1},
+  {id: '2to3', label: '2 to 3', min: 2, max: 3, sortIndex: 2},
+  {id: '3to4', label: '3 to 4', min: 3, max: 4, sortIndex: 3},
+  {id: '4to4.5', label: '4 to 4.5', min: 4, max: 4.5, sortIndex: 4},
+  {id: '4.5plus', label: '4.5+', min: 4.5, max: Infinity, sortIndex: 5}
+];
+
+export const ratingRanges10 = [
+  {id: '0to1', label: '0 to 1', min: 0, max: 1, sortIndex: 0},
+  {id: '1to2', label: '1 to 2', min: 1, max: 2, sortIndex: 1},
+  {id: '2to3', label: '2 to 3', min: 2, max: 3, sortIndex: 2},
+  {id: '3to4', label: '3 to 4', min: 3, max: 4, sortIndex: 3},
+  {id: '4to5', label: '4 to 5', min: 4, max: 5, sortIndex: 4},
+  {id: '5to6', label: '5 to 6', min: 5, max: 6, sortIndex: 5},
+  {id: '6to7', label: '6 to 7', min: 6, max: 7, sortIndex: 6},
+  {id: '7to8', label: '7 to 8', min: 7, max: 8, sortIndex: 7},
+  {id: '8to9', label: '8 to 9', min: 8, max: 9, sortIndex: 8},
+  {id: '9to10', label: '9 to 10', min: 9, max: 10, sortIndex: 9}
 ];
 
 export const fileSizeRanges = [
-  {id: '<1mb', label: '< 1 MB', min: 0, max: 1024},
-  {id: '1to10mb', label: '1–10 MB', min: 1024, max: 10240},
-  {id: '10to50mb', label: '10–50 MB', min: 10240, max: 51200},
-  {id: '50to100mb', label: '50–100 MB', min: 51200, max: 102400},
-  {id: '250to500mb', label: '250–500 MB', min: 256000, max: 512000},
-  {id: '500mbto1gb', label: '500 MB – 1 GB', min: 512000, max: 1048576},
-  {id: '1to2gb', label: '1–2 GB', min: 1048576, max: 2097152},
-  {id: '5plusgb', label: '5+ GB', min: 5242880, max: Infinity}
+  {id: '<1mb', label: '< 1 MB', min: 0, max: 1024, sortIndex: 0},
+  {id: '1to10mb', label: '1–10 MB', min: 1024, max: 10240, sortIndex: 1},
+  {id: '10to50mb', label: '10–50 MB', min: 10240, max: 51200, sortIndex: 2},
+  {id: '50to100mb', label: '50–100 MB', min: 51200, max: 102400, sortIndex: 3},
+  {id: '250to500mb', label: '250–500 MB', min: 256000, max: 512000, sortIndex: 4},
+  {id: '500mbto1gb', label: '0.5–1 GB', min: 512000, max: 1048576, sortIndex: 5},
+  {id: '1to2gb', label: '1–2 GB', min: 1048576, max: 2097152, sortIndex: 6},
+  {id: '5plusgb', label: '5+ GB', min: 5242880, max: Infinity, sortIndex: 7}
 ];
 
 export const pageCountRanges = [
-  {id: '<50', label: '< 50 pages', min: 0, max: 50},
-  {id: '50to100', label: '50–100 pages', min: 50, max: 100},
-  {id: '100to200', label: '100–200 pages', min: 100, max: 200},
-  {id: '200to400', label: '200–400 pages', min: 200, max: 400},
-  {id: '400to600', label: '400–600 pages', min: 400, max: 600},
-  {id: '600to1000', label: '600–1000 pages', min: 600, max: 1000},
-  {id: '1000plus', label: '1000+ pages', min: 1000, max: Infinity}
+  {id: '<50', label: '< 50 pages', min: 0, max: 50, sortIndex: 0},
+  {id: '50to100', label: '50–100 pages', min: 50, max: 100, sortIndex: 1},
+  {id: '100to200', label: '100–200 pages', min: 100, max: 200, sortIndex: 2},
+  {id: '200to400', label: '200–400 pages', min: 200, max: 400, sortIndex: 3},
+  {id: '400to600', label: '400–600 pages', min: 400, max: 600, sortIndex: 4},
+  {id: '600to1000', label: '600–1000 pages', min: 600, max: 1000, sortIndex: 5},
+  {id: '1000plus', label: '1000+ pages', min: 1000, max: Infinity, sortIndex: 6}
 ];
 
 export const matchScoreRanges = [
-  {id: '0.95-1.0', min: 0.95, max: 1.01, name: 'Outstanding (95–100%)', sortIndex: 0},
-  {id: '0.90-0.94', min: 0.90, max: 0.95, name: 'Excellent (90–94%)', sortIndex: 1},
-  {id: '0.80-0.89', min: 0.80, max: 0.90, name: 'Great (80–89%)', sortIndex: 2},
-  {id: '0.70-0.79', min: 0.70, max: 0.80, name: 'Good (70–79%)', sortIndex: 3},
-  {id: '0.50-0.69', min: 0.50, max: 0.70, name: 'Fair (50–69%)', sortIndex: 4},
-  {id: '0.30-0.49', min: 0.30, max: 0.50, name: 'Weak (30–49%)', sortIndex: 5},
-  {id: '0.00-0.29', min: 0.00, max: 0.30, name: 'Poor (0–29%)', sortIndex: 6}
+  {id: '0.95-1.0', min: 0.95, max: 1.01, label: 'Outstanding (95–100%)', sortIndex: 0},
+  {id: '0.90-0.94', min: 0.90, max: 0.95, label: 'Excellent (90–94%)', sortIndex: 1},
+  {id: '0.80-0.89', min: 0.80, max: 0.90, label: 'Great (80–89%)', sortIndex: 2},
+  {id: '0.70-0.79', min: 0.70, max: 0.80, label: 'Good (70–79%)', sortIndex: 3},
+  {id: '0.50-0.69', min: 0.50, max: 0.70, label: 'Fair (50–69%)', sortIndex: 4},
+  {id: '0.30-0.49', min: 0.30, max: 0.50, label: 'Weak (30–49%)', sortIndex: 5},
+  {id: '0.00-0.29', min: 0.00, max: 0.30, label: 'Poor (0–29%)', sortIndex: 6}
 ];
 
-const getLanguageFilter = (book: Book) => {
+function getLanguageFilter(book: Book): { id: string; name: string }[] {
   const lang = book.metadata?.language;
   return lang ? [{id: lang, name: lang}] : [];
-};
-
-function getFileSizeRangeFilters(sizeKb?: number) {
-  if (sizeKb == null) return [];
-  const match = fileSizeRanges.find(r => sizeKb >= r.min && sizeKb < r.max);
-  return match ? [{id: match.id, name: match.label}] : [];
 }
 
-function getRatingRangeFilters(rating?: number) {
+function getFileSizeRangeFilters(sizeKb?: number): { id: string; name: string; sortIndex?: number }[] {
+  if (sizeKb == null) return [];
+  const match = fileSizeRanges.find(r => sizeKb >= r.min && sizeKb < r.max);
+  return match ? [{id: match.id, name: match.label, sortIndex: match.sortIndex}] : [];
+}
+
+function getRatingRangeFilters(rating?: number): { id: string; name: string; sortIndex?: number }[] {
   if (rating == null) return [];
   const match = ratingRanges.find(r => rating >= r.min && rating < r.max);
-  return match ? [{id: match.id, name: match.label}] : [];
+  return match ? [{id: match.id, name: match.label, sortIndex: match.sortIndex}] : [];
+}
+
+function getRatingRangeFilters10(rating?: number): { id: string; name: string; sortIndex?: number }[] {
+  if (rating == null) return [];
+  const match = ratingRanges10.find(r => rating >= r.min && rating < r.max);
+  return match ? [{id: match.id, name: match.label, sortIndex: match.sortIndex}] : [];
 }
 
 function extractPublishedYearFilter(book: Book): { id: number; name: string }[] {
@@ -81,20 +100,20 @@ function extractPublishedYearFilter(book: Book): { id: number; name: string }[] 
 }
 
 function getShelfStatusFilter(book: Book): { id: string; name: string }[] {
-  const isShelved = book.shelves && book.shelves.length > 0;
+  const isShelved = book.shelves?.length! > 0;
   return [{id: isShelved ? 'shelved' : 'unshelved', name: isShelved ? 'Shelved' : 'Unshelved'}];
 }
 
-function getPageCountRangeFilters(pageCount?: number) {
+function getPageCountRangeFilters(pageCount?: number): { id: string; name: string; sortIndex?: number }[] {
   if (pageCount == null) return [];
   const match = pageCountRanges.find(r => pageCount >= r.min && pageCount < r.max);
-  return match ? [{id: match.id, name: match.label}] : [];
+  return match ? [{id: match.id, name: match.label, sortIndex: match.sortIndex}] : [];
 }
 
-export function getMatchScoreRangeFilters(score?: number | null): { id: string; name: string; sortIndex?: number }[] {
+function getMatchScoreRangeFilters(score?: number | null): { id: string; name: string; sortIndex?: number }[] {
   if (score == null) return [];
   const match = matchScoreRanges.find(r => score >= r.min && score < r.max);
-  return match ? [{id: match.id, name: match.name, sortIndex: match.sortIndex}] : [];
+  return match ? [{id: match.id, name: match.label, sortIndex: match.sortIndex}] : [];
 }
 
 @Component({
@@ -138,6 +157,8 @@ export class BookFilterComponent implements OnInit, OnDestroy {
     category: 'Category',
     series: 'Series',
     publisher: 'Publisher',
+    personalRating: 'Personal Rating',
+    matchScore: 'Metadata Match Score',
     amazonRating: 'Amazon Rating',
     goodreadsRating: 'Goodreads Rating',
     hardcoverRating: 'Hardcover Rating',
@@ -145,8 +166,7 @@ export class BookFilterComponent implements OnInit, OnDestroy {
     fileSize: 'File Size',
     shelfStatus: 'Shelf Status',
     pageCount: 'Page Count',
-    language: 'Language',
-    matchScore: 'Metadata Match Score'
+    language: 'Language'
   };
 
   private destroy$ = new Subject<void>();
@@ -167,16 +187,17 @@ export class BookFilterComponent implements OnInit, OnDestroy {
           author: this.getFilterStream((book: Book) => book.metadata?.authors.map(name => ({id: name, name})) || [], 'id', 'name', sortMode),
           category: this.getFilterStream((book: Book) => book.metadata?.categories.map(name => ({id: name, name})) || [], 'id', 'name', sortMode),
           series: this.getFilterStream((book) => (book.metadata?.seriesName ? [{id: book.metadata.seriesName, name: book.metadata.seriesName}] : []), 'id', 'name', sortMode),
-          matchScore: this.getFilterStream((book: Book) => getMatchScoreRangeFilters(book.metadataMatchScore), 'id', 'name', 'sortIndex'),
           publisher: this.getFilterStream((book) => (book.metadata?.publisher ? [{id: book.metadata.publisher, name: book.metadata.publisher}] : []), 'id', 'name', sortMode),
+          matchScore: this.getFilterStream((book: Book) => getMatchScoreRangeFilters(book.metadataMatchScore), 'id', 'name', 'sortIndex'),
+          personalRating: this.getFilterStream((book: Book) => getRatingRangeFilters10(book.metadata?.personalRating!), 'id', 'name', 'sortIndex'),
+          amazonRating: this.getFilterStream((book: Book) => getRatingRangeFilters(book.metadata?.amazonRating!), 'id', 'name', 'sortIndex'),
+          goodreadsRating: this.getFilterStream((book: Book) => getRatingRangeFilters(book.metadata?.goodreadsRating!), 'id', 'name', 'sortIndex'),
+          hardcoverRating: this.getFilterStream((book: Book) => getRatingRangeFilters(book.metadata?.hardcoverRating!), 'id', 'name', 'sortIndex'),
           shelfStatus: this.getFilterStream(getShelfStatusFilter, 'id', 'name', sortMode),
           publishedDate: this.getFilterStream(extractPublishedYearFilter, 'id', 'name', sortMode),
           language: this.getFilterStream(getLanguageFilter, 'id', 'name', sortMode),
-          fileSize: this.getFilterStream((book: Book) => getFileSizeRangeFilters(book.fileSizeKb), 'id', 'name', sortMode),
-          amazonRating: this.getFilterStream((book: Book) => getRatingRangeFilters(book.metadata?.amazonRating!), 'id', 'name', sortMode),
-          goodreadsRating: this.getFilterStream((book: Book) => getRatingRangeFilters(book.metadata?.goodreadsRating!), 'id', 'name', sortMode),
-          hardcoverRating: this.getFilterStream((book: Book) => getRatingRangeFilters(book.metadata?.hardcoverRating!), 'id', 'name', sortMode),
-          pageCount: this.getFilterStream((book: Book) => getPageCountRangeFilters(book.metadata?.pageCount!), 'id', 'name', sortMode),
+          fileSize: this.getFilterStream((book: Book) => getFileSizeRangeFilters(book.fileSizeKb), 'id', 'name', 'sortIndex'),
+          pageCount: this.getFilterStream((book: Book) => getPageCountRangeFilters(book.metadata?.pageCount!), 'id', 'name', 'sortIndex'),
         };
 
         this.filterTypes = Object.keys(this.filterStreams);

--- a/booklore-ui/src/app/book/components/book-browser/filters/SidebarFilter.ts
+++ b/booklore-ui/src/app/book/components/book-browser/filters/SidebarFilter.ts
@@ -2,11 +2,18 @@ import {Observable, combineLatest, of} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {BookFilter} from './BookFilter';
 import {BookState} from '../../../model/state/book-state.model';
-import {fileSizeRanges, matchScoreRanges, pageCountRanges, ratingRanges} from '../book-filter/book-filter.component';
+import {fileSizeRanges, matchScoreRanges, pageCountRanges, ratingRanges, ratingRanges10} from '../book-filter/book-filter.component';
 
 export function isRatingInRange(rating: number | undefined | null, rangeId: string): boolean {
   if (rating == null) return false;
   const range = ratingRanges.find(r => r.id === rangeId);
+  if (!range) return false;
+  return rating >= range.min && rating < range.max;
+}
+
+export function isRatingInRange10(rating: number | undefined | null, rangeId: string): boolean {
+  if (rating == null) return false;
+  const range = ratingRanges10.find(r => r.id === rangeId);
   if (!range) return false;
   return rating >= range.min && rating < range.max;
 }
@@ -69,6 +76,8 @@ export class SideBarFilter implements BookFilter {
                 return filterValues.some(range => isRatingInRange(book.metadata?.goodreadsRating, range));
               case 'hardcoverRating':
                 return filterValues.some(range => isRatingInRange(book.metadata?.hardcoverRating, range));
+              case 'personalRating':
+                return filterValues.some(range => isRatingInRange10(book.metadata?.personalRating, range));
               case 'publishedDate':
                 return filterValues.includes(new Date(book.metadata?.publishedDate || '').getFullYear());
               case 'fileSize':

--- a/booklore-ui/src/app/book/metadata/book-metadata-center/metadata-viewer/metadata-viewer.component.html
+++ b/booklore-ui/src/app/book/metadata/book-metadata-center/metadata-viewer/metadata-viewer.component.html
@@ -63,10 +63,24 @@
                 </p>
               </div>
             </div>
+
             <div class="flex items-center gap-2 pt-2">
+              <div class="flex items-center gap-2">
+                <i class="pi pi-thumbs-up-fill"
+                   pTooltip="Personal Rating"
+                   tooltipPosition="top">
+                </i>
+                <p-rating
+                  [ngModel]="book?.metadata!.personalRating"
+                  (onRate)="onPersonalRatingChange(book, $event)"
+                  stars="10"
+                  [style.--p-rating-icon-active-color]="getStarColorScaled(book?.metadata!.personalRating, 10)">
+                </p-rating>
+              </div>
               @if (book?.metadata!.amazonRating || book?.metadata!.goodreadsRating || book?.metadata!.hardcoverRating) {
                 @if (book?.metadata!.amazonRating) {
                   @if (book?.metadata!.asin) {
+                    <span>|</span>
                     <a class="flex items-center gap-1" [href]="'https://www.amazon.com/dp/' + book?.metadata!.asin" target="_blank" rel="noopener noreferrer">
                       <img src="https://www.amazon.com/favicon.ico" alt="Amazon"
                            class="w-5 h-5 object-contain transform transition duration-200 hover:scale-125 hover:drop-shadow-lg"/>
@@ -79,7 +93,7 @@
                     </span>
                   }
                   <p-rating [ngModel]="book?.metadata!.amazonRating" readonly stars="5"
-                            [style.--p-rating-icon-active-color]="getStarColor(book?.metadata!.amazonRating)">
+                            [style.--p-rating-icon-active-color]="getStarColorScaled(book?.metadata!.amazonRating)">
                   </p-rating>
                   <p class="font-semibold">({{ book?.metadata!.amazonReviewCount | number:'1.0-0' }})</p>
                   @if (book?.metadata!.goodreadsRating || book?.metadata!.hardcoverRating) {
@@ -100,7 +114,7 @@
                     </span>
                   }
                   <p-rating [ngModel]="book?.metadata!.goodreadsRating" readonly stars="5"
-                            [style.--p-rating-icon-active-color]="getStarColor(book?.metadata!.goodreadsRating)">
+                            [style.--p-rating-icon-active-color]="getStarColorScaled(book?.metadata!.goodreadsRating)">
                   </p-rating>
                   <p class="font-semibold">({{ book?.metadata!.goodreadsReviewCount | number:'1.0-0' }})</p>
                   @if (book?.metadata!.hardcoverRating) {
@@ -121,7 +135,7 @@
                     </span>
                   }
                   <p-rating [ngModel]="book?.metadata!.hardcoverRating" readonly stars="5"
-                            [style.--p-rating-icon-active-color]="getStarColor(book?.metadata!.hardcoverRating)">
+                            [style.--p-rating-icon-active-color]="getStarColorScaled(book?.metadata!.hardcoverRating)">
                   </p-rating>
                   <p class="font-semibold">({{ book?.metadata!.hardcoverReviewCount | number:'1.0-0' }})</p>
                   @if ((book?.metadata!.amazonRating || book?.metadata!.goodreadsRating || book?.metadata!.hardcoverRating) && book?.metadata!.googleId) {
@@ -134,17 +148,6 @@
                          class="w-5 h-5 object-contain transform transition duration-200 hover:scale-125 hover:drop-shadow-lg"/>
                   </a>
                 }
-
-              } @else {
-                <p-rating
-                  [(ngModel)]="book?.metadata!.rating"
-                  readonly
-                  stars="5"
-                  [style.--p-rating-icon-active-color]="getStarColor(book?.metadata!.rating)">
-                </p-rating>
-                <p class="font-semibold">
-                  {{ book.metadata?.reviewCount ? '(' + (book.metadata?.reviewCount | number:'1.0-0') + ' Ratings)' : 'No Ratings' }}
-                </p>
               }
             </div>
             <div class="flex gap-2 pt-4 overflow-x-auto scrollbar-hide">

--- a/booklore-ui/src/app/book/metadata/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/book/metadata/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -3,7 +3,7 @@ import {Button, ButtonDirective} from 'primeng/button';
 import {AsyncPipe, DecimalPipe, NgClass} from '@angular/common';
 import {Observable} from 'rxjs';
 import {BookService} from '../../../service/book.service';
-import {Rating} from 'primeng/rating';
+import {Rating, RatingRateEvent} from 'primeng/rating';
 import {FormsModule} from '@angular/forms';
 import {Tag} from 'primeng/tag';
 import {Book, BookMetadata, BookRecommendation} from '../../../model/book.model';
@@ -278,16 +278,18 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
     }
   }
 
-  getStarColor(rating?: number | null): string {
+  getStarColorScaled(rating?: number | null, maxScale: number = 5): string {
     if (rating == null) {
       return 'rgb(203, 213, 225)';
-    } else if (rating >= 4.5) {
+    }
+    const normalized = rating / maxScale;
+    if (normalized >= 0.9) {
       return 'rgb(34, 197, 94)';
-    } else if (rating >= 4) {
+    } else if (normalized >= 0.75) {
       return 'rgb(52, 211, 153)';
-    } else if (rating >= 3.5) {
+    } else if (normalized >= 0.6) {
       return 'rgb(234, 179, 8)';
-    } else if (rating >= 2.5) {
+    } else if (normalized >= 0.4) {
       return 'rgb(249, 115, 22)';
     } else {
       return 'rgb(239, 68, 68)';
@@ -309,5 +311,20 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
   getProgressColorClass(progress: number | null | undefined): string {
     if (progress == null) return 'bg-gray-600';
     return 'bg-blue-500';
+  }
+
+  onPersonalRatingChange(book: Book, event: RatingRateEvent): void {
+    const rating = event.value;
+    if (!book || !book.metadata) return;
+    const updatedMetadata = {
+      ...book.metadata,
+      personalRating: rating
+    };
+    this.bookService.updateBookMetadata(book.id, updatedMetadata, false).subscribe({
+      next: () => {
+      },
+      error: (err) => {
+      }
+    });
   }
 }

--- a/booklore-ui/src/app/book/model/book.model.ts
+++ b/booklore-ui/src/app/book/model/book.model.ts
@@ -61,6 +61,7 @@ export interface BookMetadata {
   goodreadsReviewCount?: number | null;
   hardcoverRating?: number | null;
   hardcoverReviewCount?: number | null;
+  personalRating?: number | null;
   coverUpdatedOn?: string;
   authors: string[];
   categories: string[];


### PR DESCRIPTION
- Introduced 'personalRating' field in book metadata
- Added UI for 10-star rating input
- Persist personal ratings via updateBookMetadata API
- Updated filters and sorting to include personal rating range