### PR TITLE
bug: Consider series name when sorting books

### DIFF
--- a/booklore-ui/src/app/book/components/book-browser/book-browser.component.ts
+++ b/booklore-ui/src/app/book/components/book-browser/book-browser.component.ts
@@ -673,7 +673,15 @@ export class BookBrowserComponent implements OnInit {
     const forceExpandSeries = this.shouldForceExpandSeries();
     return this.headerFilter.filter(bookState).pipe(
       switchMap(filtered => this.sideBarFilter.filter(filtered)),
-      switchMap(filtered => this.seriesCollapseFilter.filter(filtered, forceExpandSeries))
+      switchMap(filtered => this.seriesCollapseFilter.filter(filtered, forceExpandSeries)),
+      map(filtered =>
+        (filtered.loaded && !filtered.error)
+          ? ({
+              ...filtered,
+              books: this.sortService.applySort(filtered.books || [], this.bookSorter.selectedSort!)
+            })
+          : filtered
+      )
     );
   }
 

--- a/booklore-ui/src/app/book/service/sort.service.ts
+++ b/booklore-ui/src/app/book/service/sort.service.ts
@@ -8,7 +8,8 @@ import {SortDirection, SortOption} from "../model/sort.model";
 export class SortService {
 
   private readonly fieldExtractors: Record<string, (book: Book) => any> = {
-    title: (book) => book.metadata?.title?.toLowerCase() || null,
+    title: (book) => (book.seriesCount ? (book.metadata?.seriesName?.toLowerCase() || null) : null)
+      ?? (book.metadata?.title?.toLowerCase() || null),
     titleSeries: (book) => {
       const title = book.metadata?.title?.toLowerCase() || '';
       const series = book.metadata?.seriesName?.toLowerCase();


### PR DESCRIPTION
The books sorting now takes into consideration the series name when books are collapsed in series. Beforehand it was still using the firs book series title, displaying the series out of order.

<img width="1467" height="636" alt="image" src="https://github.com/user-attachments/assets/01c0ea7e-9dcc-438a-a6e8-9a839bafde54" />
