### PR TITLE
Fixes tab pluralization

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/metadata-manager/metadata-manager.component.html
+++ b/booklore-ui/src/app/features/metadata/component/metadata-manager/metadata-manager.component.html
@@ -15,7 +15,7 @@
       <p-tablist>
         @for (tab of tabConfigs; track tab.type) {
           <p-tab [value]="tab.type">
-            <i class="pi {{ tab.icon }}"></i> {{ tab.label }}s ({{ getMetadataItems(tab.type).length }})
+            <i class="pi {{ tab.icon }}"></i> {{ tab.label.endsWith('s') ? tab.label : tab.label + 's' }} ({{ getMetadataItems(tab.type).length }})
           </p-tab>
         }
       </p-tablist>


### PR DESCRIPTION
Checks to see if the string ends with an `s` before pluralizing the tab name in the Metadata Manager UI.

h/t to `h1ghb1rd` in Discord - https://discord.com/channels/1379932933581963444/1379934448472293447/1426987141870780456

<img width="1154" height="188" alt="image" src="https://github.com/user-attachments/assets/68e62a45-0fb3-4cec-ad22-42c75b72f9cf" />
