### PR TITLE
Fix: support non-ASCII filenames in Content-Disposition

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/controller/BookMediaController.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/controller/BookMediaController.java
@@ -9,6 +9,7 @@ import com.adityachandel.booklore.service.reader.PdfReaderService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @AllArgsConstructor
 @RestController
@@ -54,9 +56,13 @@ public class BookMediaController {
     @GetMapping("/bookdrop/{bookdropId}/cover")
     public ResponseEntity<Resource> getBookdropCover(@PathVariable long bookdropId) {
         Resource file = bookDropService.getBookdropCover(bookdropId);
+        String contentDisposition = ContentDisposition.builder("inline")
+                .filename("cover.jpg", StandardCharsets.UTF_8)
+                .build()
+                .toString();
         return (file != null)
                 ? ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=cover.jpg")
+                .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
                 .contentType(MediaType.IMAGE_JPEG)
                 .body(file)
                 : ResponseEntity.noContent().build();
@@ -75,8 +81,13 @@ public class BookMediaController {
                     ? MediaType.IMAGE_PNG
                     : MediaType.IMAGE_JPEG;
 
+            String contentDisposition = ContentDisposition.builder("inline")
+                    .filename(filename, StandardCharsets.UTF_8)
+                    .build()
+                    .toString();
+
             return ResponseEntity.ok()
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=" + filename)
+                    .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
                     .contentType(mediaType)
                     .body(file);
         } catch (Exception e) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/AdditionalFileService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/AdditionalFileService.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -78,9 +80,14 @@ public class AdditionalFileService {
 
         Resource resource = new UrlResource(filePath.toUri());
 
+        String contentDisposition = ContentDisposition.builder("attachment")
+                .filename(file.getFileName(), StandardCharsets.UTF_8)
+                .build()
+                .toString();
+
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFileName() + "\"")
+                .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
                 .body(resource);
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/BookDownloadService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/BookDownloadService.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -51,10 +53,15 @@ public class BookDownloadService {
             InputStream inputStream = new FileInputStream(bookFile);
             InputStreamResource resource = new InputStreamResource(inputStream);
 
+            String contentDisposition = ContentDisposition.builder("attachment")
+                    .filename(file.getFileName().toString(), StandardCharsets.UTF_8)
+                    .build()
+                    .toString();
+
             return ResponseEntity.ok()
                     .contentType(MediaType.APPLICATION_OCTET_STREAM)
                     .contentLength(bookFile.length())
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFileName() + "\"")
+                    .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
                     .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
                     .header(HttpHeaders.PRAGMA, "no-cache")
                     .header(HttpHeaders.EXPIRES, "0")
@@ -106,7 +113,11 @@ public class BookDownloadService {
     private void setResponseHeaders(HttpServletResponse response, File file) {
         response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
         response.setContentLengthLong(file.length());
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getName() + "\"");
+        String contentDisposition = ContentDisposition.builder("attachment")
+                .filename(file.getName(), StandardCharsets.UTF_8)
+                .build()
+                .toString();
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition);
     }
 
     private void streamFileToResponse(File file, HttpServletResponse response) throws IOException {

--- a/booklore-ui/src/app/shared/service/file-download.service.ts
+++ b/booklore-ui/src/app/shared/service/file-download.service.ts
@@ -76,9 +76,11 @@ export class FileDownloadService {
 
   private extractFilenameFromResponse(response: HttpResponse<Blob>, defaultFilename: string): string {
     const contentDisposition = response.headers.get('Content-Disposition');
-    return contentDisposition
-      ? contentDisposition.match(/filename="(.+?)"/)?.[1] || defaultFilename
-      : defaultFilename;
+    if (contentDisposition) {
+      const encodedFilename = contentDisposition.match(/filename\*=UTF-8''([\w%\-\.]+)(?:; ?|$)/i)?.[1];
+      return encodedFilename ? decodeURIComponent(encodedFilename) : defaultFilename;
+    }
+    return defaultFilename;
   }
 
   private triggerBrowserDownload(blob: Blob, filename: string): void {


### PR DESCRIPTION
This PR fixes issue #1053 by adding support for non-ASCII characters in `Content-Disposition` headers during book downloads (web and OPDS). Previously, `filename=` only handled ASCII, causing errors with international characters. I've updated it to use `filename*=` for proper UTF-8 encoding, so all filenames download correctly now. Screenshots showing the fix are attached.
<img width="950" height="607" alt="image" src="https://github.com/user-attachments/assets/f75953c6-5a1f-4752-b94e-00c7b15cc7b9" />
