### PR TITLE
add: .gitattributes for building on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,107 @@
+## Set Git attributes for paths including line ending
+## normalization, diff behavior, etc.
+##
+## Get latest from `dotnet new gitattributes`
+
+# Auto detect text files and perform LF normalization
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+
+*.cs     text diff=csharp
+*.cshtml text diff=html
+*.csx    text diff=csharp
+*.sln    text eol=crlf
+
+# Content below from: https://github.com/gitattributes/gitattributes/blob/master/Common.gitattributes
+
+# Documents
+*.bibtex   text diff=bibtex
+*.doc      diff=astextplain
+*.DOC      diff=astextplain
+*.docx     diff=astextplain
+*.DOCX     diff=astextplain
+*.dot      diff=astextplain
+*.DOT      diff=astextplain
+*.pdf      diff=astextplain
+*.PDF      diff=astextplain
+*.rtf      diff=astextplain
+*.RTF      diff=astextplain
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text
+# Per RFC 4180, .csv should be CRLF
+*.csv      text eol=crlf
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+*.epub     diff=astextplain
+
+# Graphics
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.tif      binary
+*.tiff     binary
+*.ico      binary
+# SVG treated as text by default.
+*.svg      text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg    binary
+*.eps      binary
+
+# Scripts
+# Force Unix scripts to always use lf line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.ksh      text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+# Likewise, force cmd and batch scripts to always use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+
+# Serialization
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.bz       binary
+*.bz2      binary
+*.bzip2    binary
+*.gz       binary
+*.lz       binary
+*.lzma     binary
+*.rar      binary
+*.tar      binary
+*.taz      binary
+*.tbz      binary
+*.tbz2     binary
+*.tgz      binary
+*.tlz      binary
+*.txz      binary
+*.xz       binary
+*.Z        binary
+*.zip      binary
+*.zst      binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+# Exclude files from exporting
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore


### PR DESCRIPTION
The .sh files end up with CRLF without this and won't be able to run. This adds a default .gitattributes to the repo