### PR TITLE
fix: tie book uploading topbar item to upload book permission

### DIFF
--- a/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.html
+++ b/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.html
@@ -45,7 +45,7 @@
             }
           </li>
           <li>
-            @if (userState.user?.permissions?.canManipulateLibrary || userState.user?.permissions?.admin) {
+            @if (userState.user?.permissions?.canUpload || userState.user?.permissions?.admin) {
               <a class="topbar-item" (click)="openFileUploadDialog()" pTooltip="Upload Book" tooltipPosition="bottom">
                 <i class="pi pi-upload text-surface-100"></i>
               </a>
@@ -170,19 +170,21 @@
               <li>
                 <button
                   class="flex items-center gap-2 w-full text-left p-2 hover:bg-surface-200 dark:hover:bg-surface-700 rounded"
-                  (click)="openFileUploadDialog(); mobileMenu.hide()"
-                >
-                  <i class="pi pi-upload text-surface-100"></i>
-                  Upload Book
-                </button>
-              </li>
-              <li>
-                <button
-                  class="flex items-center gap-2 w-full text-left p-2 hover:bg-surface-200 dark:hover:bg-surface-700 rounded"
                   (click)="navigateToBookdrop(); mobileMenu.hide()"
                 >
                   <i class="pi pi-inbox text-surface-100"></i>
                   Bookdrop
+                </button>
+              </li>
+            }
+            @if (userState.user?.permissions?.canUpload || userState.user?.permissions?.admin) {
+              <li>
+                <button
+                  class="flex items-center gap-2 w-full text-left p-2 hover:bg-surface-200 dark:hover:bg-surface-700 rounded"
+                  (click)="openFileUploadDialog(); mobileMenu.hide()"
+                >
+                  <i class="pi pi-upload text-surface-100"></i>
+                  Upload Book
                 </button>
               </li>
             }


### PR DESCRIPTION
This closes https://github.com/booklore-app/booklore/issues/1141. Tested in a Docker container with:
- [An admin account (full permissions)](https://github.com/user-attachments/assets/b6ba7e72-e88d-4108-b0c2-3ebce776ec95)
- [A user with all permissions except Admin and Upload Book](https://github.com/user-attachments/assets/bf295e97-612e-4baf-b2c8-9dab24cd11e4)
- [A user with only Upload Book permissions](https://github.com/user-attachments/assets/ad26afb0-ee52-4bc2-9c6b-0b98be3067ef).

I did notice an issue with a gap between items when permissions are not high enough, but given that this happens on the base repository and is not introduced per se with this PR, I've elected not to chase it.