### PR TITLE
feat(ui): make grid view cells clickable

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-table/book-table.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-table/book-table.component.html
@@ -48,8 +48,27 @@
             (click)="toggleMetadataLock(metadata)">
           </p-button>
         </td>
-        <td (click)="openMetadataCenter(book.id)" class="cursor-pointer">
-          <img [attr.src]="urlHelper.getThumbnailUrl(metadata.bookId, metadata.coverUpdatedOn)" alt="Book Cover" class="size-7"/>
+        <td>
+          <a [routerLink]="urlHelper.getBookUrl(book)">
+            <img
+              [attr.src]="urlHelper.getThumbnailUrl(metadata.bookId, metadata.coverUpdatedOn)"
+              alt="Book Cover"
+              class="size-7"
+              tooltipPosition="left"
+              [pTooltip]="tooltipContent"
+              tooltipStyleClass="[&>.p-tooltip-text]:p-1"
+            />
+          </a>
+          <ng-template #tooltipContent>
+            <div class="flex flex-col items-center gap-2">
+              <img
+                [attr.src]="urlHelper.getThumbnailUrl(metadata.bookId, metadata.coverUpdatedOn)"
+                alt="Book Cover"
+                class="w-[40rem] h-auto"
+              />
+              <em class="text-sm text-balance text-center">{{ metadata.title }}</em>
+            </div>
+          </ng-template>
         </td>
 
         @for (col of visibleColumns; track col.field) {
@@ -79,9 +98,17 @@
               </span>
             </td>
           } @else {
-            <td [title]="getCellValue(metadata, book, col.field)"
-                class="overflow-hidden truncate text-right min-w-[6rem] max-w-[12rem]">
-              {{ getCellValue(metadata, book, col.field) }}
+            <td
+              [title]="getCellValue(metadata, book, col.field)"
+              class="overflow-hidden truncate text-right min-w-[6rem] max-w-[12rem]">
+              @if(['title', 'authors', 'publisher', 'seriesName', 'categories', 'language'].includes(col.field)) {
+                @for (item of getCellClickableValue(metadata, book, col.field); track $index; let isLast = $last) {
+                  <a [routerLink]="item.url" class="hover:underline hover:text-blue-400">
+                    {{ item.anchor }}</a>@if (!isLast) {<span>, </span>}
+                }
+              } @else {
+                {{ getCellValue(metadata, book, col.field) }}
+              }
             </td>
           }
         }

--- a/booklore-ui/src/app/features/book/components/book-browser/book-table/book-table.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-table/book-table.component.ts
@@ -10,7 +10,7 @@ import {UrlHelperService} from '../../../../../shared/service/url-helper.service
 import {Button} from 'primeng/button';
 import {BookService} from '../../../service/book.service';
 import {MessageService} from 'primeng/api';
-import {Router} from '@angular/router';
+import {Router, RouterLink} from '@angular/router';
 import {filter, Subject} from 'rxjs';
 import {UserService} from '../../../../settings/user-management/user.service';
 import {BookMetadataCenterComponent} from '../../../../metadata/component/book-metadata-center/book-metadata-center.component';
@@ -28,7 +28,8 @@ import {ReadStatusHelper} from '../../../helpers/read-status.helper';
     FormsModule,
     Button,
     TooltipModule,
-    NgClass
+    NgClass,
+    RouterLink
   ],
   styleUrls: ['./book-table.component.scss'],
   providers: [DatePipe]
@@ -207,6 +208,55 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
 
   shouldShowStatusIcon(readStatus: ReadStatus | undefined): boolean {
     return this.readStatusHelper.shouldShowStatusIcon(readStatus);
+  }
+
+  getAuthors(metadata: BookMetadata): string[] {
+    return metadata.authors ?? []
+  }
+
+  getCellClickableValue(metadata: BookMetadata, book: Book, field: string){
+    const filterKeys:Record<string, string> = {
+      'authors': 'author',
+      'publisher': 'publisher',
+      'categories': 'category',
+      'language': 'language',
+      'title': 'title'
+    } as const;
+
+    let data:string[] =[metadata[field]];
+
+    switch (field) {
+      case 'title':
+        return [
+          {
+            url: this.urlHelper.getBookUrl(book),
+            anchor: metadata.title ?? book.fileName
+          }
+        ];
+
+      case 'categories':
+        data = metadata.categories ?? [];
+        break;
+
+      case 'authors':
+        data = metadata.authors ?? [];
+        break;
+
+      case 'seriesName':
+        return [
+          {
+            url: this.urlHelper.filterBooksBy('series', metadata.seriesName ?? '' ),
+            anchor: metadata.seriesName
+          }
+        ]
+    }
+
+    return data.map(item => {
+      return {
+        url: this.urlHelper.filterBooksBy(filterKeys[field] ?? field, item),
+        anchor: item
+      }
+    });
   }
 
   getCellValue(metadata: BookMetadata, book: Book, field: string): string | number {

--- a/booklore-ui/src/app/shared/service/url-helper.service.ts
+++ b/booklore-ui/src/app/shared/service/url-helper.service.ts
@@ -3,6 +3,8 @@ import {API_CONFIG} from '../../core/config/api-config';
 import {AuthService} from './auth.service';
 import {BookService} from '../../features/book/service/book.service';
 import {CoverGeneratorComponent} from '../components/cover-generator/cover-generator.component';
+import { Router } from '@angular/router';
+import { Book } from '../../features/book/model/book.model';
 
 @Injectable({
   providedIn: 'root'
@@ -12,6 +14,7 @@ export class UrlHelperService {
   private readonly mediaBaseUrl = `${this.baseUrl}/api/v1/media`;
   private authService = inject(AuthService);
   private bookService = inject(BookService);
+  private router = inject(Router);
 
   private getToken(): string | null {
     return this.authService.getOidcAccessToken() || this.authService.getInternalAccessToken();
@@ -74,5 +77,27 @@ export class UrlHelperService {
       url += `${url.includes('?') ? '&' : '?'}token=${token}`;
     }
     return url;
+  }
+
+  getBookUrl(book: Book) {
+    return this.router.createUrlTree(['/book', book.id], {
+      queryParams: {tab: 'view'}
+    });
+  }
+
+  filterBooksBy(filterKey: string, filterValue: string){
+    if (filterKey === 'series') {
+      return this.router.createUrlTree(['/series', encodeURIComponent(filterValue)])
+    }
+
+    return this.router.createUrlTree(['/all-books'], {
+      queryParams: {
+        view: 'grid',
+        sort: 'title',
+        direction: 'asc',
+        sidebar: true,
+        filter: `${filterKey}:${encodeURIComponent(filterValue)}`
+      }
+    });
   }
 }


### PR DESCRIPTION
Adds a couple of improvements on grid view:

1. add a tooltip so image can be slightly enlarged on hover
2. make title clickable (will open book details)
3. replace `onClick` event with actual router (so can be opened with the middle click in new tab)
4. make authors, publisher, series name, categories & language clickable, so filters are a click away