### PR TITLE
Enhancement: Import custom pagecount field from calibre

### DIFF
--- a/booklore-api/build.gradle
+++ b/booklore-api/build.gradle
@@ -65,7 +65,6 @@ dependencies {
     // --- JSON & Web Scraping ---
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.0'
     implementation 'org.jsoup:jsoup:1.21.2'
-    implementation 'org.json:json:20250517'
 
     // --- Mapping (DTOs & Entities) ---
     implementation 'org.mapstruct:mapstruct:1.6.3'

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.model.FileHeader;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
 import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -19,7 +21,6 @@ import java.io.*;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
-import org.json.*;
 import java.util.Set;
 
 @Slf4j
@@ -142,17 +143,19 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                                 if (name.equals("calibre:pages") || name.equals("pagecount") || prop.equals("schema:pagecount") || prop.equals("media:pagecount") || prop.equals("booklore:page_count")) {
                                     safeParseInt(content, builderMeta::pageCount);
                                 } else if (name.equals("calibre:user_metadata:#pagecount")) {
-                                    JSONObject jsonroot = new JSONObject(content);
-                                    Object value = jsonroot.opt("#value#");
-                                    if (value != null) {
+                                    try {
+                                        JSONObject jsonroot = new JSONObject(content);
+                                        Object value = jsonroot.opt("#value#");
                                         safeParseInt(String.valueOf(value), builderMeta::pageCount);
+                                    } catch (JSONException ignored) {
                                     }
                                 } else if (prop.equals("calibre:user_metadata")) {
-                                    JSONObject jsonroot = new JSONObject(content);
-                                    JSONObject pages = jsonroot.getJSONObject("#pagecount");
-                                    Object value = pages.opt("#value#");
-                                    if (value != null) {
+                                    try {
+                                        JSONObject jsonroot = new JSONObject(content);
+                                        JSONObject pages = jsonroot.getJSONObject("#pagecount");
+                                        Object value = pages.opt("#value#");
                                         safeParseInt(String.valueOf(value), builderMeta::pageCount);
+                                    } catch (JSONException ignored) {
                                     }
                                 }
 


### PR DESCRIPTION
Calibre exports custom columns as JSON strings. This PR parses this JSON data and adds the pagecount value to booklore. By convention, the calibre column must be named "pagecount".