### PR TITLE
feat(ui): set the correct file name when triggering a download

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -213,7 +213,7 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
           label: 'Download',
           icon: 'pi pi-download',
           command: () => {
-            this.bookService.downloadFile(this.book.id);
+            this.bookService.downloadFile(this.book);
           }
         });
       } else {
@@ -512,7 +512,7 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
       label: `${this.book.fileName || 'Book File'}`,
       icon: 'pi pi-file',
       command: () => {
-        this.bookService.downloadFile(this.book.id);
+        this.bookService.downloadFile(this.book);
       }
     });
 
@@ -528,7 +528,7 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
         items.push({
           label: `${format.fileName} (${this.getFileSizeInMB(format)})`,
           icon: this.getFileIcon(extension),
-          command: () => this.downloadAdditionalFile(this.book.id, format.id)
+          command: () => this.downloadAdditionalFile(this.book, format.id)
         });
       });
     }
@@ -546,7 +546,7 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
         items.push({
           label: `${file.fileName} (${this.getFileSizeInMB(file)})`,
           icon: this.getFileIcon(extension),
-          command: () => this.downloadAdditionalFile(this.book.id, file.id)
+          command: () => this.downloadAdditionalFile(this.book, file.id)
         });
       });
     }
@@ -619,8 +619,8 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
       !!(this.book.supplementaryFiles && this.book.supplementaryFiles.length > 0);
   }
 
-  private downloadAdditionalFile(bookId: number, fileId: number): void {
-    this.bookService.downloadAdditionalFile(bookId, fileId);
+  private downloadAdditionalFile(book: Book, fileId: number): void {
+    this.bookService.downloadAdditionalFile(book, fileId);
   }
 
   private deleteAdditionalFile(bookId: number, fileId: number, fileName: string): void {

--- a/booklore-ui/src/app/features/book/service/book.service.ts
+++ b/booklore-ui/src/app/features/book/service/book.service.ts
@@ -355,14 +355,15 @@ export class BookService {
     );
   }
 
-  downloadFile(bookId: number): void {
-    const downloadUrl = `${this.url}/${bookId}/download`;
-    this.fileDownloadService.downloadFile(downloadUrl, `book_${bookId}`);
+  downloadFile(book: Book): void {
+    const downloadUrl = `${this.url}/${book.id}/download`;
+    this.fileDownloadService.downloadFile(downloadUrl, book.fileName!);
   }
 
-  downloadAdditionalFile(bookId: number, fileId: number): void {
-    const downloadUrl = `${this.url}/${bookId}/files/${fileId}/download`;
-    this.fileDownloadService.downloadFile(downloadUrl, `additional_file_${fileId}`);
+  downloadAdditionalFile(book: Book, fileId: number): void {
+    const additionalFile = book.alternativeFormats!.find((f: AdditionalFile) => f.id === fileId);
+    const downloadUrl = `${this.url}/${additionalFile!.id}/files/${fileId}/download`;
+    this.fileDownloadService.downloadFile(downloadUrl, additionalFile!.fileName!);
   }
 
   savePdfProgress(bookId: number, page: number, percentage: number): Observable<void> {

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
@@ -462,7 +462,7 @@
                     label="Download"
                     icon="pi pi-download"
                     [model]="downloadItems"
-                    (onClick)="download(book!.id)"
+                    (onClick)="download(book)"
                     severity="success"
                     outlined/>
                 }
@@ -472,7 +472,7 @@
                   icon="pi pi-download"
                   severity="success"
                   outlined
-                  (onClick)="download(book!.id)">
+                  (onClick)="download(book)">
                 </p-button>
               }
             }

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -157,7 +157,7 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
             items.push({
               label: `${format.fileName} (${this.getFileSizeInMB(format)})`,
               icon: this.getFileIcon(extension),
-              command: () => this.downloadAdditionalFile(book.id, format.id)
+              command: () => this.downloadAdditionalFile(book, format.id)
             });
           });
         }
@@ -175,7 +175,7 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
             items.push({
               label: `${file.fileName} (${this.getFileSizeInMB(file)})`,
               icon: this.getFileIcon(extension),
-              command: () => this.downloadAdditionalFile(book.id, file.id)
+              command: () => this.downloadAdditionalFile(book, file.id)
             });
           });
         }
@@ -354,12 +354,12 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
     if (bookId) this.bookService.readBook(bookId, reader);
   }
 
-  download(bookId: number) {
-    this.bookService.downloadFile(bookId);
+  download(book: Book) {
+    this.bookService.downloadFile(book);
   }
 
-  downloadAdditionalFile(bookId: number, fileId: number) {
-    this.bookService.downloadAdditionalFile(bookId, fileId);
+  downloadAdditionalFile(book: Book, fileId: number) {
+    this.bookService.downloadAdditionalFile(book, fileId);
   }
 
   deleteAdditionalFile(bookId: number, fileId: number, fileName: string) {


### PR DESCRIPTION
Currently, when downloading a book on ipad, you'll get a file called `book_123`. Which is not very helpful, as ipadOS isn't smart enough to figure out what to do with a file without an extension.

This PR will trigger the download of the file with the right `fileName` property rather than its ID.