### PR TITLE
Added timestamp from koreader_last_sync_time to returned json on GET for KOReader Sync API

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/progress/KoreaderProgress.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/progress/KoreaderProgress.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 @Builder
 @ToString
 public class KoreaderProgress {
+    private Long timestamp;
     private String document;
     private Float percentage;
     private String progress;

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/koreader/KoreaderService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/koreader/KoreaderService.java
@@ -51,7 +51,12 @@ public class KoreaderService {
                 progress.getKoreaderProgress(), progress.getKoreaderProgressPercent(),
                 authDetails.getBookLoreUserId(), bookHash);
 
+        Long timestamp = progress.getKoreaderLastSyncTime() != null
+                ? progress.getKoreaderLastSyncTime().getEpochSecond()
+                : null;
+
         return KoreaderProgress.builder()
+                .timestamp(timestamp)
                 .document(bookHash)
                 .progress(progress.getKoreaderProgress())
                 .percentage(progress.getKoreaderProgressPercent())

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/KoreaderServiceTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/KoreaderServiceTest.java
@@ -139,6 +139,49 @@ class KoreaderServiceTest {
     }
 
     @Test
+    void getProgress_includesTimestamp() {
+        when(details.isSyncEnabled()).thenReturn(true);
+        var book = new BookEntity();
+        book.setId(100L);
+        when(bookRepo.findByCurrentHash("hash123")).thenReturn(Optional.of(book));
+
+        var prog = new UserBookProgressEntity();
+        prog.setKoreaderProgress("progress/path");
+        prog.setKoreaderProgressPercent(0.75F);
+        Instant syncTime = Instant.ofEpochSecond(1762209924L);
+        prog.setKoreaderLastSyncTime(syncTime);
+        when(progressRepo.findByUserIdAndBookId(42L, 100L))
+                .thenReturn(Optional.of(prog));
+
+        KoreaderProgress out = service.getProgress("hash123");
+        assertEquals("hash123", out.getDocument());
+        assertEquals("progress/path", out.getProgress());
+        assertEquals(0.75F, out.getPercentage());
+        assertEquals(1762209924L, out.getTimestamp());
+    }
+
+    @Test
+    void getProgress_nullTimestamp() {
+        when(details.isSyncEnabled()).thenReturn(true);
+        var book = new BookEntity();
+        book.setId(101L);
+        when(bookRepo.findByCurrentHash("hash456")).thenReturn(Optional.of(book));
+
+        var prog = new UserBookProgressEntity();
+        prog.setKoreaderProgress("progress/path2");
+        prog.setKoreaderProgressPercent(0.25F);
+        prog.setKoreaderLastSyncTime(null);
+        when(progressRepo.findByUserIdAndBookId(42L, 101L))
+                .thenReturn(Optional.of(prog));
+
+        KoreaderProgress out = service.getProgress("hash456");
+        assertEquals("hash456", out.getDocument());
+        assertEquals("progress/path2", out.getProgress());
+        assertEquals(0.25F, out.getPercentage());
+        assertNull(out.getTimestamp());
+    }
+
+    @Test
     void saveProgress_createsNew() {
         when(details.isSyncEnabled()).thenReturn(true);
         var book = new BookEntity();


### PR DESCRIPTION
I determined that the reason why some KOReader sync server clients did not accurately go to the correct progress point was because the json returned by the Booklore implementation did not include the timestamp data.

KOReader official:
```
{
    "timestamp": 1762209924,
    "device_id": "a4dd8b11-5c42-462e-baa3-88b677ba3354",
    "progress": "/body/DocFragment[6]/body/div/section/p[43]",
    "document": "5880fa8e2e7941161994467023d5e334",
    "percentage": 0.017006802721088,
    "device": "Readest (macOS)"
}
```

Booklore:

```
{{
    "document": "5880fa8e2e7941161994467023d5e334",
    "percentage": 0.510204,
    "progress": "/body/DocFragment[21]/body/div/section/p[85]",
    "device": "BookLore",
    "device_id": "BookLore"
    // ❌ NO TIMESTAMP FIELD!
}
```