### PR TITLE
chore: remove leading space from LoginGuard import

### DIFF
--- a/booklore-ui/src/app/app.routes.ts
+++ b/booklore-ui/src/app/app.routes.ts
@@ -10,7 +10,7 @@ import {SetupComponent} from './shared/components/setup/setup.component';
 import {SetupGuard} from './shared/components/setup/setup.guard';
 import {SetupRedirectGuard} from './shared/components/setup/setup-redirect.guard';
 import {EmptyComponent} from './shared/components/empty/empty.component';
-import {LoginGuard} from './shared/components/setup/ login.guard';
+import {LoginGuard} from './shared/components/setup/login.guard';
 import {OidcCallbackComponent} from './core/security/oidc-callback/oidc-callback.component';
 import {CbxReaderComponent} from './features/readers/cbx-reader/cbx-reader.component';
 import {MainDashboardComponent} from './features/dashboard/components/main-dashboard/main-dashboard.component';


### PR DESCRIPTION
Removes a space in the path for importing LoginGuard. For some reason for me, this caused an error when building the UI app (with a Docker environment), though I'm not sure how this is not more of a widespread issue. In any case, I figured no harm in opening the PR.