### PR TITLE
Fix: Change p-tabpanels height in multi-book-metadata-editor-component

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/multi-book-metadata-editor/multi-book-metadata-editor-component.html
+++ b/booklore-ui/src/app/features/metadata/component/multi-book-metadata-editor/multi-book-metadata-editor-component.html
@@ -8,7 +8,7 @@
         <p-tab value="match">Search Metadata</p-tab>
       }
     </p-tablist>
-    <p-tabpanels class="h-[calc(100dvh-10rem)]">
+    <p-tabpanels class="h-[80dvh]">
       @if (admin || canEditMetadata) {
         <p-tabpanel value="edit">
           <app-metadata-editor


### PR DESCRIPTION
Hi On the current version, the save button of the multi-book-metadata-editor is hidden slightly below the bottom border of the dynamic dialog on bigger screens: 
<img width="2560" height="1293" alt="image" src="https://github.com/user-attachments/assets/38d3db69-4db9-4dc2-9bed-03f399760023" /> 
This issue becomes worse the bigger the height of the screen, until the save button is completely invisible without scrolling down. Changing the height to 80dvh instead of 100dvh-10rem makes the save button fully visible without scrolling on nearly all screen sizes, except for extremely small heights that would be unusable either way.