### PR TITLE
fix(metadata-updater): fix partial metadata save on Bookdrop

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/bookdrop/BookDropService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/bookdrop/BookDropService.java
@@ -4,6 +4,8 @@ import com.adityachandel.booklore.config.AppProperties;
 import com.adityachandel.booklore.exception.ApiError;
 import com.adityachandel.booklore.mapper.BookdropFileMapper;
 import com.adityachandel.booklore.model.FileProcessResult;
+import com.adityachandel.booklore.model.MetadataUpdateContext;
+import com.adityachandel.booklore.model.MetadataUpdateWrapper;
 import com.adityachandel.booklore.model.dto.BookMetadata;
 import com.adityachandel.booklore.model.dto.BookdropFile;
 import com.adityachandel.booklore.model.dto.BookdropFileNotification;
@@ -432,7 +434,19 @@ public class BookDropService {
                 .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("Book ID missing after import"));
 
         notificationService.sendMessage(Topic.BOOK_ADD, fileProcessResult.getBook());
-        metadataRefreshService.updateBookMetadata(bookEntity, metadata, metadata.getThumbnailUrl() != null, false, MetadataReplaceMode.REPLACE_ALL);
+        MetadataUpdateContext context = MetadataUpdateContext.builder()
+                .bookEntity(bookEntity)
+                .metadataUpdateWrapper(MetadataUpdateWrapper.builder()
+                        .metadata(metadata)
+                        .build())
+                .updateThumbnail(metadata.getThumbnailUrl() != null)
+                .mergeCategories(false)
+                .replaceMode(MetadataReplaceMode.REPLACE_ALL)
+                .mergeMoods(true)
+                .mergeTags(true)
+                .build();
+
+        metadataRefreshService.updateBookMetadata(context);
 
         cleanupBookdropData(bookdropFile);
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/MetadataRefreshService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/MetadataRefreshService.java
@@ -277,23 +277,26 @@ public class MetadataRefreshService {
     }
 
     public void updateBookMetadata(BookEntity bookEntity, BookMetadata metadata, boolean replaceCover, boolean mergeCategories, MetadataReplaceMode replaceMode) {
-        if (metadata != null) {
+        MetadataUpdateContext context = MetadataUpdateContext.builder()
+                .bookEntity(bookEntity)
+                .metadataUpdateWrapper(MetadataUpdateWrapper.builder()
+                        .metadata(metadata)
+                        .build())
+                .updateThumbnail(replaceCover)
+                .mergeCategories(mergeCategories)
+                .replaceMode(replaceMode)
+                .mergeMoods(true)
+                .mergeTags(true)
+                .build();
 
-            MetadataUpdateContext context = MetadataUpdateContext.builder()
-                    .bookEntity(bookEntity)
-                    .metadataUpdateWrapper(MetadataUpdateWrapper.builder()
-                            .metadata(metadata)
-                            .build())
-                    .updateThumbnail(replaceCover)
-                    .mergeCategories(mergeCategories)
-                    .replaceMode(replaceMode)
-                    .mergeMoods(true)
-                    .mergeTags(true)
-                    .build();
+        updateBookMetadata(context);
+    }
 
+    public void updateBookMetadata(MetadataUpdateContext context) {
+        if (context.getMetadataUpdateWrapper() != null && context.getMetadataUpdateWrapper().getMetadata() != null) {
             bookMetadataUpdater.setBookMetadata(context);
 
-            Book book = bookMapper.toBook(bookEntity);
+            Book book = bookMapper.toBook(context.getBookEntity());
             notificationService.sendMessage(Topic.BOOK_METADATA_UPDATE, book);
         }
     }


### PR DESCRIPTION
Fixed a bug where Bookdrop imports wouldn't save all metadata, forcing users to re-edit the book manually. The importer was defaulting to a conservative "replace missing" mod,; switched it to REPLACE_ALL so the import data actually takes priority.


**Metadata Update Refactor:**

* Replaced direct parameter passing in `BookDropService.processMovedFile` with construction of a `MetadataUpdateContext` object, enabling detailed control over update options such as thumbnail replacement, category merging, replace mode, and merging moods/tags. (`booklore-api/src/main/java/com/adityachandel/booklore/service/bookdrop/BookDropService.java`)
* Updated `MetadataRefreshService.updateBookMetadata` to accept both the new context object and legacy parameter sets, providing backward compatibility and supporting the new replace mode for metadata updates. (`booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/MetadataRefreshService.java`)

**Model and Enum Imports:**

* Added imports for `MetadataUpdateContext`, `MetadataUpdateWrapper`, and `MetadataReplaceMode` to support the new metadata update workflow. (`booklore-api/src/main/java/com/adityachandel/booklore/service/bookdrop/BookDropService.java`)

Closes: #1543