### PR TITLE
Enable assign to shelf on existing shelves and magic shelves

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.html
@@ -298,23 +298,21 @@
                             icon="pi pi-database">
                           </p-button>
                         }
-                        @if (entityType === EntityType.LIBRARY || entityType === EntityType.ALL_BOOKS || entityType === EntityType.UNSHELVED) {
-                          <p-button
-                            icon="pi pi-bookmark-fill"
-                            outlined="true"
-                            severity="info"
-                            (onClick)="openShelfAssigner()"
-                            pTooltip="Assign to shelf"
-                            tooltipPosition="top">
-                          </p-button>
-                        }
+                        <p-button
+                          icon="pi pi-bookmark-fill"
+                          outlined="true"
+                          severity="info"
+                          (onClick)="openShelfAssigner()"
+                          pTooltip="Assign to shelf"
+                          tooltipPosition="top">
+                        </p-button>
                         @if (entityType === EntityType.SHELF) {
                           <p-button
                             icon="pi pi-bookmark"
                             outlined="true"
                             severity="info"
                             (click)="unshelfBooks()"
-                            pTooltip="Remove from shelf"
+                            pTooltip="Remove from this shelf"
                             tooltipPosition="top">
                           </p-button>
                         }

--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -554,9 +554,6 @@ export class BookBrowserComponent implements OnInit {
 
   openShelfAssigner(): void {
     this.dynamicDialogRef = this.dialogHelperService.openShelfAssigner(this.selectedBooks);
-    this.dynamicDialogRef?.onClose.subscribe(() => {
-      this.selectedBooks = new Set<number>();
-    });
   }
 
   lockUnlockMetadata(): void {


### PR DESCRIPTION
This allows you to assign to another shelf if you are viewing books on an existing shelf or magic shelf. It fixes #1579

It also stops de-selecting all books after closing the assign to shelf dialog which is consistent with all the other multi-book action dialogs.