### PR TITLE
Fix: Prevent sorting prefs select options from overflowing container

### DIFF
--- a/booklore-ui/src/app/features/settings/view-preferences-parent/sidebar-sorting-preferences/sidebar-sorting-preferences.component.html
+++ b/booklore-ui/src/app/features/settings/view-preferences-parent/sidebar-sorting-preferences/sidebar-sorting-preferences.component.html
@@ -28,6 +28,7 @@
                 [options]="sortingOptions"
                 [(ngModel)]="selectedLibrarySorting"
                 (ngModelChange)="onLibrarySortingChange()"
+                appendTo="body"
                 placeholder="Select Sorting">
               </p-select>
             </div>
@@ -53,6 +54,7 @@
                 [options]="sortingOptions"
                 [(ngModel)]="selectedShelfSorting"
                 (ngModelChange)="onShelfSortingChange()"
+                appendTo="body"
                 placeholder="Select Sorting">
               </p-select>
             </div>


### PR DESCRIPTION
Opening the library or shelf sorting preference options pickers can cause a containing element to overflow and a vertical scrollbar to appear. This fixes that.