### PR TITLE
refactor(api): Add BufferedImage resource cleanup to prevent native memory leaks

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/file/BackgroundUploadService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/file/BackgroundUploadService.java
@@ -44,6 +44,7 @@ public class BackgroundUploadService {
 
             deleteExistingBackgroundFiles(userId);
             fileService.saveBackgroundImage(originalImage, filename, userId);
+            originalImage.flush(); // Release resources after saving
 
             String fileUrl = FileService.getBackgroundUrl(filename, userId);
             return new UploadResponse(fileUrl);
@@ -64,6 +65,7 @@ public class BackgroundUploadService {
             deleteExistingBackgroundFiles(userId);
 
             fileService.saveBackgroundImage(originalImage, filename, userId);
+            originalImage.flush(); // Release resources after saving
 
             String fileUrl = FileService.getBackgroundUrl(filename, userId);
             return new UploadResponse(fileUrl);

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/CbxProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/CbxProcessor.java
@@ -74,11 +74,16 @@ public class CbxProcessor extends AbstractFileProcessor implements BookFileProce
         try {
             Optional<BufferedImage> imageOptional = extractImagesFromArchive(file);
             if (imageOptional.isPresent()) {
-                boolean saved = fileService.saveCoverImages(imageOptional.get(), bookEntity.getId());
-                if (saved) {
-                    bookEntity.getMetadata().setCoverUpdatedOn(Instant.now());
-                    bookMetadataRepository.save(bookEntity.getMetadata());
-                    return true;
+                BufferedImage image = imageOptional.get();
+                try {
+                    boolean saved = fileService.saveCoverImages(image, bookEntity.getId());
+                    if (saved) {
+                        bookEntity.getMetadata().setCoverUpdatedOn(Instant.now());
+                        bookMetadataRepository.save(bookEntity.getMetadata());
+                        return true;
+                    }
+                } finally {
+                    image.flush(); // Release resources after processing
                 }
             }
         } catch (Exception e) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/EpubProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/EpubProcessor.java
@@ -151,6 +151,12 @@ public class EpubProcessor extends AbstractFileProcessor implements BookFileProc
 
     private boolean saveCoverImage(Resource coverImage, long bookId) throws IOException {
         BufferedImage originalImage = ImageIO.read(new ByteArrayInputStream(coverImage.getData()));
-        return fileService.saveCoverImages(originalImage, bookId);
+        try {
+            return fileService.saveCoverImages(originalImage, bookId);
+        } finally {
+            if (originalImage != null) {
+                originalImage.flush(); // Release resources after processing
+            }
+        }
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/PdfMetadataExtractor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/PdfMetadataExtractor.java
@@ -47,14 +47,20 @@ public class PdfMetadataExtractor implements FileMetadataExtractor {
 
     @Override
     public byte[] extractCover(File file) {
+        BufferedImage coverImage = null;
         try (PDDocument pdf = Loader.loadPDF(file)) {
-            BufferedImage coverImage = new PDFRenderer(pdf).renderImageWithDPI(0, 300, ImageType.RGB);
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ImageIO.write(coverImage, "jpg", baos);
-            return baos.toByteArray();
+            coverImage = new PDFRenderer(pdf).renderImageWithDPI(0, 300, ImageType.RGB);
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                ImageIO.write(coverImage, "jpg", baos);
+                return baos.toByteArray();
+            }
         } catch (Exception e) {
             log.warn("Failed to extract cover from PDF: {}", file.getAbsolutePath(), e);
             return null;
+        } finally {
+            if (coverImage != null) {
+                coverImage.flush(); // Release native resources
+            }
         }
     }
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/migration/AppMigrationService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/migration/AppMigrationService.java
@@ -130,9 +130,11 @@ public class AppMigrationService {
                 try (var stream = Files.walk(thumbsDir)) {
                     stream.filter(Files::isRegularFile)
                             .forEach(path -> {
+                                BufferedImage originalImage = null;
+                                BufferedImage resized = null;
                                 try {
                                     // Load original image
-                                    BufferedImage originalImage = ImageIO.read(path.toFile());
+                                    originalImage = ImageIO.read(path.toFile());
                                     if (originalImage == null) {
                                         log.warn("Skipping non-image file: {}", path);
                                         return;
@@ -150,7 +152,7 @@ public class AppMigrationService {
                                     ImageIO.write(originalImage, "jpg", coverFile.toFile());
 
                                     // Resize and save thumbnail.jpg
-                                    BufferedImage resized = FileService.resizeImage(originalImage, 250, 350);
+                                    resized = FileService.resizeImage(originalImage, 250, 350);
                                     Path thumbnailFile = bookDir.resolve("thumbnail.jpg");
                                     ImageIO.write(resized, "jpg", thumbnailFile.toFile());
 
@@ -158,6 +160,13 @@ public class AppMigrationService {
                                 } catch (IOException e) {
                                     log.error("Error processing file {}", path, e);
                                     throw new UncheckedIOException(e);
+                                } finally {
+                                    if (originalImage != null) {
+                                        originalImage.flush();
+                                    }
+                                    if (resized != null) {
+                                        resized.flush();
+                                    }
                                 }
                             });
                 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/reader/PdfReaderService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/reader/PdfReaderService.java
@@ -94,9 +94,16 @@ public class PdfReaderService {
         try (PDDocument document = Loader.loadPDF(new File(pdfPath.toFile().toURI()))) {
             PDFRenderer renderer = new PDFRenderer(document);
             for (int i = 0; i < document.getNumberOfPages(); i++) {
-                BufferedImage image = renderer.renderImageWithDPI(i, 200, ImageType.RGB);
-                Path outputFile = targetDir.resolve(String.format("%04d.jpg", i + 1));
-                ImageIO.write(image, "JPEG", outputFile.toFile());
+                BufferedImage image = null;
+                try {
+                    image = renderer.renderImageWithDPI(i, 200, ImageType.RGB);
+                    Path outputFile = targetDir.resolve(String.format("%04d.jpg", i + 1));
+                    ImageIO.write(image, "JPEG", outputFile.toFile());
+                } finally {
+                    if (image != null) {
+                        image.flush(); // Release native resources
+                    }
+                }
             }
         } catch (IOException e) {
             log.error("Failed to render PDF pages from {}", pdfPath, e);

--- a/booklore-api/src/main/java/com/adityachandel/booklore/util/FileService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/util/FileService.java
@@ -143,15 +143,24 @@ public class FileService {
     }
 
     public static void saveImage(byte[] imageData, String filePath) throws IOException {
-        BufferedImage originalImage = ImageIO.read(new ByteArrayInputStream(imageData));
-        File outputFile = new File(filePath);
-        File parentDir = outputFile.getParentFile();
-        if (!parentDir.exists() && !parentDir.mkdirs()) {
-            throw new IOException("Failed to create directory: " + parentDir);
+        BufferedImage originalImage = null;
+        try {
+            originalImage = ImageIO.read(new ByteArrayInputStream(imageData));
+            if (originalImage == null) {
+                throw new IOException("Invalid image data: unable to decode image");
+            }
+            File outputFile = new File(filePath);
+            File parentDir = outputFile.getParentFile();
+            if (!parentDir.exists() && !parentDir.mkdirs()) {
+                throw new IOException("Failed to create directory: " + parentDir);
+            }
+            ImageIO.write(originalImage, IMAGE_FORMAT, outputFile);
+            log.info("Image saved successfully to: {}", filePath);
+        } finally {
+            if (originalImage != null) {
+                originalImage.flush(); // Release native resources
+            }
         }
-        ImageIO.write(originalImage, IMAGE_FORMAT, outputFile);
-        originalImage.flush(); // Release native resources
-        log.info("Image saved successfully to: {}", filePath);
     }
 
     public BufferedImage downloadImageFromUrl(String imageUrl) throws IOException {
@@ -205,6 +214,7 @@ public class FileService {
             if (!success) {
                 throw ApiError.FILE_READ_ERROR.createException("Failed to save cover images");
             }
+            originalImage.flush(); // Release resources after processing
             log.info("Cover images created and saved for book ID: {}", bookId);
         } catch (Exception e) {
             log.error("An error occurred while creating the thumbnail: {}", e.getMessage(), e);
@@ -219,6 +229,7 @@ public class FileService {
             if (!success) {
                 throw ApiError.FILE_READ_ERROR.createException("Failed to save cover images");
             }
+            originalImage.flush(); // Release resources after processing
             log.info("Cover images created and saved from URL for book ID: {}", bookId);
         } catch (Exception e) {
             log.error("An error occurred while creating thumbnail from URL: {}", e.getMessage(), e);
@@ -227,44 +238,58 @@ public class FileService {
     }
 
     public boolean saveCoverImages(BufferedImage coverImage, long bookId) throws IOException {
-        String folderPath = getImagesFolder(bookId);
-        File folder = new File(folderPath);
-        if (!folder.exists() && !folder.mkdirs()) {
-            throw new IOException("Failed to create directory: " + folder.getAbsolutePath());
+        BufferedImage rgbImage = null;
+        BufferedImage resized = null;
+        BufferedImage thumb = null;
+        try {
+            String folderPath = getImagesFolder(bookId);
+            File folder = new File(folderPath);
+            if (!folder.exists() && !folder.mkdirs()) {
+                throw new IOException("Failed to create directory: " + folder.getAbsolutePath());
+            }
+
+            rgbImage = new BufferedImage(
+                    coverImage.getWidth(),
+                    coverImage.getHeight(),
+                    BufferedImage.TYPE_INT_RGB
+            );
+            Graphics2D g = rgbImage.createGraphics();
+            g.drawImage(coverImage, 0, 0, Color.WHITE, null);
+            g.dispose();
+            // Note: coverImage is not flushed here - caller is responsible for its lifecycle
+
+            // Resize original image if too large to prevent OOM
+            double scale = Math.min(
+                    (double) MAX_ORIGINAL_WIDTH / rgbImage.getWidth(),
+                    (double) MAX_ORIGINAL_HEIGHT / rgbImage.getHeight()
+            );
+            if (scale < 1.0) {
+                resized = resizeImage(rgbImage, (int) (rgbImage.getWidth() * scale), (int) (rgbImage.getHeight() * scale));
+                rgbImage.flush(); // Release resources of the original large image
+                rgbImage = resized;
+            }
+
+            File originalFile = new File(folder, COVER_FILENAME);
+            boolean originalSaved = ImageIO.write(rgbImage, IMAGE_FORMAT, originalFile);
+
+            thumb = resizeImage(rgbImage, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+            File thumbnailFile = new File(folder, THUMBNAIL_FILENAME);
+            boolean thumbnailSaved = ImageIO.write(thumb, IMAGE_FORMAT, thumbnailFile);
+
+            return originalSaved && thumbnailSaved;
+        } finally {
+            // Cleanup resources created within this method
+            // Note: resized may equal rgbImage after reassignment, avoid double-flush
+            if (rgbImage != null) {
+                rgbImage.flush();
+            }
+            if (resized != null && resized != rgbImage) {
+                resized.flush();
+            }
+            if (thumb != null) {
+                thumb.flush();
+            }
         }
-        BufferedImage rgbImage = new BufferedImage(
-                coverImage.getWidth(),
-                coverImage.getHeight(),
-                BufferedImage.TYPE_INT_RGB
-        );
-        Graphics2D g = rgbImage.createGraphics();
-        g.drawImage(coverImage, 0, 0, Color.WHITE, null);
-        g.dispose();
-        coverImage.flush(); // Original input no longer needed after conversion
-
-        // Resize original image if too large to prevent OOM
-        double scale = Math.min(
-                (double) MAX_ORIGINAL_WIDTH / rgbImage.getWidth(),
-                (double) MAX_ORIGINAL_HEIGHT / rgbImage.getHeight()
-        );
-        if (scale < 1.0) {
-            BufferedImage resized = resizeImage(rgbImage, (int) (rgbImage.getWidth() * scale), (int) (rgbImage.getHeight() * scale));
-            rgbImage.flush(); // Release resources of the original large image
-            rgbImage = resized;
-        }
-
-        File originalFile = new File(folder, COVER_FILENAME);
-        boolean originalSaved = ImageIO.write(rgbImage, IMAGE_FORMAT, originalFile);
-
-        BufferedImage thumb = resizeImage(rgbImage, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
-        File thumbnailFile = new File(folder, THUMBNAIL_FILENAME);
-        boolean thumbnailSaved = ImageIO.write(thumb, IMAGE_FORMAT, thumbnailFile);
-
-        // Cleanup resources
-        rgbImage.flush();
-        thumb.flush();
-
-        return originalSaved && thumbnailSaved;
     }
 
     public static void setBookCoverPath(BookMetadataEntity bookMetadataEntity) {
@@ -313,9 +338,8 @@ public class FileService {
         }
 
         log.info("Background image saved successfully for user {}: {}", userId, filename);
-    }
-
-    public void deleteBackgroundFile(String filename, Long userId) {
+        // Note: input image is not flushed here - caller is responsible for its lifecycle
+    }    public void deleteBackgroundFile(String filename, Long userId) {
         try {
             String backgroundsFolder = getBackgroundsFolder(userId);
             File file = new File(backgroundsFolder, filename);

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/extractor/PdfMetadataExtractorTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/extractor/PdfMetadataExtractorTest.java
@@ -12,9 +12,13 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import java.io.ByteArrayInputStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class PdfMetadataExtractorTest {
 
@@ -51,12 +55,10 @@ class PdfMetadataExtractorTest {
     @Test
     void extractMetadata_shouldUseFilenameWithoutExtension_whenMetadataMissing() throws IOException {
         // Arrange: Create a PDF with NO metadata title
-        // Name the file "Dune.pdf"
         File pdfFile = tempDir.resolve("Dune.pdf").toFile();
 
         try (PDDocument doc = new PDDocument()) {
             doc.addPage(new PDPage());
-            // explicitly leaving metadata empty
             doc.save(pdfFile);
         }
 
@@ -82,5 +84,42 @@ class PdfMetadataExtractorTest {
 
         // Assert
         assertEquals("Harry Potter and the Sorcerer's Stone", result.getTitle());
+    }
+
+    @Test
+    void extractCover_validPdf_returnsJpegBytes() throws IOException {
+        // Arrange: Create a simple one-page PDF
+        File pdfFile = tempDir.resolve("cover-test.pdf").toFile();
+
+        try (PDDocument doc = new PDDocument()) {
+            PDPage page = new PDPage();
+            doc.addPage(page);
+            doc.save(pdfFile);
+        }
+
+        // Act
+        byte[] coverBytes = extractor.extractCover(pdfFile);
+
+        // Assert: Should return non-null, decodable JPEG bytes
+        assertNotNull(coverBytes);
+        assertTrue(coverBytes.length > 0);
+
+        BufferedImage coverImage = ImageIO.read(new ByteArrayInputStream(coverBytes));
+        assertNotNull(coverImage);
+        assertTrue(coverImage.getWidth() > 0);
+        assertTrue(coverImage.getHeight() > 0);
+    }
+
+    @Test
+    void extractCover_invalidPdf_returnsNull() throws IOException {
+        // Arrange: Create a file that looks like a PDF but isn't
+        File invalidPdf = tempDir.resolve("invalid-pdf.pdf").toFile();
+        java.nio.file.Files.writeString(invalidPdf.toPath(), "this is not a real pdf");
+
+        // Act
+        byte[] coverBytes = extractor.extractCover(invalidPdf);
+
+        // Assert: Should return null for invalid PDF
+        assertNull(coverBytes);
     }
 }


### PR DESCRIPTION
Implemented **more** resource management improvements by adding flush() calls in try-finally blocks across all image processing code paths. This ensures deterministic release of native memory regardless of execution outcome.

**FileService.java**
- Refactored saveCoverImages() with proper lifecycle management for rgbImage, resized, and thumb instances
- Added validation in saveImage() with null check before processing
- Implemented defensive logic to prevent double-flush when variable reassignment occurs (resized == rgbImage)

**PDF Processing**
- PdfMetadataExtractor.extractCover(): Wrap PDFRenderer output in try-finally
- PdfReaderService.renderPdfToImages(): Flush each page image within rendering loop

**Archive Format Processors**
- CbxProcessor.extractCoverImage(): Cleanup after saveCoverImages() call
- EpubProcessor.saveCoverImage(): Guard flush with null check in finally block

**Upload and Migration Services**
- BackgroundUploadService: Flush after saveBackgroundImage() operations
- AppMigrationService: Track originalImage and resized separately to ensure both are flushed

**Test Updates**
- Changed expected exception from IllegalArgumentException to IOException in FileServiceTest for invalid image data
- Added tests for image scaling behavior (large images scaled down, small images preserved)
- Added PdfMetadataExtractorTest coverage for valid/invalid PDF cover extraction

### Rationale
Prevents native memory exhaustion in production environments during sustained image processing operations. Particularly critical for PDF rendering and bulk upload scenarios.

### Notes
Caller responsibility clearly documented where input BufferedImage lifecycle is managed externally (e.g., saveCoverImages() does not flush the input coverImage parameter).