### PR TITLE
Re-add "description" to epub metadata extraction

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -169,6 +169,7 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                             }
                             case "creator" -> authors.add(text);
                             case "subject" -> categories.add(text);
+                            case "description" -> builderMeta.description(text);
                             case "publisher" -> builderMeta.publisher(text);
                             case "language" -> builderMeta.language(text);
                             case "identifier" -> {


### PR DESCRIPTION
A former commit (b3ae93fc6b38ec6000af07991db41da563b6d1f7) accidentially removed the description field from the metadata extraction.

Fixes #1725