### PR TITLE
fix(metadata): disable merging of moods and tags during metadata updates

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/controller/MetadataController.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/controller/MetadataController.java
@@ -72,8 +72,8 @@ public class MetadataController {
                 .updateThumbnail(true)
                 .mergeCategories(mergeCategories)
                 .replaceMode(MetadataReplaceMode.REPLACE_ALL)
-                .mergeMoods(true)
-                .mergeTags(true)
+                .mergeMoods(false)
+                .mergeTags(false)
                 .build();
 
         bookMetadataUpdater.setBookMetadata(context);

--- a/booklore-api/src/test/java/com/adityachandel/booklore/controller/MetadataControllerTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/controller/MetadataControllerTest.java
@@ -1,0 +1,73 @@
+package com.adityachandel.booklore.controller;
+
+import com.adityachandel.booklore.config.security.service.AuthenticationService;
+import com.adityachandel.booklore.mapper.BookMetadataMapper;
+import com.adityachandel.booklore.model.MetadataUpdateContext;
+import com.adityachandel.booklore.model.MetadataUpdateWrapper;
+import com.adityachandel.booklore.model.dto.BookMetadata;
+import com.adityachandel.booklore.model.entity.BookEntity;
+import com.adityachandel.booklore.model.entity.BookMetadataEntity;
+import com.adityachandel.booklore.repository.BookRepository;
+import com.adityachandel.booklore.service.metadata.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MetadataControllerTest {
+
+    @Mock
+    private BookMetadataService bookMetadataService;
+    @Mock
+    private BookMetadataUpdater bookMetadataUpdater;
+    @Mock
+    private AuthenticationService authenticationService;
+    @Mock
+    private BookMetadataMapper bookMetadataMapper;
+    @Mock
+    private MetadataMatchService metadataMatchService;
+    @Mock
+    private DuckDuckGoCoverService duckDuckGoCoverService;
+    @Mock
+    private BookRepository bookRepository;
+    @Mock
+    private MetadataManagementService metadataManagementService;
+
+    @InjectMocks
+    private MetadataController metadataController;
+
+    private MetadataUpdateContext captureContextFromUpdate() {
+        long bookId = 1L;
+        MetadataUpdateWrapper wrapper = MetadataUpdateWrapper.builder().build();
+        BookEntity bookEntity = new BookEntity();
+        bookEntity.setId(bookId);
+        bookEntity.setMetadata(new BookMetadataEntity());
+
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(bookEntity));
+        when(bookMetadataMapper.toBookMetadata(any(), anyBoolean())).thenReturn(new BookMetadata());
+
+        metadataController.updateMetadata(wrapper, bookId, true);
+
+        ArgumentCaptor<MetadataUpdateContext> captor = ArgumentCaptor.forClass(MetadataUpdateContext.class);
+        verify(bookMetadataUpdater).setBookMetadata(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void updateMetadata_shouldDisableMergingForTagsAndMoods() {
+        MetadataUpdateContext context = captureContextFromUpdate();
+
+        assertFalse(context.isMergeTags(), "mergeTags should be false to allow deletion of tags");
+        assertFalse(context.isMergeMoods(), "mergeMoods should be false to allow deletion of moods");
+    }
+}

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/BookMetadataUpdaterTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/BookMetadataUpdaterTest.java
@@ -1,0 +1,262 @@
+package com.adityachandel.booklore.service.metadata;
+
+import com.adityachandel.booklore.model.MetadataUpdateContext;
+import com.adityachandel.booklore.model.MetadataUpdateWrapper;
+import com.adityachandel.booklore.model.dto.BookMetadata;
+import com.adityachandel.booklore.model.dto.settings.AppSettings;
+import com.adityachandel.booklore.model.dto.settings.MetadataPersistenceSettings;
+import com.adityachandel.booklore.model.entity.BookEntity;
+import com.adityachandel.booklore.model.entity.BookMetadataEntity;
+import com.adityachandel.booklore.model.entity.MoodEntity;
+import com.adityachandel.booklore.model.entity.TagEntity;
+import com.adityachandel.booklore.model.enums.MetadataReplaceMode;
+import com.adityachandel.booklore.repository.*;
+import com.adityachandel.booklore.service.appsettings.AppSettingService;
+import com.adityachandel.booklore.service.file.FileMoveService;
+import com.adityachandel.booklore.service.metadata.writer.MetadataWriterFactory;
+import com.adityachandel.booklore.util.FileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookMetadataUpdaterTest {
+
+    @Mock private AuthorRepository authorRepository;
+    @Mock private CategoryRepository categoryRepository;
+    @Mock private MoodRepository moodRepository;
+    @Mock private TagRepository tagRepository;
+    @Mock private BookRepository bookRepository;
+    @Mock private FileService fileService;
+    @Mock private MetadataMatchService metadataMatchService;
+    @Mock private AppSettingService appSettingService;
+    @Mock private MetadataWriterFactory metadataWriterFactory;
+    @Mock private BookReviewUpdateService bookReviewUpdateService;
+    @Mock private FileMoveService fileMoveService;
+
+    @InjectMocks
+    private BookMetadataUpdater bookMetadataUpdater;
+
+    @BeforeEach
+    void setUp() {
+        AppSettings appSettings = new AppSettings();
+        appSettings.setMetadataPersistenceSettings(new MetadataPersistenceSettings());
+        when(appSettingService.getAppSettings()).thenReturn(appSettings);
+    }
+
+    @Test
+    void setBookMetadata_withMergeTagsFalse_shouldReplaceTags() {
+        BookEntity bookEntity = new BookEntity();
+        bookEntity.setId(1L);
+        BookMetadataEntity metadataEntity = new BookMetadataEntity();
+        
+        Set<TagEntity> existingTags = new HashSet<>();
+        existingTags.add(TagEntity.builder().name("Tag1").build());
+        existingTags.add(TagEntity.builder().name("Tag2").build());
+        metadataEntity.setTags(existingTags);
+        bookEntity.setMetadata(metadataEntity);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setTags(Set.of("Tag1"));
+
+        MetadataUpdateWrapper wrapper = MetadataUpdateWrapper.builder()
+                .metadata(newMetadata)
+                .build();
+
+        MetadataUpdateContext context = MetadataUpdateContext.builder()
+                .bookEntity(bookEntity)
+                .metadataUpdateWrapper(wrapper)
+                .mergeTags(false)
+                .replaceMode(MetadataReplaceMode.REPLACE_ALL)
+                .build();
+
+        when(tagRepository.findByName("Tag1")).thenReturn(Optional.of(TagEntity.builder().name("Tag1").build()));
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertEquals(1, bookEntity.getMetadata().getTags().size());
+        assertTrue(bookEntity.getMetadata().getTags().stream().anyMatch(t -> t.getName().equals("Tag1")));
+        assertFalse(bookEntity.getMetadata().getTags().stream().anyMatch(t -> t.getName().equals("Tag2")));
+    }
+
+    @Test
+    void setBookMetadata_withMergeTagsFalse_andEmptyIncomingSet_shouldClearAllTags() {
+        BookEntity bookEntity = new BookEntity();
+        bookEntity.setId(1L);
+        BookMetadataEntity metadataEntity = new BookMetadataEntity();
+
+        Set<TagEntity> existingTags = new HashSet<>();
+        existingTags.add(TagEntity.builder().name("Tag1").build());
+        existingTags.add(TagEntity.builder().name("Tag2").build());
+        metadataEntity.setTags(existingTags);
+        bookEntity.setMetadata(metadataEntity);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setTags(Collections.emptySet());
+
+        MetadataUpdateWrapper wrapper = MetadataUpdateWrapper.builder()
+                .metadata(newMetadata)
+                .build();
+
+        MetadataUpdateContext context = MetadataUpdateContext.builder()
+                .bookEntity(bookEntity)
+                .metadataUpdateWrapper(wrapper)
+                .mergeTags(false)
+                .replaceMode(MetadataReplaceMode.REPLACE_ALL)
+                .build();
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertTrue(bookEntity.getMetadata().getTags().isEmpty(), "All tags should be cleared when incoming set is empty");
+    }
+    @Test
+    void setBookMetadata_withMergeTagsTrue_shouldMergeTags() {
+        BookEntity bookEntity = new BookEntity();
+        bookEntity.setId(1L);
+        BookMetadataEntity metadataEntity = new BookMetadataEntity();
+        
+        Set<TagEntity> existingTags = new HashSet<>();
+        existingTags.add(TagEntity.builder().name("Tag1").build());
+        existingTags.add(TagEntity.builder().name("Tag2").build());
+        metadataEntity.setTags(existingTags);
+        bookEntity.setMetadata(metadataEntity);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setTags(Set.of("Tag3"));
+
+        MetadataUpdateWrapper wrapper = MetadataUpdateWrapper.builder()
+                .metadata(newMetadata)
+                .build();
+
+        MetadataUpdateContext context = MetadataUpdateContext.builder()
+                .bookEntity(bookEntity)
+                .metadataUpdateWrapper(wrapper)
+                .mergeTags(true)
+                .replaceMode(MetadataReplaceMode.REPLACE_ALL)
+                .build();
+
+        when(tagRepository.findByName("Tag3")).thenReturn(Optional.of(TagEntity.builder().name("Tag3").build()));
+
+        // Act
+        bookMetadataUpdater.setBookMetadata(context);
+
+        // Assert
+        assertEquals(3, bookEntity.getMetadata().getTags().size()); // Tag1, Tag2, Tag3
+        assertTrue(bookEntity.getMetadata().getTags().stream().anyMatch(t -> t.getName().equals("Tag1")));
+        assertTrue(bookEntity.getMetadata().getTags().stream().anyMatch(t -> t.getName().equals("Tag2")));
+        assertTrue(bookEntity.getMetadata().getTags().stream().anyMatch(t -> t.getName().equals("Tag3")));
+    }
+    @Test
+    void setBookMetadata_withMergeMoodsFalse_shouldReplaceMoods() {
+        BookEntity bookEntity = new BookEntity();
+        bookEntity.setId(1L);
+        BookMetadataEntity metadataEntity = new BookMetadataEntity();
+
+        Set<MoodEntity> existingMoods = new HashSet<>();
+        existingMoods.add(MoodEntity.builder().name("Mood1").build());
+        existingMoods.add(MoodEntity.builder().name("Mood2").build());
+        metadataEntity.setMoods(existingMoods);
+        bookEntity.setMetadata(metadataEntity);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setMoods(Set.of("Mood1"));
+
+        MetadataUpdateWrapper wrapper = MetadataUpdateWrapper.builder()
+                .metadata(newMetadata)
+                .build();
+
+        MetadataUpdateContext context = MetadataUpdateContext.builder()
+                .bookEntity(bookEntity)
+                .metadataUpdateWrapper(wrapper)
+                .mergeMoods(false)
+                .replaceMode(MetadataReplaceMode.REPLACE_ALL)
+                .build();
+
+        when(moodRepository.findByName("Mood1")).thenReturn(Optional.of(MoodEntity.builder().name("Mood1").build()));
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        // Assert
+        assertEquals(1, bookEntity.getMetadata().getMoods().size());
+        assertTrue(bookEntity.getMetadata().getMoods().stream().anyMatch(m -> m.getName().equals("Mood1")));
+        assertFalse(bookEntity.getMetadata().getMoods().stream().anyMatch(m -> m.getName().equals("Mood2")));
+    }
+
+    @Test
+    void setBookMetadata_withMergeMoodsFalse_andEmptyIncomingSet_shouldClearAllMoods() {
+        BookEntity bookEntity = new BookEntity();
+        bookEntity.setId(1L);
+        BookMetadataEntity metadataEntity = new BookMetadataEntity();
+
+        Set<MoodEntity> existingMoods = new HashSet<>();
+        existingMoods.add(MoodEntity.builder().name("Mood1").build());
+        existingMoods.add(MoodEntity.builder().name("Mood2").build());
+        metadataEntity.setMoods(existingMoods);
+        bookEntity.setMetadata(metadataEntity);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setMoods(Collections.emptySet());
+
+        MetadataUpdateWrapper wrapper = MetadataUpdateWrapper.builder()
+                .metadata(newMetadata)
+                .build();
+
+        MetadataUpdateContext context = MetadataUpdateContext.builder()
+                .bookEntity(bookEntity)
+                .metadataUpdateWrapper(wrapper)
+                .mergeMoods(false)
+                .replaceMode(MetadataReplaceMode.REPLACE_ALL)
+                .build();
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertTrue(bookEntity.getMetadata().getMoods().isEmpty(), "All moods should be cleared when incoming set is empty");
+    }
+
+    @Test
+    void setBookMetadata_withMergeMoodsTrue_shouldMergeMoods() {
+        BookEntity bookEntity = new BookEntity();
+        bookEntity.setId(1L);
+        BookMetadataEntity metadataEntity = new BookMetadataEntity();
+
+        Set<MoodEntity> existingMoods = new HashSet<>();
+        existingMoods.add(MoodEntity.builder().name("Mood1").build());
+        existingMoods.add(MoodEntity.builder().name("Mood2").build());
+        metadataEntity.setMoods(existingMoods);
+        bookEntity.setMetadata(metadataEntity);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setMoods(Set.of("Mood3"));
+
+        MetadataUpdateWrapper wrapper = MetadataUpdateWrapper.builder()
+                .metadata(newMetadata)
+                .build();
+
+        MetadataUpdateContext context = MetadataUpdateContext.builder()
+                .bookEntity(bookEntity)
+                .metadataUpdateWrapper(wrapper)
+                .mergeMoods(true)
+                .replaceMode(MetadataReplaceMode.REPLACE_ALL)
+                .build();
+
+        when(moodRepository.findByName("Mood3")).thenReturn(Optional.of(MoodEntity.builder().name("Mood3").build()));
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertEquals(3, bookEntity.getMetadata().getMoods().size()); // Mood1, Mood2, Mood3
+        assertTrue(bookEntity.getMetadata().getMoods().stream().anyMatch(m -> m.getName().equals("Mood1")));
+        assertTrue(bookEntity.getMetadata().getMoods().stream().anyMatch(m -> m.getName().equals("Mood2")));
+        assertTrue(bookEntity.getMetadata().getMoods().stream().anyMatch(m -> m.getName().equals("Mood3")));
+    }
+}


### PR DESCRIPTION
This pull request updates the metadata update behavior for books by changing how tags and moods are handled during metadata replacement. Specifically, it disables merging for tags and moods by default, allowing for their deletion or full replacement. Additionally, comprehensive unit tests are added to ensure the correct behavior for merging and replacing tags and moods.

**Behavior changes for metadata updates:**

* The `updateMetadata` method in `MetadataController` now sets `mergeTags` and `mergeMoods` to `false` by default, so tags and moods will be replaced (not merged) during metadata updates. This allows tags and moods to be deleted when an empty set is provided.

**Testing improvements:**

* Added `MetadataControllerTest` to verify that the controller disables merging for tags and moods, ensuring the new behavior is enforced.
* Added `BookMetadataUpdaterTest` with detailed test cases covering all scenarios for merging and replacing tags and moods, including clearing all tags/moods when an empty set is provided, and merging when enabled.


Closes: #1630