### PR TITLE
Add missing field for Kobo OverDrive expiration check

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/kobo/BookEntitlement.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/kobo/BookEntitlement.java
@@ -52,5 +52,6 @@ public class BookEntitlement {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class ActivePeriod {
         private String from;
+        private String to;
     }
 }


### PR DESCRIPTION
Closes #1238. 

Kobo OverDrive integration is *almost* working as-is, but we need to include an extra field when re-serializing to tell Kobo that the book is still valid.

Note: I had to return and re-borrow my OverDrive books to load the correct metadata (that is, a regular sync did not include the extra field). 