### PR TITLE
Add authors hierarchy and series metadata to OPDS feed

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/controller/OpdsController.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/controller/OpdsController.java
@@ -97,6 +97,16 @@ public class OpdsController {
                 .body(feed);
     }
 
+    @Operation(summary = "Get OPDS authors navigation", description = "Retrieve the OPDS authors navigation feed.")
+    @ApiResponse(responseCode = "200", description = "Authors navigation feed returned successfully")
+    @GetMapping(value = "/authors", produces = OPDS_CATALOG_MEDIA_TYPE)
+    public ResponseEntity<String> getAuthorsNavigation(@Parameter(hidden = true) HttpServletRequest request) {
+        String feed = opdsFeedService.generateAuthorsNavigation(request);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(OPDS_CATALOG_MEDIA_TYPE))
+                .body(feed);
+    }
+
     @Operation(summary = "Get OPDS catalog feed", description = "Retrieve the OPDS acquisition catalog feed.")
     @ApiResponse(responseCode = "200", description = "Catalog feed returned successfully")
     @GetMapping(value = "/catalog", produces = OPDS_ACQUISITION_MEDIA_TYPE)

--- a/booklore-api/src/main/java/com/adityachandel/booklore/repository/BookOpdsRepository.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/repository/BookOpdsRepository.java
@@ -122,4 +122,52 @@ public interface BookOpdsRepository extends JpaRepository<BookEntity, Long>, Jpa
 
     @Query(value = "SELECT b.id FROM BookEntity b WHERE b.library.id IN :libraryIds AND (b.deleted IS NULL OR b.deleted = false) ORDER BY function('RAND')", nativeQuery = false)
     List<Long> findRandomBookIdsByLibraryIds(@Param("libraryIds") Collection<Long> libraryIds);
+
+    // ============================================
+    // AUTHORS - Distinct Authors List
+    // ============================================
+
+    @Query("""
+            SELECT DISTINCT a FROM AuthorEntity a
+            JOIN a.bookMetadataEntityList m
+            JOIN m.book b
+            WHERE (b.deleted IS NULL OR b.deleted = false)
+            ORDER BY a.name
+            """)
+    List<com.adityachandel.booklore.model.entity.AuthorEntity> findDistinctAuthors();
+
+    @Query("""
+            SELECT DISTINCT a FROM AuthorEntity a
+            JOIN a.bookMetadataEntityList m
+            JOIN m.book b
+            WHERE (b.deleted IS NULL OR b.deleted = false)
+              AND b.library.id IN :libraryIds
+            ORDER BY a.name
+            """)
+    List<com.adityachandel.booklore.model.entity.AuthorEntity> findDistinctAuthorsByLibraryIds(@Param("libraryIds") Collection<Long> libraryIds);
+
+    // ============================================
+    // BOOKS BY AUTHOR - Two Query Pattern
+    // ============================================
+
+    @Query("""
+            SELECT DISTINCT b.id FROM BookEntity b
+            JOIN b.metadata m
+            JOIN m.authors a
+            WHERE a.name = :authorName
+              AND (b.deleted IS NULL OR b.deleted = false)
+            ORDER BY b.addedOn DESC
+            """)
+    Page<Long> findBookIdsByAuthorName(@Param("authorName") String authorName, Pageable pageable);
+
+    @Query("""
+            SELECT DISTINCT b.id FROM BookEntity b
+            JOIN b.metadata m
+            JOIN m.authors a
+            WHERE a.name = :authorName
+              AND b.library.id IN :libraryIds
+              AND (b.deleted IS NULL OR b.deleted = false)
+            ORDER BY b.addedOn DESC
+            """)
+    Page<Long> findBookIdsByAuthorNameAndLibraryIds(@Param("authorName") String authorName, @Param("libraryIds") Collection<Long> libraryIds, Pageable pageable);
 }


### PR DESCRIPTION
This commit enhances the OPDS server with two major features:

1. Series Metadata in OPDS Feed:
   - Add series name and book number to OPDS book entries
   - Uses standard OPDS/EPUB 3 metadata format with <meta> tags
   - Includes belongs-to-collection and group-position properties

2. Authors Navigation Hierarchy:
   - Add new /authors endpoint for browsing books by author
   - Implement authors list navigation feed with alphabetical sorting
   - Add author filtering to catalog feed via ?author parameter
   - Support library-based access control for author lists
   - Add authors link to root OPDS navigation

Changes:
- OpdsFeedService: Add series metadata to appendMetadata(), add generateAuthorsNavigation()
- OpdsController: Add getAuthorsNavigation() endpoint
- OpdsBookService: Add getDistinctAuthors() and getBooksByAuthorName() methods
- BookOpdsRepository: Add queries for distinct authors and books by author name
- Updated generateCatalogFeed() to support author parameter
- Updated determineFeedTitle() and determineFeedId() to handle author context