### PR TITLE
fix(bookdrop): improve file filtering to ignore .caltrash (calibre generated trash file)

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileHelper.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileHelper.java
@@ -34,6 +34,7 @@ public class LibraryFileHelper {
 
         try (Stream<Path> stream = Files.walk(libraryPath, FileVisitOption.FOLLOW_LINKS)) {
             return stream.filter(Files::isRegularFile)
+                    .filter(path -> !FileUtils.shouldIgnore(path))
                     .map(fullPath -> {
                         String fileName = fullPath.getFileName().toString();
                         Optional<BookFileExtension> bookExtension = BookFileExtension.fromFileName(fileName);
@@ -51,7 +52,6 @@ public class LibraryFileHelper {
                                 .build();
                     })
                     .filter(Objects::nonNull)
-                    .filter(file -> !file.getFileName().startsWith("."))
                     .toList();
         }
     }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/util/FileUtils.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/util/FileUtils.java
@@ -59,4 +59,16 @@ public class FileUtils {
                     .forEach(File::delete);
         }
     }
+
+    public boolean shouldIgnore(Path path) {
+        if (!path.getFileName().toString().isEmpty() && path.getFileName().toString().charAt(0) == '.') {
+            return true;
+        }
+        for (Path part : path) {
+            if (".caltrash".equals(part.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
This pull request refactors file filtering logic in several services to centralize and standardize the criteria for ignoring files and directories. The new `FileUtils.shouldIgnore` method replaces previous inline checks, making the codebase easier to maintain and extend. This method now ignores hidden files and directories named `.caltrash`.

File filtering improvements:

* Introduced `FileUtils.shouldIgnore(Path)` utility method to encapsulate logic for ignoring files and directories, including hidden files (names starting with `.`) and any path segment named `.caltrash`. (`booklore-api/src/main/java/com/adityachandel/booklore/util/FileUtils.java`)
* Updated `BookdropMonitoringService` to use `FileUtils.shouldIgnore` for filtering files and directories in event processing and initial scan, replacing previous inline checks for hidden files. (`booklore-api/src/main/java/com/adityachandel/booklore/service/bookdrop/BookdropMonitoringService.java`) 
* Refactored `LibraryFileHelper` to use `FileUtils.shouldIgnore` in its file discovery method, removing duplicated logic for hidden file filtering. (`booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileHelper.java`)