### PR TITLE
docs: update license information from MIT to GPL-3.0 in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ Please be respectful, inclusive, and collaborative. Harassment, abuse, or discri
 
 ## 📄 License
 
-Booklore is open-source and licensed under the  GPL-3.0 License. See [`LICENSE`](./LICENSE) for details.
+Booklore is open-source and licensed under the GPL-3.0 License. See [`LICENSE`](./LICENSE) for details.
 
 ---
 


### PR DESCRIPTION
This pull request updates the licensing information in the `CONTRIBUTING.md` file to reflect a change in the project's license.

* Documentation update:
  * Changed the license reference from MIT to GPL-3.0 in the `CONTRIBUTING.md` file to match the project's current licensing.


Was MIT for some reason, even though in ./LICECENSE it is explicitly stated to be GPL.3.0