### PR TITLE
delete broken (legacy?) github discussions link in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,6 @@ Please be respectful, inclusive, and collaborative. Harassment, abuse, or discri
 
 ## 💬 Community & Support
 
-- Use [GitHub Discussions](https://github.com/adityachandelgit/BookLore/discussions)
 - Discord server: https://discord.gg/Ee5hd458Uz
 
 ---


### PR DESCRIPTION
Just removed the github discussion link in CONTRIBUTING.md, as it is broken and github discussions is not actively used anymore.