### PR TITLE
Fix vertical overflow on metadata edit form dialog

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.scss
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.scss
@@ -1,9 +1,28 @@
-.tabpanels-responsive {
+::ng-deep .layout-main .tabpanels-responsive {
   height: calc(100dvh - 9.7rem);
 }
 
 @media (max-width: 768px) {
-  .tabpanels-responsive {
+  ::ng-deep .layout-main .tabpanels-responsive {
     height: calc(100dvh - 8.5rem);
   }
+}
+
+::ng-deep .p-dialog-content,
+::ng-deep p-dialog app-book-metadata-center,
+::ng-deep p-dialog app-book-metadata-center > div {
+  display: flex;
+}
+
+::ng-deep p-tablist {
+  flex-shrink: 0;
+}
+
+::ng-deep .p-dialog-content {
+  padding: 0;
+}
+
+::ng-deep p-dialog app-book-metadata-center > div {
+  border-radius: 0 0 0.75rem 0.75rem !important;
+  border-width: 1px 0 0 !important;
 }

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
@@ -19,7 +19,19 @@
 }
 
 ::ng-deep .p-autocomplete-input-chip {
-  width: 7rem;
+  width: 2rem;
+}
+
+::ng-deep .p-autocomplete-clearable ul {
+  padding-inline-end: 2rem !important;
+}
+
+::ng-deep .p-autocomplete-clearable .p-autocomplete-clear-icon {
+  right: 0px;
+  margin-top: -1rem;
+  width: 2rem;
+  height: 2rem;
+  padding: 0.5rem;
 }
 
 ::ng-deep .withbutton input,


### PR DESCRIPTION
Fixes #1540 - the metadata edit form was vertically overflowing its container when displayed in dialog mode.

Also contains a minor fix to wrapping of tag chips and clear button inside autocomplete fields on the same form.