### PR TITLE
Add option to auto-add new books to Kobo shelf

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/controller/KoboSettingsController.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/controller/KoboSettingsController.java
@@ -58,4 +58,14 @@ public class KoboSettingsController {
         KoboSyncSettings updated = koboService.updateProgressThresholds(readingThreshold, finishedThreshold);
         return ResponseEntity.ok(updated);
     }
+
+    @Operation(summary = "Toggle auto-add to Kobo shelf", description = "Enable or disable automatic addition of new books to the Kobo shelf. Requires sync permission or admin.")
+    @ApiResponse(responseCode = "200", description = "Auto-add setting updated successfully")
+    @PutMapping("/auto-add")
+    @PreAuthorize("@securityUtil.canSyncKobo() or @securityUtil.isAdmin()")
+    public ResponseEntity<KoboSyncSettings> toggleAutoAdd(
+            @Parameter(description = "Enable or disable auto-add to Kobo shelf") @RequestParam boolean enabled) {
+        KoboSyncSettings updated = koboService.setAutoAddToShelf(enabled);
+        return ResponseEntity.ok(updated);
+    }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/KoboSyncSettings.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/KoboSyncSettings.java
@@ -11,4 +11,5 @@ public class KoboSyncSettings {
     private boolean syncEnabled;
     private Float progressMarkAsReadingThreshold;
     private Float progressMarkAsFinishedThreshold;
+    private boolean autoAddToShelf;
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/KoboUserSettingsEntity.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/KoboUserSettingsEntity.java
@@ -33,4 +33,8 @@ public class KoboUserSettingsEntity {
     @Column(name = "progress_mark_as_finished_threshold")
     @Builder.Default
     private Float progressMarkAsFinishedThreshold = 99f;
+
+    @Column(name = "auto_add_to_shelf")
+    @Builder.Default
+    private boolean autoAddToShelf = true;
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/kobo/KoboAutoShelfService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/kobo/KoboAutoShelfService.java
@@ -1,0 +1,80 @@
+package com.adityachandel.booklore.service.kobo;
+
+import com.adityachandel.booklore.model.entity.BookEntity;
+import com.adityachandel.booklore.model.entity.KoboUserSettingsEntity;
+import com.adityachandel.booklore.model.entity.ShelfEntity;
+import com.adityachandel.booklore.model.enums.ShelfType;
+import com.adityachandel.booklore.repository.BookRepository;
+import com.adityachandel.booklore.repository.KoboUserSettingsRepository;
+import com.adityachandel.booklore.repository.ShelfRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KoboAutoShelfService {
+
+    private final KoboUserSettingsRepository koboUserSettingsRepository;
+    private final ShelfRepository shelfRepository;
+    private final BookRepository bookRepository;
+    private final KoboCompatibilityService koboCompatibilityService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void autoAddBookToKoboShelves(Long bookId) {
+        BookEntity book = bookRepository.findById(bookId).orElse(null);
+        if (book == null) {
+            log.warn("Book not found for auto-add to Kobo shelf: {}", bookId);
+            return;
+        }
+
+        autoAddBookToKoboShelvesInternal(book);
+    }
+
+    @Transactional
+    public void autoAddBookToKoboShelvesInternal(BookEntity book) {
+        if (book == null) {
+            log.warn("Book is null for auto-add to Kobo shelf");
+            return;
+        }
+
+        Long bookId = book.getId();
+
+        if (!koboCompatibilityService.isBookSupportedForKobo(book)) {
+            log.debug("Book {} is not Kobo-compatible, skipping auto-add", bookId);
+            return;
+        }
+
+        List<KoboUserSettingsEntity> usersWithAutoAdd = koboUserSettingsRepository.findAll().stream()
+                .filter(KoboUserSettingsEntity::isAutoAddToShelf)
+                .filter(KoboUserSettingsEntity::isSyncEnabled)
+                .toList();
+
+        for (KoboUserSettingsEntity userSettings : usersWithAutoAdd) {
+            Long userId = userSettings.getUserId();
+
+            ShelfEntity koboShelf = shelfRepository.findByUserIdAndName(userId, ShelfType.KOBO.getName())
+                    .orElse(null);
+
+            if (koboShelf == null) {
+                log.debug("User {} has auto-add enabled but no Kobo shelf exists", userId);
+                continue;
+            }
+
+            if (book.getShelves().contains(koboShelf)) {
+                log.debug("Book {} already on Kobo shelf for user {}", bookId, userId);
+                continue;
+            }
+
+            book.getShelves().add(koboShelf);
+            log.info("Auto-added book {} to Kobo shelf for user {}", bookId, userId);
+        }
+
+        bookRepository.save(book);
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/kobo/KoboSettingsService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/kobo/KoboSettingsService.java
@@ -76,14 +76,24 @@ public class KoboSettingsService {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
         KoboUserSettingsEntity entity = repository.findByUserId(user.getId())
                 .orElseGet(() -> initDefaultSettings(user.getId()));
-        
+
         if (readingThreshold != null) {
             entity.setProgressMarkAsReadingThreshold(readingThreshold);
         }
         if (finishedThreshold != null) {
             entity.setProgressMarkAsFinishedThreshold(finishedThreshold);
         }
-        
+
+        repository.save(entity);
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public KoboSyncSettings setAutoAddToShelf(boolean enabled) {
+        BookLoreUser user = authenticationService.getAuthenticatedUser();
+        KoboUserSettingsEntity entity = repository.findByUserId(user.getId())
+                .orElseGet(() -> initDefaultSettings(user.getId()));
+        entity.setAutoAddToShelf(enabled);
         repository.save(entity);
         return mapToDto(entity);
     }
@@ -122,6 +132,7 @@ public class KoboSettingsService {
         dto.setSyncEnabled(entity.isSyncEnabled());
         dto.setProgressMarkAsReadingThreshold(entity.getProgressMarkAsReadingThreshold());
         dto.setProgressMarkAsFinishedThreshold(entity.getProgressMarkAsFinishedThreshold());
+        dto.setAutoAddToShelf(entity.isAutoAddToShelf());
         return dto;
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/FileAsBookProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/FileAsBookProcessor.java
@@ -8,6 +8,7 @@ import com.adityachandel.booklore.model.enums.LibraryScanMode;
 import com.adityachandel.booklore.service.event.BookEventBroadcaster;
 import com.adityachandel.booklore.service.fileprocessor.BookFileProcessor;
 import com.adityachandel.booklore.service.fileprocessor.BookFileProcessorRegistry;
+import com.adityachandel.booklore.service.kobo.KoboAutoShelfService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,7 @@ public class FileAsBookProcessor implements LibraryFileProcessor {
 
     private final BookEventBroadcaster bookEventBroadcaster;
     private final BookFileProcessorRegistry processorRegistry;
+    private final KoboAutoShelfService koboAutoShelfService;
 
     @Override
     public LibraryScanMode getScanMode() {
@@ -38,6 +40,7 @@ public class FileAsBookProcessor implements LibraryFileProcessor {
 
             if (result != null) {
                 bookEventBroadcaster.broadcastBookAddEvent(result.getBook());
+                koboAutoShelfService.autoAddBookToKoboShelves(result.getBook().getId());
                 log.debug("Processed file: {}", libraryFile.getFileName());
             }
         }

--- a/booklore-api/src/main/resources/db/migration/V66__Add_auto_add_to_kobo_shelf.sql
+++ b/booklore-api/src/main/resources/db/migration/V66__Add_auto_add_to_kobo_shelf.sql
@@ -1,0 +1,2 @@
+ALTER TABLE kobo_user_settings
+    ADD COLUMN IF NOT EXISTS auto_add_to_shelf BOOLEAN NOT NULL DEFAULT TRUE;

--- a/booklore-ui/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo-sync-settings-component.html
+++ b/booklore-ui/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo-sync-settings-component.html
@@ -150,6 +150,24 @@
                 </p>
               </div>
             </div>
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <div class="setting-label-row">
+                  <label class="setting-label">Auto-add New Books to Kobo Shelf</label>
+                  <p-toggle-switch
+                    id="autoAddToShelf"
+                    name="autoAddToShelf"
+                    [(ngModel)]="koboSyncSettings.autoAddToShelf"
+                    (ngModelChange)="onAutoAddToggle()">
+                  </p-toggle-switch>
+                </div>
+                <p class="setting-description">
+                  Automatically add new Kobo-compatible books to your Kobo shelf when they are added to your library.
+                  This saves you from manually adding each book to the shelf for syncing.
+                </p>
+              </div>
+            </div>
           }
         </div>
       </div>

--- a/booklore-ui/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo-sync-settings-component.ts
+++ b/booklore-ui/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo-sync-settings-component.ts
@@ -55,7 +55,8 @@ export class KoboSyncSettingsComponent implements OnInit, OnDestroy {
     token: '',
     syncEnabled: false,
     progressMarkAsReadingThreshold: 1,
-    progressMarkAsFinishedThreshold: 99
+    progressMarkAsFinishedThreshold: 99,
+    autoAddToShelf: true
   }
 
   ngOnInit() {
@@ -108,6 +109,7 @@ export class KoboSyncSettingsComponent implements OnInit, OnDestroy {
         this.koboSyncSettings.syncEnabled = settings.syncEnabled;
         this.koboSyncSettings.progressMarkAsReadingThreshold = settings.progressMarkAsReadingThreshold ?? 1;
         this.koboSyncSettings.progressMarkAsFinishedThreshold = settings.progressMarkAsFinishedThreshold ?? 99;
+        this.koboSyncSettings.autoAddToShelf = settings.autoAddToShelf ?? true;
         this.credentialsSaved = !!settings.token;
       },
       error: () => {
@@ -240,6 +242,27 @@ export class KoboSyncSettingsComponent implements OnInit, OnDestroy {
           severity: 'error',
           summary: 'Error',
           detail: 'Failed to update progress thresholds'
+        });
+      }
+    });
+  }
+
+  onAutoAddToggle() {
+    this.koboService.toggleAutoAdd(this.koboSyncSettings.autoAddToShelf).subscribe({
+      next: () => {
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Setting Updated',
+          detail: this.koboSyncSettings.autoAddToShelf
+            ? 'New books will automatically be added to your Kobo shelf'
+            : 'Auto-add to Kobo shelf disabled'
+        });
+      },
+      error: () => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'Failed to update auto-add setting'
         });
       }
     });

--- a/booklore-ui/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo.service.ts
+++ b/booklore-ui/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo.service.ts
@@ -8,6 +8,7 @@ export interface KoboSyncSettings {
   syncEnabled: boolean;
   progressMarkAsReadingThreshold?: number;
   progressMarkAsFinishedThreshold?: number;
+  autoAddToShelf: boolean;
 }
 
 @Injectable({
@@ -39,5 +40,10 @@ export class KoboService {
       params = params.set('finishedThreshold', finishedThreshold.toString());
     }
     return this.http.put<KoboSyncSettings>(`${this.baseUrl}/progress-thresholds`, null, { params });
+  }
+
+  toggleAutoAdd(enabled: boolean): Observable<KoboSyncSettings> {
+    const params = new HttpParams().set('enabled', enabled.toString());
+    return this.http.put<KoboSyncSettings>(`${this.baseUrl}/auto-add`, null, { params });
   }
 }


### PR DESCRIPTION
## Summary

This implements the feature requested in #1703.

When enabled, new Kobo-compatible books added to the library will automatically be placed on the user's Kobo shelf, removing the need to manually add each book for syncing.

The setting defaults to enabled (true) so that new users get the expected behavior without additional configuration.

## Implementation Details

### Backend

**Database Migration (V66)**
- Adds `auto_add_to_shelf` column to the `kobo_user_settings` table with a default value of `true`

**New Service: KoboAutoShelfService**
- Contains the core logic for automatically adding books to Kobo shelves
- Checks if the book is Kobo-compatible before attempting to add it
- Finds all users who have both `syncEnabled` and `autoAddToShelf` set to true
- For each qualifying user, adds the book to their Kobo shelf if not already present
- Uses `@Transactional(propagation = Propagation.REQUIRES_NEW)` to ensure the book lookup happens after the book is fully committed to the database

**Modified: FileAsBookProcessor**
- Calls `KoboAutoShelfService.autoAddBookToKoboShelves()` after successfully processing a new book

**New API Endpoint**
- `PUT /api/v1/kobo-settings/auto-add?enabled=true|false`
- Requires `canSyncKobo` permission or admin role
- Returns the updated `KoboSyncSettings` DTO

**Updated: KoboSettingsService**
- Added `setAutoAddToShelf(boolean enabled)` method
- Updated `mapToDto()` to include the new field

### Frontend

**kobo.service.ts**
- Added `autoAddToShelf` to the `KoboSyncSettings` interface
- Added `toggleAutoAdd(enabled: boolean)` method to call the new API endpoint

**kobo-sync-settings-component.ts**
- Added `autoAddToShelf` to the default settings object
- Loads the setting from the API response
- Added `onAutoAddToggle()` handler to persist changes

**kobo-sync-settings-component.html**
- Added a toggle switch in the sync settings section
- Shows a description explaining the feature

## Testing

1. Enable Kobo sync for a user
2. Toggle the "Auto-add New Books to Kobo Shelf" setting on
3. Add a new book to the library (EPUB or PDF)
4. Verify the book appears on the Kobo shelf automatically
5. Toggle the setting off
6. Add another book
7. Verify the book does not automatically appear on the Kobo shelf

Closes #1703