### PR TITLE
Add /shared/ folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,6 @@ out/
 .vscode/
 local/
 
+### Dev config, books, and data ###
 booklore-api/src/main/resources/application-local.yaml
+/shared/


### PR DESCRIPTION
/shared/ is populated with books and data on a docker development setup