### PR TITLE
feat(file-move): add copy mode with images and metadata duplication

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/request/FileMoveRequest.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/request/FileMoveRequest.java
@@ -1,7 +1,7 @@
 package com.adityachandel.booklore.model.dto.request;
 
+import com.adityachandel.booklore.model.enums.FileOperationMode;
 import lombok.Data;
-
 import java.util.List;
 import java.util.Set;
 
@@ -9,6 +9,7 @@ import java.util.Set;
 public class FileMoveRequest {
     private Set<Long> bookIds;
     private List<Move> moves;
+    private FileOperationMode mode;
 
     @Data
     public static class Move {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/file/FileMoveHelper.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/file/FileMoveHelper.java
@@ -68,6 +68,19 @@ public class FileMoveHelper {
         executeWithRetry(() -> Files.move(source, target, StandardCopyOption.REPLACE_EXISTING));
     }
 
+    public void copyFile(Path source, Path target) throws IOException {
+        if (!waitForFileAccessible(source)) {
+            throw new NoSuchFileException(source.toString(), null, "Source file not accessible after retries");
+        }
+
+        if (target.getParent() != null) {
+            Files.createDirectories(target.getParent());
+        }
+
+        log.info("Copying file from {} to {}", source, target);
+        executeWithRetry(() -> Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING));
+    }
+
     public Path moveFileWithBackup(Path source) throws IOException {
         if (!waitForFileAccessible(source)) {
             throw new NoSuchFileException(source.toString(), null, "Source file not accessible after retries");

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/file/FileMoveService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/file/FileMoveService.java
@@ -7,21 +7,30 @@ import com.adityachandel.booklore.model.dto.request.FileMoveRequest;
 import com.adityachandel.booklore.model.entity.BookEntity;
 import com.adityachandel.booklore.model.entity.LibraryEntity;
 import com.adityachandel.booklore.model.entity.LibraryPathEntity;
+import com.adityachandel.booklore.model.entity.BookMetadataEntity;
+import com.adityachandel.booklore.model.enums.FileOperationMode;
 import com.adityachandel.booklore.model.websocket.Topic;
 import com.adityachandel.booklore.repository.BookRepository;
 import com.adityachandel.booklore.repository.LibraryRepository;
 import com.adityachandel.booklore.service.NotificationService;
 import com.adityachandel.booklore.service.monitoring.MonitoringRegistrationService;
+import com.adityachandel.booklore.util.FileService;
 import jakarta.persistence.EntityManager;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @AllArgsConstructor
 @Service
@@ -38,11 +47,13 @@ public class FileMoveService {
     private final BookMapper bookMapper;
     private final NotificationService notificationService;
     private final EntityManager entityManager;
+    private final FileService fileService;
 
 
     @Transactional
     public void bulkMoveFiles(FileMoveRequest request) {
         List<FileMoveRequest.Move> moves = request.getMoves();
+        FileOperationMode mode = request.getMode() == null ? FileOperationMode.MOVE : request.getMode();
         
         Set<Long> allAffectedLibraryIds = collectAllAffectedLibraryIds(moves);
         Set<Path> libraryPaths = monitoringRegistrationService.getPathsForLibraries(allAffectedLibraryIds);
@@ -53,7 +64,11 @@ public class FileMoveService {
 
         try {
             for (FileMoveRequest.Move move : moves) {
-                processSingleMove(move);
+                if (mode == FileOperationMode.COPY) {
+                    processSingleCopy(move);
+                } else {
+                    processSingleMove(move);
+                }
             }
         } finally {
             for (Long libraryId : allAffectedLibraryIds) {
@@ -137,6 +152,164 @@ public class FileMoveService {
             if (tempPath != null && currentFilePath != null) {
                 fileMoveHelper.rollbackMove(tempPath, currentFilePath);
             }
+        }
+    }
+
+    private void processSingleCopy(FileMoveRequest.Move move) {
+        Long bookId = move.getBookId();
+        Long targetLibraryId = move.getTargetLibraryId();
+        Long targetLibraryPathId = move.getTargetLibraryPathId();
+
+        try {
+            Optional<BookEntity> optionalBook = bookRepository.findById(bookId);
+            Optional<LibraryEntity> optionalLibrary = libraryRepository.findById(targetLibraryId);
+            if (optionalBook.isEmpty()) {
+                log.warn("Book not found for copy operation: bookId={}", bookId);
+                return;
+            }
+            if (optionalLibrary.isEmpty()) {
+                log.warn("Target library not found for copy operation: libraryId={}", targetLibraryId);
+                return;
+            }
+            BookEntity sourceBook = optionalBook.get();
+            LibraryEntity targetLibrary = optionalLibrary.get();
+
+            Optional<LibraryPathEntity> optionalLibraryPathEntity = targetLibrary.getLibraryPaths().stream()
+                    .filter(libraryPath -> Objects.equals(libraryPath.getId(), targetLibraryPathId))
+                    .findFirst();
+            if (optionalLibraryPathEntity.isEmpty()) {
+                log.warn("Target library path not found for copy operation: libraryId={}, pathId={}", targetLibraryId, targetLibraryPathId);
+                return;
+            }
+            LibraryPathEntity libraryPathEntity = optionalLibraryPathEntity.get();
+
+            String pattern = fileMoveHelper.getFileNamingPattern(targetLibrary);
+            Path newFilePath = fileMoveHelper.generateNewFilePath(sourceBook, libraryPathEntity, pattern);
+            String newFileName = newFilePath.getFileName().toString();
+            String newFileSubPath = fileMoveHelper.extractSubPath(newFilePath, libraryPathEntity);
+
+            fileMoveHelper.copyFile(sourceBook.getFullFilePath(), newFilePath);
+
+            BookEntity newBook = BookEntity.builder()
+                    .fileName(newFileName)
+                    .fileSubPath(newFileSubPath)
+                    .bookType(sourceBook.getBookType())
+                    .fileSizeKb(sourceBook.getFileSizeKb())
+                    .metadataMatchScore(sourceBook.getMetadataMatchScore())
+                    .library(targetLibrary)
+                    .libraryPath(libraryPathEntity)
+                    .initialHash(sourceBook.getInitialHash())
+                    .currentHash(sourceBook.getCurrentHash())
+                    .addedOn(Instant.now())
+                    .deleted(Boolean.FALSE)
+                    .build();
+
+            if (sourceBook.getMetadata() != null) {
+                BookMetadataEntity sourceMetadata = sourceBook.getMetadata();
+                BookMetadataEntity newMetadata = BookMetadataEntity.builder()
+                        .title(sourceMetadata.getTitle())
+                        .subtitle(sourceMetadata.getSubtitle())
+                        .publisher(sourceMetadata.getPublisher())
+                        .publishedDate(sourceMetadata.getPublishedDate())
+                        .description(sourceMetadata.getDescription())
+                        .seriesName(sourceMetadata.getSeriesName())
+                        .seriesNumber(sourceMetadata.getSeriesNumber())
+                        .seriesTotal(sourceMetadata.getSeriesTotal())
+                        .isbn13(sourceMetadata.getIsbn13())
+                        .isbn10(sourceMetadata.getIsbn10())
+                        .pageCount(sourceMetadata.getPageCount())
+                        .language(sourceMetadata.getLanguage())
+                        .rating(sourceMetadata.getRating())
+                        .reviewCount(sourceMetadata.getReviewCount())
+                        .coverUpdatedOn(sourceMetadata.getCoverUpdatedOn())
+                        .amazonRating(sourceMetadata.getAmazonRating())
+                        .amazonReviewCount(sourceMetadata.getAmazonReviewCount())
+                        .goodreadsRating(sourceMetadata.getGoodreadsRating())
+                        .goodreadsReviewCount(sourceMetadata.getGoodreadsReviewCount())
+                        .hardcoverRating(sourceMetadata.getHardcoverRating())
+                        .hardcoverReviewCount(sourceMetadata.getHardcoverReviewCount())
+                        .asin(sourceMetadata.getAsin())
+                        .goodreadsId(sourceMetadata.getGoodreadsId())
+                        .hardcoverId(sourceMetadata.getHardcoverId())
+                        .googleId(sourceMetadata.getGoogleId())
+                        .comicvineId(sourceMetadata.getComicvineId())
+                        .titleLocked(sourceMetadata.getTitleLocked())
+                        .subtitleLocked(sourceMetadata.getSubtitleLocked())
+                        .publisherLocked(sourceMetadata.getPublisherLocked())
+                        .publishedDateLocked(sourceMetadata.getPublishedDateLocked())
+                        .descriptionLocked(sourceMetadata.getDescriptionLocked())
+                        .isbn13Locked(sourceMetadata.getIsbn13Locked())
+                        .isbn10Locked(sourceMetadata.getIsbn10Locked())
+                        .asinLocked(sourceMetadata.getAsinLocked())
+                        .pageCountLocked(sourceMetadata.getPageCountLocked())
+                        .languageLocked(sourceMetadata.getLanguageLocked())
+                        .amazonRatingLocked(sourceMetadata.getAmazonRatingLocked())
+                        .amazonReviewCountLocked(sourceMetadata.getAmazonReviewCountLocked())
+                        .goodreadsRatingLocked(sourceMetadata.getGoodreadsRatingLocked())
+                        .goodreadsReviewCountLocked(sourceMetadata.getGoodreadsReviewCountLocked())
+                        .hardcoverRatingLocked(sourceMetadata.getHardcoverRatingLocked())
+                        .hardcoverReviewCountLocked(sourceMetadata.getHardcoverReviewCountLocked())
+                        .coverLocked(sourceMetadata.getCoverLocked())
+                        .seriesNameLocked(sourceMetadata.getSeriesNameLocked())
+                        .seriesNumberLocked(sourceMetadata.getSeriesNumberLocked())
+                        .seriesTotalLocked(sourceMetadata.getSeriesTotalLocked())
+                        .authorsLocked(sourceMetadata.getAuthorsLocked())
+                        .categoriesLocked(sourceMetadata.getCategoriesLocked())
+                        .moodsLocked(sourceMetadata.getMoodsLocked())
+                        .tagsLocked(sourceMetadata.getTagsLocked())
+                        .goodreadsIdLocked(sourceMetadata.getGoodreadsIdLocked())
+                        .hardcoverIdLocked(sourceMetadata.getHardcoverIdLocked())
+                        .googleIdLocked(sourceMetadata.getGoogleIdLocked())
+                        .comicvineIdLocked(sourceMetadata.getComicvineIdLocked())
+                        .reviewsLocked(sourceMetadata.getReviewsLocked())
+                        .build();
+
+                newMetadata.setAuthors(sourceMetadata.getAuthors() == null ? new HashSet<>() : new HashSet<>(sourceMetadata.getAuthors()));
+                newMetadata.setCategories(sourceMetadata.getCategories() == null ? new HashSet<>() : new HashSet<>(sourceMetadata.getCategories()));
+                newMetadata.setMoods(sourceMetadata.getMoods() == null ? new HashSet<>() : new HashSet<>(sourceMetadata.getMoods()));
+                newMetadata.setTags(sourceMetadata.getTags() == null ? new HashSet<>() : new HashSet<>(sourceMetadata.getTags()));
+                newMetadata.setBook(newBook);
+                newBook.setMetadata(newMetadata);
+            }
+
+            BookEntity saved = bookRepository.save(newBook);
+            BookEntity fresh = bookRepository.findById(saved.getId()).orElse(saved);
+            copyBookImages(sourceBook.getId(), fresh.getId());
+            notificationService.sendMessage(Topic.BOOK_ADD, bookMapper.toBookWithDescription(fresh, false));
+
+        } catch (Exception e) {
+            log.error("Error copying file for book ID {}: {}", bookId, e.getMessage(), e);
+        }
+    }
+
+    private void copyBookImages(Long sourceBookId, Long targetBookId) {
+        try {
+            Path source = Paths.get(fileService.getImagesFolder(sourceBookId));
+            if (!Files.exists(source) || !Files.isDirectory(source)) {
+                log.info("No images to copy for book {}", sourceBookId);
+                return;
+            }
+            Path target = Paths.get(fileService.getImagesFolder(targetBookId));
+            Files.createDirectories(target);
+
+            try (Stream<Path> walk = Files.walk(source)) {
+                walk.forEach(path -> {
+                    try {
+                        Path relative = source.relativize(path);
+                        Path dest = target.resolve(relative);
+                        if (Files.isDirectory(path)) {
+                            Files.createDirectories(dest);
+                        } else {
+                            Files.copy(path, dest, StandardCopyOption.REPLACE_EXISTING);
+                        }
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+            }
+            log.info("Copied images for book {} to {}", sourceBookId, targetBookId);
+        } catch (UncheckedIOException | IOException e) {
+            log.warn("Failed to copy images from book {} to {}: {}", sourceBookId, targetBookId, e.getMessage());
         }
     }
 

--- a/booklore-ui/src/app/shared/components/file-mover/file-mover-component.html
+++ b/booklore-ui/src/app/shared/components/file-mover/file-mover-component.html
@@ -73,11 +73,29 @@
           optionLabel="path"
           optionValue="id"
           placeholder="Select default path"
-          (onChange)="onDefaultLibraryPathChange()"
-          class="min-w-[250px]"
-          size="small"
-          appendTo="body"
-        ></p-select>
+        (onChange)="onDefaultLibraryPathChange()"
+        class="min-w-[250px]"
+        size="small"
+        appendTo="body"
+      ></p-select>
+      }
+    </div>
+    <div class="flex items-center gap-3">
+      <label class="text-sm font-medium text-gray-300">Mode:</label>
+      <p-select
+        [options]="[{label: 'Move', value: 'MOVE'}, {label: 'Copy', value: 'COPY'}]"
+        [(ngModel)]="operationMode"
+        placeholder="Select mode"
+        class="min-w-[140px]"
+        size="small"
+        appendTo="body"
+      ></p-select>
+      @if (operationMode === 'COPY') {
+        <i
+          class="pi pi-info-circle text-blue-300 cursor-pointer"
+          pTooltip="The default mode is Move. Copy will duplicate the file, metadata, and images into the target library, leaving the original in place."
+          tooltipPosition="top"
+        ></i>
       }
     </div>
   </div>
@@ -162,7 +180,7 @@
   <div class="flex justify-end items-center gap-4 flex-shrink-0 px-4 pt-4">
     @if (movedFileCount > 0) {
       <span class="text-green-500 flex items-center font-semibold drop-shadow-sm select-none">
-        {{ movedFileCount }} file{{ movedFileCount > 1 ? 's' : '' }} successfully moved
+        {{ movedFileCount }} file{{ movedFileCount > 1 ? 's' : '' }} successfully {{ operationMode === 'MOVE' ? 'moved' : 'copied' }}
         <i
           class="pi pi-check-circle ml-2 text-green-500 animate-bounce"
           style="animation-duration: 1.5s;"
@@ -173,8 +191,8 @@
     }
     @if (movedFileCount === 0) {
       <p-button
-        [label]="loading ? 'Moving...' : 'Move Files'"
-        [icon]="loading ? 'pi pi-spin pi-spinner' : 'pi pi-arrows-h'"
+        [label]="loading ? (operationMode === 'MOVE' ? 'Moving...' : 'Copying...') : (operationMode === 'MOVE' ? 'Move Files' : 'Copy Files')"
+        [icon]="loading ? 'pi pi-spin pi-spinner' : (operationMode === 'MOVE' ? 'pi pi-arrows-h' : 'pi pi-copy')"
         severity="success"
         (click)="saveChanges()"
         [disabled]="loading || filePreviews.length === 0"

--- a/booklore-ui/src/app/shared/components/file-mover/file-mover-component.ts
+++ b/booklore-ui/src/app/shared/components/file-mover/file-mover-component.ts
@@ -14,6 +14,7 @@ import {FileMoveRequest, FileOperationsService} from '../../service/file-operati
 import {LibraryService} from "../../../features/book/service/library.service";
 import {AppSettingsService} from '../../service/app-settings.service';
 import {Select} from 'primeng/select';
+import {TooltipModule} from 'primeng/tooltip';
 import {Library, LibraryPath} from '../../../features/book/model/library.model';
 
 interface FilePreview {
@@ -36,7 +37,7 @@ interface FilePreview {
 @Component({
   selector: 'app-file-mover-component',
   standalone: true,
-  imports: [Button, FormsModule, TableModule, Divider, Select],
+  imports: [Button, FormsModule, TableModule, Divider, Select, TooltipModule],
   templateUrl: './file-mover-component.html',
   styleUrl: './file-mover-component.scss'
 })
@@ -60,6 +61,7 @@ export class FileMoverComponent implements OnDestroy {
   defaultMovePattern = '';
   loading = false;
   patternsCollapsed = true;
+  operationMode: 'MOVE' | 'COPY' = 'MOVE';
 
   bookIds: Set<number> = new Set();
   books: Book[] = [];
@@ -354,6 +356,7 @@ export class FileMoverComponent implements OnDestroy {
 
     const request: FileMoveRequest = {
       bookIds: [...this.bookIds],
+      mode: this.operationMode,
       moves: this.filePreviews.map(preview => ({
         bookId: preview.bookId,
         targetLibraryId: preview.targetLibraryId,
@@ -369,8 +372,8 @@ export class FileMoverComponent implements OnDestroy {
         this.filePreviews.forEach(p => (p.isMoved = true));
         this.messageService.add({
           severity: 'success',
-          summary: 'Files Organized!',
-          detail: `Successfully organized ${this.filePreviews.length} file${this.filePreviews.length === 1 ? '' : 's'}.`,
+          summary: this.operationMode === 'MOVE' ? 'Files Organized!' : 'Files Copied!',
+          detail: `${this.operationMode === 'MOVE' ? 'Moved' : 'Copied'} ${this.filePreviews.length} file${this.filePreviews.length === 1 ? '' : 's'}.`,
           life: 3000
         });
       },

--- a/booklore-ui/src/app/shared/service/file-operations-service.ts
+++ b/booklore-ui/src/app/shared/service/file-operations-service.ts
@@ -5,6 +5,7 @@ import {API_CONFIG} from '../../core/config/api-config';
 
 export interface FileMoveRequest {
   bookIds: number[];
+  mode: 'MOVE' | 'COPY';
   moves: {
     bookId: number;
     targetLibraryId: number | null;


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
<!-- Provide a clear, concise description of what this PR accomplishes -->
<!-- Reference related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
Adds a copy/move mode toggle to Organize Book Files. Copy duplicates the file, metadata, and images to the target library while leaving the original untouched. This helps when using separate libraries per user (e.g., Kobo sync) and needing to duplicate shared books without re-importing or re-tagging.

## 🛠️ Changes Made
<!-- Summarize the key changes in this pull request -->
- add copy/move toggle with tooltip on Organize Book Files
- copy mode clones file, metadata, and images into the target library
- keeping original book and assets untouched

## 🧪 Testing
<!-- Describe how you verified these changes work correctly -->
- [x] Tested manually in local environment (copy and move flows)
- [ ] Added/updated automated unit/integration tests
- [ ] All existing tests pass


## 📸 Visual Changes _(if applicable)_
<!-- Include screenshots or videos for UI/UX changes -->
- Tooltip next to mode selector (only visible when Copy is selected)

## ✅ Pre-submission Checklist
<!-- Ensure all items are completed before requesting review -->
- [x] Code follows project style guidelines and conventions
- [ ] Tests added/updated to cover changes
- [ ] All tests pass locally (`./gradlew test` for backend)
- [ ] Flyway migration versioning is correct _(if database changes made)_
- [x] Branch is synced with latest `develop` branch
- [ ] Documentation PR created at [booklore-docs](https://github.com/booklore-app/booklore-docs) _(for major features)_


## 💬 Additional Notes _(optional)_
<!-- Add any context, considerations, or discussion points for reviewers -->
Context: I use one library per user to keep Kobo sync separate. When users share books, copying between libraries avoids manually re-adding and re-tagging metadata. I know this creates duplicates in the All Books view for Admin, but that’s acceptable for my use case. Tested and working.