### PR TITLE
fix: remove the personal rating extraction from fb2 books

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/Fb2Processor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/Fb2Processor.java
@@ -108,7 +108,6 @@ public class Fb2Processor extends AbstractFileProcessor implements BookFileProce
         metadata.setLanguage(truncate((lang == null || "UND".equalsIgnoreCase(lang)) ? "en" : lang, 1000));
 
         metadata.setAsin(truncate(fb2Metadata.getAsin(), 20));
-        metadata.setPersonalRating(fb2Metadata.getPersonalRating());
         metadata.setAmazonRating(fb2Metadata.getAmazonRating());
         metadata.setAmazonReviewCount(fb2Metadata.getAmazonReviewCount());
         metadata.setGoodreadsId(truncate(fb2Metadata.getGoodreadsId(), 100));


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Current develop build is failing, as the new fb2 additions are trying to extract personal ratings from the fb2 metadata. This doesn't exist on the metadata object (Supports amazon rating, goodreads rating etc), but personal rating is something that is not present on the book metadata


## 🛠️ Changes Implemented
Removed the 1 metadata extraction line that's blocking the build


## 🧪 Testing Strategy
I have removed the line and confirmed that the build is successful


## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [x] Code adheres to project style guidelines and conventions
- [x] Branch synchronized with latest `develop` branch
- [x] Automated unit/integration tests added/updated to cover changes
- [x] All tests pass locally (`./gradlew test` for backend)
- [x] Manual testing completed in local development environment
