### PR TITLE
fix(ui): Force page reload on logout

### DIFF
--- a/booklore-ui/src/app/core/security/auth-interceptor.service.ts
+++ b/booklore-ui/src/app/core/security/auth-interceptor.service.ts
@@ -73,7 +73,6 @@ function handle401Error(authService: AuthService, request: HttpRequest<any>, nex
 }
 
 function forceLogout(authService: AuthService, router: Router, message?: string): void {
-  authService.logout();
-  router.navigate(['/login']);
   if (message) console.warn(message);
+  authService.logout();
 }

--- a/booklore-ui/src/app/shared/components/change-password/change-password.component.ts
+++ b/booklore-ui/src/app/shared/components/change-password/change-password.component.ts
@@ -73,6 +73,5 @@ export class ChangePasswordComponent {
 
   logout() {
     this.authService.logout();
-    window.location.href = '/login';
   }
 }

--- a/booklore-ui/src/app/shared/service/auth.service.ts
+++ b/booklore-ui/src/app/shared/service/auth.service.ts
@@ -94,7 +94,9 @@ export class AuthService {
     this.oAuthStorage.removeItem("id_token");
     this.tokenSubject.next(null);
     this.getRxStompService().deactivate();
-    this.router.navigate(['/login']);
+
+    // Force reload so user's data is not cached for next user that logs in
+    window.location.href = '/login';
   }
 
   getRxStompService(): RxStompService {


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Forces a full page reload when a user logs out to avoid potential unwanted information disclosure. Currently BL routes back to the login form and if a different user logs in they see cached data from the previously logged in user such as shelves that should be private.

Fixes #1866

## 🛠️ Changes Implemented
Reload page on calls to AuthService.logout()

## 🧪 Testing Strategy
Manual execution of steps described in #1866:

1. Log in as User1.
2. Create a shelf "User1-Shelf1"
3. Log out
4. Log in as User2 and check that "User1-Shelf1" is not visible

## ⚠️ Required Pre-Submission Checklist
- [x] Code adheres to project style guidelines and conventions
- [x] Branch synchronized with latest `develop` branch
- [x] Manual testing completed in local development environment

## 💬 Additional Context _(optional)_
There are other parts of the app that call `router.navigate(['/login']` directly, including initial user setup sequence, OIDC failures, and AuthGuard. **They should be verified by someone more familiar with those processes than me to evaluate if this poses a risk.**