### PR TITLE
fix: bookdrop bulk actions not applying to uncached pages

### DIFF
--- a/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.ts
+++ b/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.ts
@@ -210,6 +210,45 @@ export class BookdropFileReviewComponent implements OnInit {
       });
   }
 
+  private async loadAllPagesIntoCache(): Promise<void> {
+    const totalPages = Math.ceil(this.totalRecords / this.pageSize);
+    const pagePromises: Promise<void>[] = [];
+
+    for (let page = 0; page < totalPages; page++) {
+      const promise = new Promise<void>((resolve, reject) => {
+        this.bookdropService.getPendingFiles(page, this.pageSize)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe({
+            next: response => {
+              response.content.forEach(file => {
+                if (!this.fileUiCache[file.id]) {
+                  const fresh = this.createFileUI(file);
+
+                  if (this.defaultLibraryId) {
+                    const selectedLib = this.libraries.find(l => String(l.id) === this.defaultLibraryId);
+                    const selectedPaths = selectedLib?.paths ?? [];
+                    fresh.selectedLibraryId = this.defaultLibraryId;
+                    fresh.availablePaths = selectedPaths.map(p => ({id: String(p.id ?? ''), name: p.path}));
+                    fresh.selectedPathId = this.defaultPathId ?? null;
+                  }
+
+                  this.fileUiCache[file.id] = fresh;
+                }
+              });
+              resolve();
+            },
+            error: err => {
+              console.error('Error loading page:', err);
+              reject(err);
+            }
+          });
+      });
+      pagePromises.push(promise);
+    }
+
+    await Promise.all(pagePromises);
+  }
+
   onLibraryChange(file: BookdropFileUI): void {
     const lib = this.libraries.find(l => String(l.id) === file.selectedLibraryId);
     file.availablePaths = lib?.paths.map(p => ({id: String(p.id ?? ''), name: p.path})) ?? [];
@@ -665,7 +704,21 @@ export class BookdropFileReviewComponent implements OnInit {
     });
   }
 
-  private applyBulkMetadataViaBackend(result: BulkEditResult): void {
+  private async applyBulkMetadataViaBackend(result: BulkEditResult): Promise<void> {
+    if (this.selectAllAcrossPages) {
+      try {
+        await this.loadAllPagesIntoCache();
+      } catch (err) {
+        console.error('Error loading pages into cache:', err);
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Bulk Edit Failed',
+          detail: 'An error occurred while loading files into cache.',
+        });
+        return;
+      }
+    }
+
     const selectedFiles = this.getSelectedFiles();
     const selectedIds = selectedFiles.map(f => f.file.id);
 
@@ -729,7 +782,21 @@ export class BookdropFileReviewComponent implements OnInit {
     });
   }
 
-  private applyExtractedMetadata(results: FileExtractionResult[]): void {
+  private async applyExtractedMetadata(results: FileExtractionResult[]): Promise<void> {
+    if (this.selectAllAcrossPages) {
+      try {
+        await this.loadAllPagesIntoCache();
+      } catch (err) {
+        console.error('Error loading pages into cache:', err);
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Pattern Extraction Failed',
+          detail: 'An error occurred while loading files into cache.',
+        });
+        return;
+      }
+    }
+
     let appliedCount = 0;
 
     results.forEach(result => {


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Doing some further testing, I realised my previous bulk actions PR https://github.com/booklore-app/booklore/pull/1846 was only applying to all cached pages. During my previous testing I had opened each page prior to doing the bulk action, which meant I never observed this issue.

Without this fix, only the pages that the user has navigated to **prior** to using bulk edit or pattern extract would actually be changed visually on the bookdrop page.

## 🛠️ Changes Implemented
Adds a function that will load all pages if the user has pressed `Select All`, and then used one of the bulk actions. This loads them into cache as if the user had navigated through each page prior to doing the bulk action


## 🧪 Testing Strategy
Applied the fix, and then tested it on a Bookdrop import of 400+ files and went through each page to confirm the updated metadata was related in the UI.


## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [x] Code adheres to project style guidelines and conventions
- [x] Branch synchronized with latest `develop` branch
- [x] All tests pass locally (`./gradlew test` for backend)
- [x] Manual testing completed in local development environment
