### PR TITLE
fix: Library icon name bug

### DIFF
--- a/booklore-ui/src/app/features/library-creator/library-creator.component.ts
+++ b/booklore-ui/src/app/features/library-creator/library-creator.component.ts
@@ -68,7 +68,8 @@ export class LibraryCreatorComponent implements OnInit {
         if (iconType === 'CUSTOM_SVG') {
           this.selectedIcon = {type: 'CUSTOM_SVG', value: icon};
         } else {
-          this.selectedIcon = {type: 'PRIME_NG', value: `pi pi-${icon}`};
+          const value = icon.slice(0, 6) === 'pi pi-' ? icon : `pi pi-${icon}`;
+          this.selectedIcon = {type: 'PRIME_NG', value: value};
         }
 
         this.watch = watch;


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Fix for repeatedly saving a library causing the library icon name to expand indefinitely.
i.e. on consecutive saves this is what happens:

1. pi pi-book
2. pi pi-pi pi-book
3. pi pi-pi pi-pi pi-book


## 🛠️ Changes Implemented
Fixed string substitution


## 🧪 Testing Strategy
Local browser

## ⚠️ Required Pre-Submission Checklist
- [x] Code adheres to project style guidelines and conventions
- [x] Branch synchronized with latest `develop` branch
- [x] Manual testing completed in local development environment
