### PR TITLE
feat: add library sync URL generation in KoboUrlBuilder

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/kobo/KoboInitializationService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/kobo/KoboInitializationService.java
@@ -41,6 +41,7 @@ public class KoboInitializationService {
             objectNode.put("image_host", baseBuilder.build().toUriString());
             objectNode.put("image_url_template", koboUrlBuilder.imageUrlTemplate(token));
             objectNode.put("image_url_quality_template", koboUrlBuilder.imageUrlQualityTemplate(token));
+            objectNode.put("library_sync", koboUrlBuilder.librarySyncUrl(token));
         }
 
         return ResponseEntity.ok()

--- a/booklore-api/src/main/java/com/adityachandel/booklore/util/kobo/KoboUrlBuilder.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/util/kobo/KoboUrlBuilder.java
@@ -70,4 +70,11 @@ public class KoboUrlBuilder {
                 .build()
                 .toUriString();
     }
+
+    public String librarySyncUrl(String token) {
+        return baseBuilder()
+                .pathSegment("api", "kobo", token, "v1", "library", "sync")
+                .build()
+                .toUriString();
+    }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Fixes #1742

The core issue is that booklore has a kobo library sync feature, but doesn't expose it to the kobo device through the /v1/initialization endpoint. This PR replaces the sync endpoint in /v1/initialization to refer to the booklore instance, allowing the kobo device to sync the library.


## 🛠️ Changes Implemented
<!-- Detail the specific modifications, additions, or removals made in this pull request -->
- Expose the /v1/library/sync endpoint in /v1/initialization.


## 🧪 Testing Strategy
I ran the dev server, configured my real kobo device to sync to it, then added a book to the kobo shelf. It synced. I removed the book via kobo's menu, and booklore removed it from the shelf. (Pitfall: re-adding the book to the shelf did not re-sync the book to kobo. I couldn't figure out why, but deleting the book from booklore and re-adding it allowed kobo to sync it again.)

Adding a second book synced fine. It may be worth documenting that kobo's book removal function shouldn't be used on the synced library? Let me know and I can add that.


## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [x] Code adheres to project style guidelines and conventions
- [x] Branch synchronized with latest `develop` branch
- [ ] Automated unit/integration tests added/updated to cover changes
- [x] All tests pass locally (`./gradlew test` for backend)
- [x] Manual testing completed in local development environment
- [ ] Flyway migration versioning follows correct sequence _(if database schema modified)_
- [ ] Documentation pull request submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(required for features or enhancements that introduce user-facing or visual changes)_


## 💬 Additional Context _(optional)_
I didn't add any tests, as this is such a small and simple change. If you require one, let me know what form it should take.