### PR TITLE
fix: Don't log stack trace when fetching latest version fails

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/VersionService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/VersionService.java
@@ -36,7 +36,7 @@ public class VersionService {
         try {
             latest = fetchLatestGitHubReleaseVersion();
         } catch (Exception e) {
-            log.error("Error fetching latest release version", e);
+            log.warn("Error fetching latest release version");
         }
         return new VersionInfo(appVersion, latest);
     }
@@ -57,7 +57,7 @@ public class VersionService {
             return root.path("tag_name").asText("unknown");
 
         } catch (Exception e) {
-            log.error("Failed to fetch latest release version", e);
+            log.warn("Failed to fetch latest release version");
             return "unknown";
         }
     }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Minor annoyance when developing Booklore: it dumps an unnecessary multi-page stack trace whenever it fails to fetch the latest version.

## 🛠️ Changes Implemented
Log a warning without the stack trace.

## ⚠️ Required Pre-Submission Checklist
- [x] Code adheres to project style guidelines and conventions
- [x] Branch synchronized with latest `develop` branch
- [x] Manual testing completed in local development environment
