### PR TITLE
fix: Prevent transaction rollback when cover download fails

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataUpdater.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataUpdater.java
@@ -356,7 +356,12 @@ public class BookMetadataUpdater {
         }
         if (!set) return;
         if (!StringUtils.hasText(m.getThumbnailUrl()) || isLocalOrPrivateUrl(m.getThumbnailUrl())) return;
-        fileService.createThumbnailFromUrl(bookId, m.getThumbnailUrl());
+        try {
+            fileService.createThumbnailFromUrl(bookId, m.getThumbnailUrl());
+        } catch (Exception ex) {
+            log.warn("Failed to download cover for book {}: {}", bookId, ex.getMessage());
+            // Don't rethrow - cover failures shouldn't roll back metadata updates
+        }
     }
 
     private void updateLocks(BookMetadata m, BookMetadataEntity e) {


### PR DESCRIPTION
## Summary

Cover download failures during metadata refresh were causing entire book metadata updates to roll back, even when metadata was fetched successfully.

**Root cause:** `updateThumbnailIfNeeded()` is called within a `@Transactional` method. When `createThumbnailFromUrl()` throws an exception (e.g., CDN serves WebP with JPEG headers), Spring marks the transaction as rollback-only. The exception is caught higher up in `MetadataRefreshService`, but by then the transaction is already poisoned.

**Fix:** Wrap the thumbnail download in try-catch and log a warning instead of propagating the exception. Cover failures are non-critical and shouldn't prevent metadata updates from persisting.

## Reproduction

1. Have a book whose cover URL returns content-type mismatch (e.g., Amazon CDN serving WebP as JPEG)
2. Run metadata refresh
3. Observe: `Batch update returned unexpected row count from update [0]` and metadata not saved

## Test Plan

- [x] Verified fix locally - book metadata now persists even when cover download fails
- [x] Cover failures logged as WARN instead of causing ERROR/rollback