### PR TITLE
fix: when selecting a series, select all books from the series

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -33,13 +33,13 @@ import {BookNavigationService} from '../../../service/book-navigation.service';
 })
 export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
 
-  @Output() checkboxClick = new EventEmitter<{ index: number; bookId: number; selected: boolean; shiftKey: boolean }>();
+  @Output() checkboxClick = new EventEmitter<{ index: number; book: Book; selected: boolean; shiftKey: boolean }>();
   @Output() menuToggled = new EventEmitter<boolean>();
 
   @Input() index!: number;
   @Input() book!: Book;
   @Input() isCheckboxEnabled: boolean = false;
-  @Input() onBookSelect?: (bookId: number, selected: boolean) => void;
+  @Input() onBookSelect?: (book: Book, selected: boolean) => void;
   @Input() isSelected: boolean = false;
   @Input() bottomBarHidden: boolean = false;
   @Input() seriesViewEnabled: boolean = false;
@@ -694,13 +694,13 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
 
     this.checkboxClick.emit({
       index: this.index,
-      bookId: this.book.id,
+      book: this.book,
       selected: selected,
       shiftKey: shiftKey,
     });
 
     if (this.onBookSelect) {
-      this.onBookSelect(this.book.id, selected);
+      this.onBookSelect(this.book, selected);
     }
 
     this.lastMouseEvent = null;

--- a/booklore-ui/src/app/features/book/components/book-browser/filters/SeriesCollapseFilter.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/filters/SeriesCollapseFilter.ts
@@ -81,6 +81,7 @@ export class SeriesCollapseFilter implements BookFilter, OnDestroy {
           const firstBook = sortedGroup[0];
           collapsedBooks.push({
             ...firstBook,
+            seriesBooks: group,
             seriesCount: group.length
           });
         }

--- a/booklore-ui/src/app/features/book/model/book.model.ts
+++ b/booklore-ui/src/app/features/book/model/book.model.ts
@@ -40,6 +40,7 @@ export interface Book extends FileInfo {
   koreaderProgress?: KoReaderProgress;
   koboProgress?: KoboProgress;
   seriesCount?: number | null;
+  seriesBooks?: Book[] | null;
   metadataMatchScore?: number | null;
   personalRating?: number | null;
   readStatus?: ReadStatus;


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Right now when series collapse is enabled, if you select a "series" book only one book of the series is selected.


## 🛠️ Changes Implemented
Now all books from the series are selected

## 🧪 Testing Strategy
Select a series, see the number selection change. Test multi metadata editor and see that all books are selected

## 📸 Visual Changes _(if applicable)_
<!-- Attach screenshots or videos demonstrating UI/UX modifications -->


## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [x] Code adheres to project style guidelines and conventions
- [x] Branch synchronized with latest `develop` branch
- [ ] Automated unit/integration tests added/updated to cover changes
- [x] All tests pass locally (`./gradlew test` for backend)
- [x] Manual testing completed in local development environment
- [x] Flyway migration versioning follows correct sequence _(if database schema modified)_
- [ ] Documentation pull request submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(required for features or enhancements that introduce user-facing or visual changes)_


## 💬 Additional Context _(optional)_
<!-- Provide any supplementary information, implementation considerations, or discussion points for reviewers -->
