### PR TITLE
perf(cbz): optimize CBZ reading

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/CbxProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/CbxProcessor.java
@@ -110,26 +110,43 @@ public class CbxProcessor extends AbstractFileProcessor implements BookFileProce
     }
 
     private Optional<BufferedImage> extractFirstImageFromZip(File file) {
+        // Fast path: Try reading from Central Directory
         try (ZipFile zipFile = ZipFile.builder()
                 .setFile(file)
                 .setUseUnicodeExtraFields(true)
                 .setIgnoreLocalFileHeader(true)
                 .get()) {
-            return Collections.list(zipFile.getEntries()).stream()
-                    .filter(e -> !e.isDirectory() && IMAGE_EXTENSION_CASE_INSENSITIVE_PATTERN.matcher(e.getName()).matches())
-                    .min(Comparator.comparing(ZipArchiveEntry::getName))
-                    .map(entry -> {
-                        try (InputStream is = zipFile.getInputStream(entry)) {
-                            return ImageIO.read(is);
-                        } catch (Exception e) {
-                            log.warn("Failed to read image from ZIP entry {}: {}", entry.getName(), e.getMessage());
-                            return null;
-                        }
-                    });
+             Optional<BufferedImage> image = findAndReadFirstImage(zipFile);
+             if (image.isPresent()) return image;
+        } catch (Exception e) {
+            log.debug("Fast path failed for ZIP extraction: {}", e.getMessage());
+        }
+
+        // Slow path: Fallback to scanning local file headers
+        try (ZipFile zipFile = ZipFile.builder()
+                .setFile(file)
+                .setUseUnicodeExtraFields(true)
+                .setIgnoreLocalFileHeader(false)
+                .get()) {
+            return findAndReadFirstImage(zipFile);
         } catch (Exception e) {
             log.error("Error extracting ZIP: {}", e.getMessage());
             return Optional.empty();
         }
+    }
+
+    private Optional<BufferedImage> findAndReadFirstImage(ZipFile zipFile) {
+        return Collections.list(zipFile.getEntries()).stream()
+                .filter(e -> !e.isDirectory() && IMAGE_EXTENSION_CASE_INSENSITIVE_PATTERN.matcher(e.getName()).matches())
+                .min(Comparator.comparing(ZipArchiveEntry::getName))
+                .map(entry -> {
+                    try (InputStream is = zipFile.getInputStream(entry)) {
+                        return ImageIO.read(is);
+                    } catch (Exception e) {
+                        log.warn("Failed to read image from ZIP entry {}: {}", entry.getName(), e.getMessage());
+                        return null;
+                    }
+                });
     }
 
     private Optional<BufferedImage> extractFirstImageFrom7z(File file) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/kobo/CbxConversionService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/kobo/CbxConversionService.java
@@ -196,27 +196,44 @@ public class CbxConversionService {
     }
     
     private List<Path> extractImagesFromZip(File cbzFile, Path extractedImagesDir) throws IOException {
-        List<Path> imagePaths = new ArrayList<>();
-        
+        // Fast path: Try reading from Central Directory
         try (ZipFile zipFile = ZipFile.builder()
                 .setFile(cbzFile)
                 .setUseUnicodeExtraFields(true)
                 .setIgnoreLocalFileHeader(true)
                 .get()) {
-            for (ZipArchiveEntry entry : Collections.list(zipFile.getEntries())) {
-                if (entry.isDirectory() || !isImageFile(entry.getName())) {
-                    continue;
-                }
-                
+            List<Path> paths = extractImagesFromZipFile(zipFile, extractedImagesDir);
+            if (!paths.isEmpty()) return paths;
+        } catch (Exception e) {
+            log.debug("Fast path extraction failed for {}: {}", cbzFile.getName(), e.getMessage());
+        }
+
+        // Slow path: Fallback to scanning local file headers
+        try (ZipFile zipFile = ZipFile.builder()
+                .setFile(cbzFile)
+                .setUseUnicodeExtraFields(true)
+                .setIgnoreLocalFileHeader(false)
+                .get()) {
+            return extractImagesFromZipFile(zipFile, extractedImagesDir);
+        }
+    }
+
+    private List<Path> extractImagesFromZipFile(ZipFile zipFile, Path extractedImagesDir) {
+        List<Path> imagePaths = new ArrayList<>();
+        for (ZipArchiveEntry entry : Collections.list(zipFile.getEntries())) {
+            if (entry.isDirectory() || !isImageFile(entry.getName())) {
+                continue;
+            }
+
+            try {
                 validateImageSize(entry.getName(), entry.getSize());
-                
+                Path outputPath = extractedImagesDir.resolve(extractFileName(entry.getName()));
                 try (InputStream inputStream = zipFile.getInputStream(entry)) {
-                    Path outputPath = extractedImagesDir.resolve(extractFileName(entry.getName()));
                     Files.copy(inputStream, outputPath);
                     imagePaths.add(outputPath);
-                } catch (Exception e) {
-                    log.warn("Error extracting image {}: {}", entry.getName(), e.getMessage());
                 }
+            } catch (Exception e) {
+                log.warn("Error extracting image {}: {}", entry.getName(), e.getMessage());
             }
         }
         

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/reader/CbxReaderService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/reader/CbxReaderService.java
@@ -137,27 +137,36 @@ public class CbxReaderService {
         String[] encodingsToTry = {"UTF-8", "Shift_JIS", "ISO-8859-1", "CP437", "MS932"};
 
         for (String encoding : encodingsToTry) {
+            Charset charset = Charset.forName(encoding);
             try {
-                extractZipWithEncoding(cbzPath, targetDir, Charset.forName(encoding));
-                return;
-            } catch (IllegalArgumentException | java.util.zip.ZipException e) {
-                log.debug("Failed to extract with encoding {}: {}", encoding, e.getMessage());
+                // Fast path: Try reading from Central Directory only
+                if (extractZipWithEncoding(cbzPath, targetDir, charset, true)) return;
+            } catch (Exception e) {
+                log.debug("Fast path failed for encoding {}: {}", encoding, e.getMessage());
+            }
+            
+            try {
+                // Slow path: Fallback to scanning local file headers
+                if (extractZipWithEncoding(cbzPath, targetDir, charset, false)) return;
+            } catch (Exception e) {
+                log.debug("Slow path failed for encoding {}: {}", encoding, e.getMessage());
             }
         }
 
         throw new IOException("Unable to extract ZIP archive with any supported encoding");
     }
 
-    private void extractZipWithEncoding(Path cbzPath, Path targetDir, Charset charset) throws IOException {
+    private boolean extractZipWithEncoding(Path cbzPath, Path targetDir, Charset charset, boolean useFastPath) throws IOException {
         try (org.apache.commons.compress.archivers.zip.ZipFile zipFile =
                      org.apache.commons.compress.archivers.zip.ZipFile.builder()
                              .setPath(cbzPath)
                              .setCharset(charset)
                              .setUseUnicodeExtraFields(true)
-                             .setIgnoreLocalFileHeader(true)
+                             .setIgnoreLocalFileHeader(useFastPath)
                              .get()) {
 
             var entries = zipFile.getEntries();
+            boolean foundImages = false;
             while (entries.hasMoreElements()) {
                 ZipArchiveEntry entry = entries.nextElement();
                 if (!entry.isDirectory() && isImageFile(entry.getName())) {
@@ -165,9 +174,11 @@ public class CbxReaderService {
                     Path target = targetDir.resolve(fileName);
                     try (InputStream in = zipFile.getInputStream(entry)) {
                         Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+                        foundImages = true;
                     }
                 }
             }
+            return foundImages;
         }
     }
 
@@ -335,10 +346,19 @@ public class CbxReaderService {
         String[] encodingsToTry = {"UTF-8", "Shift_JIS", "ISO-8859-1", "CP437", "MS932"};
 
         for (String encoding : encodingsToTry) {
+            Charset charset = Charset.forName(encoding);
             try {
-                return estimateCbzWithEncoding(cbxPath, Charset.forName(encoding));
-            } catch (IllegalArgumentException | java.util.zip.ZipException e) {
-                log.debug("Failed to estimate with encoding {}: {}", encoding, e.getMessage());
+                long size = estimateCbzWithEncoding(cbxPath, charset, true);
+                if (size > 0) return size;
+            } catch (Exception e) {
+                log.debug("Fast path estimation failed for encoding {}: {}", encoding, e.getMessage());
+            }
+
+            try {
+                long size = estimateCbzWithEncoding(cbxPath, charset, false);
+                if (size > 0) return size;
+            } catch (Exception e) {
+                log.debug("Slow path estimation failed for encoding {}: {}", encoding, e.getMessage());
             }
         }
 
@@ -346,13 +366,13 @@ public class CbxReaderService {
         return Long.MAX_VALUE;
     }
 
-    private long estimateCbzWithEncoding(Path cbxPath, Charset charset) throws IOException {
+    private long estimateCbzWithEncoding(Path cbxPath, Charset charset, boolean useFastPath) throws IOException {
         try (org.apache.commons.compress.archivers.zip.ZipFile zipFile =
                      org.apache.commons.compress.archivers.zip.ZipFile.builder()
                              .setPath(cbxPath)
                              .setCharset(charset)
                              .setUseUnicodeExtraFields(true)
-                             .setIgnoreLocalFileHeader(true)
+                             .setIgnoreLocalFileHeader(useFastPath)
                              .get()) {
 
             long total = 0;


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
<!-- Provide a clear and concise summary of the changes introduced in this pull request -->
<!-- Reference related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->

This PR improves the performance of reading CBZ (Zip) archives by prioritizing Central Directory lookups ("Fast Path") while maintaining compatibility with malformed or legacy archives through a "Slow Path" fallback mechanism.
## 🛠️ Changes Implemented
<!-- Detail the specific modifications, additions, or removals made in this pull request -->
 Overview



- Performance: By default, commons-compress scans the Local File Header of every entry. On large archives this seek-heavy operation can take seconds.
- Compatibility: Simply disabling the Local Header scan (to read only the Central Directory) reduces read time. However, some archives place Unicode filenames only in the Local File Header's extra fields. Reading only the Central Directory for these specific files results in garbled filenames or missing entries.

Implemented a "Try Fast, Then Slow" strategy across CbxReaderService, CbxProcessor, and CbxConversionService:
1. Fast Path (Primary):
       * Attempt to read the archive using setIgnoreLocalFileHeader(true) and setUseUnicodeExtraFields(true).
       * This relies solely on the Central Directory and is faster.
2. Slow Path (Fallback):
       * If the Fast Path throws an exception OR returns zero images, the system automatically falls back to setIgnoreLocalFileHeader(false).
       * This performs the traditional, slower scan to ensure we successfully extract content from edge-case archives.


## 🧪 Testing Strategy
<!-- Describe the testing methodology used to verify the correctness of these changes -->
<!-- Include testing approach, scenarios covered, and edge cases considered -->


## 📸 Visual Changes _(if applicable)_
<!-- Attach screenshots or videos demonstrating UI/UX modifications -->


## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [X] Code adheres to project style guidelines and conventions
- [X] Branch synchronized with latest `develop` branch
- [X] Automated unit/integration tests added/updated to cover changes
- [X] All tests pass locally (`./gradlew test` for backend)
- [X] Manual testing completed in local development environment
- [X] Flyway migration versioning follows correct sequence _(if database schema modified)_
- [ ] Documentation pull request submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(required for features or enhancements that introduce user-facing or visual changes)_


## 💬 Additional Context _(optional)_
<!-- Provide any supplementary information, implementation considerations, or discussion points for reviewers -->
