### PR TITLE
feat(settings): add export/import configuration feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ local/
 ### Dev config, books, and data ###
 booklore-api/src/main/resources/application-local.yaml
 /shared/
+
+/.gorev/
+/docs/ideas/

--- a/booklore-api/src/main/java/com/adityachandel/booklore/controller/ConfigurationExportController.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/controller/ConfigurationExportController.java
@@ -1,0 +1,93 @@
+package com.adityachandel.booklore.controller;
+
+import com.adityachandel.booklore.service.export.ConfigurationExportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Tag(name = "Configuration Export/Import", description = "Export and import library configuration")
+@RestController
+@RequestMapping("/api/v1/configuration")
+@RequiredArgsConstructor
+public class ConfigurationExportController {
+
+    private final ConfigurationExportService exportService;
+
+    @Operation(summary = "Export configuration as JSON", description = "Export shelves, magic shelves, and settings as JSON")
+    @GetMapping("/export")
+    public ResponseEntity<String> exportConfiguration() {
+        String jsonConfig = exportService.exportConfiguration();
+
+        String filename = "booklore-config-" +
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")) +
+                ".json";
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .body(jsonConfig);
+    }
+
+    @Operation(summary = "Import configuration from JSON", description = "Import shelves, magic shelves, and settings from JSON")
+    @PostMapping("/import")
+    public ResponseEntity<Void> importConfiguration(
+            @RequestBody String jsonConfig,
+            @Parameter(description = "Skip existing items") @RequestParam(defaultValue = "true") boolean skipExisting,
+            @Parameter(description = "Overwrite existing items") @RequestParam(defaultValue = "false") boolean overwrite,
+            @Parameter(description = "Import shelves") @RequestParam(defaultValue = "true") boolean importShelves,
+            @Parameter(description = "Import magic shelves") @RequestParam(defaultValue = "true") boolean importMagicShelves,
+            @Parameter(description = "Import settings") @RequestParam(defaultValue = "true") boolean importSettings
+    ) {
+        com.adityachandel.booklore.model.dto.export.ImportOptions options = com.adityachandel.booklore.model.dto.export.ImportOptions.builder()
+                .skipExisting(skipExisting)
+                .overwrite(overwrite)
+                .importShelves(importShelves)
+                .importMagicShelves(importMagicShelves)
+                .importSettings(importSettings)
+                .skipBookMappings(true)
+                .build();
+
+        exportService.importConfiguration(jsonConfig, options);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "Get configuration template", description = "Get empty template for configuration")
+    @GetMapping("/template")
+    public ResponseEntity<String> getTemplate() {
+        String template = """
+                {
+                  "version": "1.0",
+                  "shelves": [
+                    {
+                      "name": "My Shelf",
+                      "icon": "pi-book",
+                      "iconType": "PRIME_NG",
+                      "sort": null,
+                      "books": []
+                    }
+                  ],
+                  "magicShelves": [
+                    {
+                      "name": "My Magic Shelf",
+                      "icon": "pi-star",
+                      "iconType": "PRIME_NG",
+                      "isPublic": false,
+                      "filterJson": "{\\"rules\\":[]}"
+                    }
+                  ],
+                  "settings": [
+                    {"key": "theme", "value": "dark"}
+                  ]
+                }
+                """;
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(template);
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/export/ConfigurationExportDTO.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/export/ConfigurationExportDTO.java
@@ -1,0 +1,79 @@
+package com.adityachandel.booklore.model.dto.export;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * DTO for exporting user configuration (shelves, magic shelves, settings) as JSON
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfigurationExportDTO {
+    private String version;
+    private Instant exportedAt;
+    private String username;
+    private List<ShelfExportDTO> shelves;
+    private List<MagicShelfExportDTO> magicShelves;
+    private List<SettingExportDTO> settings;
+
+    /**
+     * DTO for exporting a single shelf
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ShelfExportDTO {
+        private String name;
+        private String icon;
+        private String iconType;
+        private SortDTO sort;
+        private List<String> books; // Book identifiers (id:filename)
+    }
+
+    /**
+     * DTO for exporting a single magic shelf
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MagicShelfExportDTO {
+        private String name;
+        private String icon;
+        private String iconType;
+        private boolean isPublic;
+        private String filterJson;
+    }
+
+    /**
+     * DTO for exporting a single user setting
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SettingExportDTO {
+        private String key;
+        private String value;
+    }
+
+    /**
+     * DTO for sort configuration
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SortDTO {
+        private String field;
+        private String direction; // ASCENDING or DESCENDING
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/export/ImportOptions.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/export/ImportOptions.java
@@ -1,0 +1,53 @@
+package com.adityachandel.booklore.model.dto.export;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Options for importing configuration
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImportOptions {
+    /**
+     * Import regular shelves
+     */
+    @Builder.Default
+    private boolean importShelves = true;
+
+    /**
+     * Import magic shelves
+     */
+    @Builder.Default
+    private boolean importMagicShelves = true;
+
+    /**
+     * Import user settings
+     */
+    @Builder.Default
+    private boolean importSettings = true;
+
+    /**
+     * Skip items that already exist (default behavior)
+     */
+    @Builder.Default
+    private boolean skipExisting = true;
+
+    /**
+     * Overwrite existing items (conflicts with skipExisting)
+     * If both are true, skipExisting takes precedence
+     */
+    @Builder.Default
+    private boolean overwrite = false;
+
+    /**
+     * Don't import book mappings for shelves (just shelf structure)
+     * Book IDs may not match across different libraries
+     */
+    @Builder.Default
+    private boolean skipBookMappings = true;
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/export/ConfigurationExportService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/export/ConfigurationExportService.java
@@ -1,0 +1,292 @@
+package com.adityachandel.booklore.service.export;
+
+import com.adityachandel.booklore.config.security.service.AuthenticationService;
+import com.adityachandel.booklore.exception.ApiError;
+import com.adityachandel.booklore.model.dto.BookLoreUser;
+import com.adityachandel.booklore.model.dto.Sort;
+import com.adityachandel.booklore.model.dto.export.ConfigurationExportDTO;
+import com.adityachandel.booklore.model.dto.export.ConfigurationExportDTO.*;
+import com.adityachandel.booklore.model.dto.export.ImportOptions;
+import com.adityachandel.booklore.model.entity.*;
+import com.adityachandel.booklore.model.enums.IconType;
+import com.adityachandel.booklore.model.enums.SortDirection;
+import com.adityachandel.booklore.repository.MagicShelfRepository;
+import com.adityachandel.booklore.repository.ShelfRepository;
+import com.adityachandel.booklore.repository.UserRepository;
+import com.adityachandel.booklore.repository.UserSettingRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConfigurationExportService {
+
+    private final ShelfRepository shelfRepository;
+    private final MagicShelfRepository magicShelfRepository;
+    private final UserSettingRepository userSettingRepository;
+    private final UserRepository userRepository;
+    private final AuthenticationService authenticationService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Export user configuration as JSON string
+     */
+    public String exportConfiguration() {
+        BookLoreUser user = authenticationService.getAuthenticatedUser();
+        Long userId = user.getId();
+
+        // Export shelves
+        List<ShelfExportDTO> shelves = shelfRepository.findByUserId(userId)
+                .stream()
+                .map(this::mapToShelfExport)
+                .collect(Collectors.toList());
+
+        // Export magic shelves
+        List<MagicShelfExportDTO> magicShelves = magicShelfRepository.findAllByUserId(userId)
+                .stream()
+                .map(this::mapToMagicShelfExport)
+                .collect(Collectors.toList());
+
+        // Export user settings (filtered)
+        List<SettingExportDTO> settings = userSettingRepository.findByUserId(userId)
+                .stream()
+                .filter(this::isExportableSetting)
+                .map(this::mapToSettingExport)
+                .collect(Collectors.toList());
+
+        ConfigurationExportDTO export = ConfigurationExportDTO.builder()
+                .version("1.0")
+                .exportedAt(Instant.now())
+                .username(user.getUsername())
+                .shelves(shelves)
+                .magicShelves(magicShelves)
+                .settings(settings)
+                .build();
+
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(export);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize configuration", e);
+            throw ApiError.INTERNAL_SERVER_ERROR.createException("Failed to export configuration");
+        }
+    }
+
+    /**
+     * Import configuration from JSON string
+     */
+    @Transactional
+    public void importConfiguration(String jsonConfig, ImportOptions options) {
+        BookLoreUser user = authenticationService.getAuthenticatedUser();
+        Long userId = user.getId();
+
+        try {
+            ConfigurationExportDTO importData = objectMapper.readValue(jsonConfig, ConfigurationExportDTO.class);
+
+            // Validate version
+            if (!importData.getVersion().equals("1.0")) {
+                throw ApiError.INVALID_INPUT.createException("Unsupported configuration version: " + importData.getVersion());
+            }
+
+            // Import based on options
+            if (options.isImportShelves()) {
+                importShelves(importData.getShelves(), userId, options);
+            }
+
+            if (options.isImportMagicShelves()) {
+                importMagicShelves(importData.getMagicShelves(), userId, options);
+            }
+
+            if (options.isImportSettings()) {
+                importSettings(importData.getSettings(), userId, options);
+            }
+
+            log.info("Configuration imported successfully for user: {}", userId);
+
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse configuration JSON", e);
+            throw ApiError.INVALID_INPUT.createException("Invalid configuration format");
+        }
+    }
+
+    private void importShelves(List<ShelfExportDTO> shelves, Long userId, ImportOptions options) {
+        if (shelves == null) return;
+
+        BookLoreUserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(userId));
+
+        for (ShelfExportDTO shelfDto : shelves) {
+            // Check if shelf exists
+            ShelfEntity existing = shelfRepository.findByUserIdAndName(userId, shelfDto.getName()).orElse(null);
+
+            if (existing != null) {
+                if (options.isSkipExisting()) {
+                    continue;
+                }
+                if (options.isOverwrite()) {
+                    // Update existing shelf (don't modify book mappings)
+                    existing.setIcon(shelfDto.getIcon());
+                    if (shelfDto.getIconType() != null) {
+                        existing.setIconType(IconType.valueOf(shelfDto.getIconType()));
+                    }
+                    if (shelfDto.getSort() != null) {
+                        existing.setSort(mapToSort(shelfDto.getSort()));
+                    }
+                    shelfRepository.save(existing);
+                }
+            } else {
+                // Create new shelf
+                ShelfEntity newShelf = ShelfEntity.builder()
+                        .user(userEntity)
+                        .name(shelfDto.getName())
+                        .icon(shelfDto.getIcon())
+                        .iconType(shelfDto.getIconType() != null ? IconType.valueOf(shelfDto.getIconType()) : IconType.PRIME_NG)
+                        .sort(shelfDto.getSort() != null ? mapToSort(shelfDto.getSort()) : null)
+                        .build();
+
+                shelfRepository.save(newShelf);
+            }
+        }
+    }
+
+    private void importMagicShelves(List<MagicShelfExportDTO> magicShelves, Long userId, ImportOptions options) {
+        if (magicShelves == null) return;
+
+        for (MagicShelfExportDTO msDto : magicShelves) {
+            MagicShelfEntity existing = magicShelfRepository.findByUserIdAndName(userId, msDto.getName()).orElse(null);
+
+            if (existing != null) {
+                if (options.isSkipExisting()) {
+                    continue;
+                }
+                if (options.isOverwrite()) {
+                    existing.setIcon(msDto.getIcon());
+                    if (msDto.getIconType() != null) {
+                        existing.setIconType(IconType.valueOf(msDto.getIconType()));
+                    }
+                    existing.setFilterJson(msDto.getFilterJson());
+                    existing.setPublic(msDto.isPublic());
+                    magicShelfRepository.save(existing);
+                }
+            } else {
+                MagicShelfEntity newMs = MagicShelfEntity.builder()
+                        .userId(userId)
+                        .name(msDto.getName())
+                        .icon(msDto.getIcon())
+                        .iconType(msDto.getIconType() != null ? IconType.valueOf(msDto.getIconType()) : IconType.PRIME_NG)
+                        .filterJson(msDto.getFilterJson())
+                        .isPublic(msDto.isPublic())
+                        .build();
+
+                magicShelfRepository.save(newMs);
+            }
+        }
+    }
+
+    private void importSettings(List<SettingExportDTO> settings, Long userId, ImportOptions options) {
+        if (settings == null) return;
+
+        BookLoreUserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(userId));
+
+        for (SettingExportDTO setting : settings) {
+            if (!isImportableSetting(setting.getKey())) {
+                continue;
+            }
+
+            UserSettingEntity existing = userSettingRepository.findByUserIdAndSettingKey(userId, setting.getKey()).orElse(null);
+
+            if (existing != null) {
+                if (options.isOverwrite()) {
+                    existing.setSettingValue(setting.getValue());
+                    userSettingRepository.save(existing);
+                }
+            } else {
+                UserSettingEntity newSetting = UserSettingEntity.builder()
+                        .user(userEntity)
+                        .settingKey(setting.getKey())
+                        .settingValue(setting.getValue())
+                        .build();
+
+                userSettingRepository.save(newSetting);
+            }
+        }
+    }
+
+    // Mapping helper methods
+
+    private ShelfExportDTO mapToShelfExport(ShelfEntity entity) {
+        return ShelfExportDTO.builder()
+                .name(entity.getName())
+                .icon(entity.getIcon())
+                .iconType(entity.getIconType().name())
+                .sort(entity.getSort() != null ? mapToSortDTO(entity.getSort()) : null)
+                .books(entity.getBookEntities() != null ? entity.getBookEntities().stream()
+                        .map(book -> book.getId() + ":" + book.getFileName())
+                        .collect(Collectors.toList()) : List.of())
+                .build();
+    }
+
+    private MagicShelfExportDTO mapToMagicShelfExport(MagicShelfEntity entity) {
+        return MagicShelfExportDTO.builder()
+                .name(entity.getName())
+                .icon(entity.getIcon())
+                .iconType(entity.getIconType().name())
+                .isPublic(entity.isPublic())
+                .filterJson(entity.getFilterJson())
+                .build();
+    }
+
+    private SettingExportDTO mapToSettingExport(UserSettingEntity entity) {
+        return SettingExportDTO.builder()
+                .key(entity.getSettingKey())
+                .value(entity.getSettingValue())
+                .build();
+    }
+
+    private SortDTO mapToSortDTO(Sort sort) {
+        if (sort == null) return null;
+        return SortDTO.builder()
+                .field(sort.getField())
+                .direction(sort.getDirection() != null ? sort.getDirection().name() : null)
+                .build();
+    }
+
+    private Sort mapToSort(SortDTO dto) {
+        if (dto == null) return null;
+        Sort sort = new Sort();
+        sort.setField(dto.getField());
+        if (dto.getDirection() != null) {
+            sort.setDirection(SortDirection.valueOf(dto.getDirection()));
+        }
+        return sort;
+    }
+
+    /**
+     * Settings that should NOT be exported (sensitive, system, etc.)
+     */
+    private boolean isExportableSetting(UserSettingEntity setting) {
+        String key = setting.getSettingKey();
+        // Skip sensitive settings
+        if (key.startsWith("password") || key.startsWith("token") || key.startsWith("secret")) {
+            return false;
+        }
+        // Skip system settings
+        if (key.startsWith("system.") || key.startsWith("internal.")) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isImportableSetting(String key) {
+        return !key.startsWith("system.") && !key.startsWith("internal.");
+    }
+}

--- a/booklore-ui/src/app/features/settings/export-import/export-import.component.ts
+++ b/booklore-ui/src/app/features/settings/export-import/export-import.component.ts
@@ -1,0 +1,215 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { CheckboxModule } from 'primeng/checkbox';
+import { FileSelectEvent, FileUploadModule } from 'primeng/fileupload';
+import { ToastModule } from 'primeng/toast';
+import { ConfigurationExportService, ImportOptions } from '../../../shared/services/configuration-export.service';
+
+@Component({
+  selector: 'app-export-import',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ButtonModule,
+    CheckboxModule,
+    FileUploadModule,
+    ToastModule
+  ],
+  template: `
+    <div class="export-import-section">
+      <p-toast />
+
+      <h3>Export/Import Configuration</h3>
+      <p class="text-sm text-color-secondary mb-4">
+        Export your shelves, magic shelves, and settings as JSON for backup or sharing.
+      </p>
+
+      <!-- Export Section -->
+      <div class="export-section mb-4 p-3 surface-ground border-round">
+        <h4>Export Configuration</h4>
+        <p-button
+          label="Download Configuration"
+          icon="pi pi-download"
+          (onClick)="exportConfiguration()"
+          [loading]="exporting"
+        />
+      </div>
+
+      <!-- Import Section -->
+      <div class="import-section p-3 surface-ground border-round">
+        <h4>Import Configuration</h4>
+        <p-fileUpload
+          mode="basic"
+          accept=".json"
+          [auto]="true"
+          chooseLabel="Select JSON File"
+          (onSelect)="importConfiguration($event)"
+          [disabled]="importing"
+        />
+
+        <div class="import-options-section">
+          <h5>Import Options</h5>
+          <p class="text-sm text-color-secondary mb-3">Choose how to handle existing items and what to import</p>
+
+          <div class="import-row">
+            <p-checkbox
+              binary="true"
+              [(ngModel)]="importOptions.skipExisting"
+              inputId="skip"
+            ></p-checkbox>
+            <label for="skip" class="ml-2">Skip existing items (don't update)</label>
+          </div>
+
+          <div class="import-row">
+            <p-checkbox
+              binary="true"
+              [(ngModel)]="importOptions.overwrite"
+              inputId="overwrite"
+            ></p-checkbox>
+            <label for="overwrite" class="ml-2">Overwrite existing items</label>
+          </div>
+
+          <hr class="my-3" />
+
+          <div class="import-row">
+            <p-checkbox
+              binary="true"
+              [(ngModel)]="importOptions.importShelves"
+              inputId="shelves"
+            ></p-checkbox>
+            <label for="shelves" class="ml-2">Include shelves</label>
+          </div>
+
+          <div class="import-row">
+            <p-checkbox
+              binary="true"
+              [(ngModel)]="importOptions.importMagicShelves"
+              inputId="magic"
+            ></p-checkbox>
+            <label for="magic" class="ml-2">Include smart shelves (auto-generated)</label>
+          </div>
+
+          <div class="import-row">
+            <p-checkbox
+              binary="true"
+              [(ngModel)]="importOptions.importSettings"
+              inputId="settings"
+            ></p-checkbox>
+            <label for="settings" class="ml-2">Include user settings</label>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .export-import-section {
+      padding: 1rem;
+    }
+
+    .import-options-section {
+      margin-top: 1rem;
+    }
+
+    .import-row {
+      display: flex;
+      align-items: center;
+      margin-bottom: 1rem;
+    }
+
+    .import-row label {
+      font-size: 0.95rem;
+      cursor: pointer;
+      user-select: none;
+    }
+  `]
+})
+export class ExportImportComponent {
+  exporting = false;
+  importing = false;
+
+  importOptions: ImportOptions = {
+    skipExisting: true,
+    overwrite: false,
+    importShelves: true,
+    importMagicShelves: true,
+    importSettings: true
+  };
+
+  constructor(
+    private exportService: ConfigurationExportService,
+    private messageService: MessageService
+  ) {}
+
+  exportConfiguration() {
+    this.exporting = true;
+    this.exportService.exportConfiguration().subscribe({
+      next: (blob: Blob) => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `booklore-config-${new Date().toISOString().slice(0, 10)}.json`;
+        a.click();
+        window.URL.revokeObjectURL(url);
+        this.exporting = false;
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Success',
+          detail: 'Configuration exported successfully'
+        });
+      },
+      error: () => {
+        this.exporting = false;
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'Failed to export configuration'
+        });
+      }
+    });
+  }
+
+  importConfiguration(event: FileSelectEvent) {
+    const file = event.files[0];
+    if (!file) return;
+
+    this.importing = true;
+    const reader = new FileReader();
+
+    reader.onload = (e) => {
+      const content = e.target?.result as string;
+      this.exportService.importConfiguration(content, this.importOptions).subscribe({
+        next: () => {
+          this.importing = false;
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Success',
+            detail: 'Configuration imported successfully'
+          });
+        },
+        error: (err) => {
+          this.importing = false;
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Import Failed',
+            detail: err.error?.message || 'Invalid configuration file'
+          });
+        }
+      });
+    };
+
+    reader.onerror = () => {
+      this.importing = false;
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Failed to read file'
+      });
+    };
+
+    reader.readAsText(file);
+  }
+}

--- a/booklore-ui/src/app/features/settings/settings.component.html
+++ b/booklore-ui/src/app/features/settings/settings.component.html
@@ -51,6 +51,9 @@
           <p-tab [value]="SettingsTab.DeviceSettings">
             <i class="pi pi-mobile"></i> Devices
           </p-tab>
+          <p-tab [value]="SettingsTab.ExportImport">
+            <i class="pi pi-download"></i> Export/Import
+          </p-tab>
         </p-tablist>
         <p-tabpanels>
           <p-tabpanel [value]="SettingsTab.ReaderSettings">
@@ -100,6 +103,9 @@
           </p-tabpanel>
           <p-tabpanel [value]="SettingsTab.DeviceSettings">
             <app-device-settings-component></app-device-settings-component>
+          </p-tabpanel>
+          <p-tabpanel [value]="SettingsTab.ExportImport">
+            <app-export-import></app-export-import>
           </p-tabpanel>
         </p-tabpanels>
       </p-tabs>

--- a/booklore-ui/src/app/features/settings/settings.component.ts
+++ b/booklore-ui/src/app/features/settings/settings.component.ts
@@ -17,6 +17,7 @@ import {DeviceSettingsComponent} from './device-settings/device-settings-compone
 import {LibraryMetadataSettingsComponent} from './library-metadata-settings/library-metadata-settings.component';
 import { PageTitleService } from "../../shared/service/page-title.service";
 import {EmailV2Component} from './email-v2/email-v2.component';
+import {ExportImportComponent} from './export-import/export-import.component';
 
 export enum SettingsTab {
   ReaderSettings = 'reader',
@@ -31,6 +32,7 @@ export enum SettingsTab {
   AuthenticationSettings = 'authentication',
   OpdsV2 = 'opds',
   Tasks = 'task',
+  ExportImport = 'export-import',
 }
 
 @Component({
@@ -53,7 +55,8 @@ export enum SettingsTab {
     OpdsSettings,
     LibraryMetadataSettingsComponent,
     TaskManagementComponent,
-    EmailV2Component
+    EmailV2Component,
+    ExportImportComponent
   ],
   templateUrl: './settings.component.html',
   styleUrl: './settings.component.scss'

--- a/booklore-ui/src/app/shared/services/configuration-export.service.ts
+++ b/booklore-ui/src/app/shared/services/configuration-export.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_CONFIG } from '../../core/config/api-config';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfigurationExportService {
+  private apiUrl = `${API_CONFIG.BASE_URL}/api/v1/configuration`;
+
+  constructor(private http: HttpClient) {}
+
+  exportConfiguration(): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}/export`, {
+      responseType: 'blob'
+    });
+  }
+
+  importConfiguration(
+    jsonConfig: string,
+    options: ImportOptions = {}
+  ): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/import`, jsonConfig, {
+      params: {
+        skipExisting: options.skipExisting !== false,
+        overwrite: options.overwrite === true,
+        importShelves: options.importShelves !== false,
+        importMagicShelves: options.importMagicShelves !== false,
+        importSettings: options.importSettings !== false
+      }
+    });
+  }
+
+  getTemplate(): Observable<string> {
+    return this.http.get(`${this.apiUrl}/template`, {
+      responseType: 'text'
+    });
+  }
+}
+
+export interface ImportOptions {
+  skipExisting?: boolean;
+  overwrite?: boolean;
+  importShelves?: boolean;
+  importMagicShelves?: boolean;
+  importSettings?: boolean;
+}

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -41,22 +41,16 @@ services:
 
   ui:
     image: node:22-alpine
-    command: sh -c "cd /angular-app && npm install -g @angular/cli --force && npm install --force && ng serve --host 0.0.0.0"
+    command: sh -c "cd /angular-app && npm install && npm start -- --host 0.0.0.0"
     environment:
       - NODE_ENV=development
+      - BACKEND_URL=http://booklore-backend-1:8080
     stdin_open: true
     tty: true
     restart: unless-stopped
     volumes:
       - './booklore-ui:/angular-app'
-
-        # you can have node_modules in a volume. however, if you enable this, expect trouble in some IDEs, as the deps are not available anymore
-        # - node_modules:/angular-app/node_modules
-
-        # we ignore package-lock otherwise will throw
-        # An unhandled exception occurred: Cannot find module @rollup/rollup-linux-x64-musl. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828).
-        # Please try `npm i` again after removing both package-lock.json and node_modules directory.
-      - '/dev/null:/angular-app/package-lock.json'
+      - node_modules:/angular-app/node_modules
     ports:
       - "${FRONTEND_PORT:-4200}:4200"
 


### PR DESCRIPTION
## Summary
- Export user configuration (shelves, magic shelves, settings) as JSON
- Import configuration with options:
  - Skip existing items or overwrite
  - Selective import (shelves, magic shelves, settings)
- Sensitive settings (passwords, tokens) are filtered from export

## Changes
- **Backend**: New controller, service, DTOs for configuration export/import
- **Frontend**: New UI component in Settings page
- **Docker**: Updated dev.docker-compose.yml (removed /dev/null workaround)

## Testing
- ✅ Export creates valid JSON with all user data
- ✅ Import successfully creates shelves from JSON
- ✅ Sensitive settings excluded from export
- ✅ UI displays all options with clear labels

## Checklist
- [x] Code follows project conventions
- [x] All tests pass
- [x] Changes are documented
- [x] Branch is up-to-date with develop