### PR TITLE
Disable nginx IPv6 listener when disabled on host

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ envsubst '${BOOKLORE_PORT}' < /etc/nginx/nginx.conf > "$TMP_CONF"
 # Move to final location
 mv "$TMP_CONF" /etc/nginx/nginx.conf
 
-# Disable nginx IPv6 listener when disabled on host
+# Disable nginx IPv6 listener when IPv6 is disabled on host
 [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6 2>/dev/null)" = "0" ] || sed -i '/^[[:space:]]*listen \[\:\:\]:6060;$/d' /etc/nginx/nginx.conf
 
 # Start nginx in background


### PR DESCRIPTION
Patch nginx.conf when host has IPv6 disabled so nginx does not fail to start.

# 🚀 Pull Request

## 📝 Description
Proposed fix for #1997, so nginx can start on non dual stack hosts.


## 🛠️ Changes Implemented
Added IPv6 check and nginx.conf patch in start.sh


## 🧪 Testing Strategy
Tested on RHEL and derivates.



## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [ ] Code adheres to project style guidelines and conventions
- [ ] Branch synchronized with latest `develop` branch
- [ ] Automated unit/integration tests added/updated to cover changes
- [ ] All tests pass locally (`./gradlew test` for backend)
- [ ] Manual testing completed in local development environment
- [ ] Flyway migration versioning follows correct sequence _(if database schema modified)_
- [ ] Documentation pull request submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(required for features or enhancements that introduce user-facing or visual changes)_


## 💬 Additional Context _(optional)_
<!-- Provide any supplementary information, implementation considerations, or discussion points for reviewers -->
