### PR TITLE
fix(security): allow unauthenticated access to SVG icons endpoint

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/config/security/SecurityConfig.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/config/security/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
             "/kobo/**",                // Kobo API requests (auth handled in KoboAuthFilter)
             "/api/v1/auth/**",         // Login and token refresh endpoints (must remain public)
             "/api/v1/public-settings", // Public endpoint for checking OIDC or other app settings
-            "/api/v1/setup/**"         // Setup wizard endpoints (must remain accessible before initial setup)
+            "/api/v1/setup/**",         // Setup wizard endpoints (must remain accessible before initial setup)
+            "/api/v1/icons/all/content" // Public endpoint for loading SVG icons used in the UI
     };
 
     private static final String[] COMMON_UNAUTHENTICATED_ENDPOINTS = {


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
<!-- Provide a clear and concise summary of the changes introduced in this pull request -->
<!-- Reference related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->

The UI fails to load without this change, specifically in containerized environments. I discovered this while updating the OIDC PR; debugging revealed browser errors because the login page could not access necessary icons.

This likely went undetected because it only occurs with a fresh database or an unauthenticated session. If a user is already authenticated, the endpoint works as expected, which is why it wasn't caught sooner. If user not authenticated then they don't have access to the icons needed for UI, hence it fails.

## 🛠️ Changes Implemented
<!-- Detail the specific modifications, additions, or removals made in this pull request -->
- 


## 🧪 Testing Strategy
<!-- Describe the testing methodology used to verify the correctness of these changes -->
<!-- Include testing approach, scenarios covered, and edge cases considered -->


## 📸 Visual Changes _(if applicable)_
<!-- Attach screenshots or videos demonstrating UI/UX modifications -->


## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [ ] Code adheres to project style guidelines and conventions
- [ ] Branch synchronized with latest `develop` branch
- [ ] Automated unit/integration tests added/updated to cover changes
- [ ] All tests pass locally (`./gradlew test` for backend)
- [ ] Manual testing completed in local development environment
- [ ] Flyway migration versioning follows correct sequence _(if database schema modified)_
- [ ] Documentation pull request submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(required for features or enhancements that introduce user-facing or visual changes)_


## 💬 Additional Context _(optional)_
<!-- Provide any supplementary information, implementation considerations, or discussion points for reviewers -->
