### PR TITLE
fix(bookdrop): improve pattern extractor date extraction

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/bookdrop/FilenamePatternExtractor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/bookdrop/FilenamePatternExtractor.java
@@ -65,6 +65,7 @@ public class FilenamePatternExtractor {
     private static final Pattern TWO_DIGIT_YEAR_PATTERN = Pattern.compile("\\d{2}");
     private static final Pattern COMPACT_DATE_PATTERN = Pattern.compile("\\d{8}");
     private static final Pattern YEAR_MONTH_PATTERN = Pattern.compile("(\\d{4})([^\\d])(\\d{1,2})");
+    private static final Pattern MONTH_YEAR_PATTERN = Pattern.compile("(\\d{1,2})([^\\d])(\\d{4})");
     private static final Pattern FLEXIBLE_DATE_PATTERN = Pattern.compile("(\\d{1,4})([^\\d])(\\d{1,2})\\2(\\d{1,4})");
 
     @Transactional
@@ -519,6 +520,14 @@ public class FilenamePatternExtractor {
             String monthPart = yearMonthMatcher.group(3);
             String monthFormat = monthPart.length() == 1 ? "M" : "MM";
             return "yyyy" + separator + monthFormat;
+        }
+        
+        Matcher monthYearMatcher = MONTH_YEAR_PATTERN.matcher(trimmed);
+        if (monthYearMatcher.matches()) {
+            String monthPart = monthYearMatcher.group(1);
+            String separator = monthYearMatcher.group(2);
+            String monthFormat = monthPart.length() == 1 ? "M" : "MM";
+            return monthFormat + separator + "yyyy";
         }
         
         Matcher flexibleMatcher = FLEXIBLE_DATE_PATTERN.matcher(trimmed);

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/bookdrop/FilenamePatternExtractorTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/bookdrop/FilenamePatternExtractorTest.java
@@ -538,6 +538,20 @@ class FilenamePatternExtractorTest {
     }
 
     @Test
+    void extractFromFilename_WithPublishedMonthYear_ShouldExtractAndDefaultToFirstDay() {
+        String filename = "The Lost City (05-2012).epub";
+        String pattern = "{Title} ({Published:MM-yyyy})";
+
+        BookMetadata result = extractor.extractFromFilename(filename, pattern);
+
+        assertNotNull(result);
+        assertEquals("The Lost City", result.getTitle());
+        assertEquals(2012, result.getPublishedDate().getYear());
+        assertEquals(5, result.getPublishedDate().getMonthValue());
+        assertEquals(1, result.getPublishedDate().getDayOfMonth());
+    }
+
+    @Test
     void extractFromFilename_PublishedWithoutFormat_AutoDetectsISODate() {
         String filename = "The Lost City (2023-05-15).epub";
         String pattern = "{Title} ({Published})";
@@ -600,6 +614,20 @@ class FilenamePatternExtractorTest {
 
         assertNotNull(result);
         assertEquals("The Lost City", result.getTitle());
+        assertEquals(2012, result.getPublishedDate().getYear());
+        assertEquals(5, result.getPublishedDate().getMonthValue());
+        assertEquals(1, result.getPublishedDate().getDayOfMonth());
+    }
+
+    @Test
+    void extractFromFilename_PublishedWithoutFormat_AutoDetectsMonthYear() {
+        String filename = "Chronicles of Earth (05-2012).epub";
+        String pattern = "{Title} ({Published})";
+
+        BookMetadata result = extractor.extractFromFilename(filename, pattern);
+
+        assertNotNull(result);
+        assertEquals("Chronicles of Earth", result.getTitle());
         assertEquals(2012, result.getPublishedDate().getYear());
         assertEquals(5, result.getPublishedDate().getMonthValue());
         assertEquals(1, result.getPublishedDate().getDayOfMonth());


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Resolves issues with the bookdrop pattern extractor to add support for formats like yyyy-MM and MM-yyyy, defaulting to the first day of the month. Would silently fail to extract the date format otherwise, and these are common format styles for dates in filenames.

Previously this would only support either formats with the full date (Year, Month, and Day) or just the Year.

## 🛠️ Changes Implemented

- Adds extraction logic for dates with just the year and date component
- Adds improved detection logic for yyyy-MM and MM-yyyy style formats. Better auto-detection for these formats if no date format is provided.
- Adds unit tests for these new edge cases


## 🧪 Testing Strategy
Created unit tests for the new edges cases, and did some basic testing in the UI with files matching the desired name pattern.

## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [x] Code adheres to project style guidelines and conventions
- [x] Branch synchronized with latest `develop` branch
- [x] Automated unit/integration tests added/updated to cover changes
- [x] All tests pass locally (`./gradlew test` for backend)
- [x] Manual testing completed in local development environment
- [x] Flyway migration versioning follows correct sequence _(if database schema modified)_
- [x] Documentation pull request submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(required for features or enhancements that introduce user-facing or visual changes)_
