### PR TITLE
fix(metadata): add null handling for MetadataRefreshService and improve default initialization in MetadataRefreshOptions

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/request/MetadataRefreshOptions.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/request/MetadataRefreshOptions.java
@@ -19,9 +19,11 @@ public class MetadataRefreshOptions {
     private boolean mergeCategories;
     private Boolean reviewBeforeApply;
     @NotNull(message = "Field options cannot be null")
-    private FieldOptions fieldOptions;
+    @Builder.Default
+    private FieldOptions fieldOptions = new FieldOptions();
     @NotNull(message = "Enabled fields cannot be null")
-    private EnabledFields enabledFields;
+    @Builder.Default
+    private EnabledFields enabledFields = new EnabledFields();
 
     @Getter
     @Setter

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/MetadataRefreshService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/MetadataRefreshService.java
@@ -394,8 +394,16 @@ public class MetadataRefreshService {
 
     public BookMetadata buildFetchMetadata(Long bookId, MetadataRefreshOptions refreshOptions, Map<MetadataProvider, BookMetadata> metadataMap) {
         BookMetadata metadata = BookMetadata.builder().bookId(bookId).build();
+        
         MetadataRefreshOptions.FieldOptions fieldOptions = refreshOptions.getFieldOptions();
+        if (fieldOptions == null) {
+            fieldOptions = new MetadataRefreshOptions.FieldOptions();
+        }
+
         MetadataRefreshOptions.EnabledFields enabledFields = refreshOptions.getEnabledFields();
+        if (enabledFields == null) {
+            enabledFields = new MetadataRefreshOptions.EnabledFields();
+        }
 
         if (enabledFields.isTitle()) {
             metadata.setTitle(resolveFieldAsString(metadataMap, fieldOptions.getTitle(), BookMetadata::getTitle));

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/MetadataRefreshServiceTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/MetadataRefreshServiceTest.java
@@ -1,0 +1,55 @@
+package com.adityachandel.booklore.service.metadata;
+
+import com.adityachandel.booklore.model.dto.BookMetadata;
+import com.adityachandel.booklore.model.dto.request.MetadataRefreshOptions;
+import com.adityachandel.booklore.model.enums.MetadataProvider;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@ExtendWith(MockitoExtension.class)
+class MetadataRefreshServiceTest {
+
+    @InjectMocks
+    private MetadataRefreshService metadataRefreshService;
+
+    @ParameterizedTest
+    @MethodSource("provideNullCombinations")
+    void buildFetchMetadata_shouldHandleNullOptions(
+            MetadataRefreshOptions.FieldOptions fieldOptions,
+            MetadataRefreshOptions.EnabledFields enabledFields
+    ) {
+        Long bookId = 1L;
+        MetadataRefreshOptions refreshOptions = new MetadataRefreshOptions();
+        refreshOptions.setFieldOptions(fieldOptions);
+        refreshOptions.setEnabledFields(enabledFields);
+        
+        Map<MetadataProvider, BookMetadata> metadataMap = Collections.emptyMap();
+
+        BookMetadata result = assertDoesNotThrow(() ->
+                metadataRefreshService.buildFetchMetadata(bookId, refreshOptions, metadataMap)
+        );
+
+        assertThat(result).isNotNull();
+        assertThat(result.getBookId()).isEqualTo(bookId);
+    }
+
+    private static Stream<Arguments> provideNullCombinations() {
+        return Stream.of(
+                Arguments.of(null, null),
+                Arguments.of(new MetadataRefreshOptions.FieldOptions(), null),
+                Arguments.of(null, new MetadataRefreshOptions.EnabledFields()),
+                Arguments.of(new MetadataRefreshOptions.FieldOptions(), new MetadataRefreshOptions.EnabledFields())
+        );
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
<!-- Provide a clear and concise summary of the changes introduced in this pull request -->
<!-- Reference related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
Closes: #1519



This pull request improves the handling of potentially null fields in `MetadataRefreshOptions` and adds comprehensive tests to ensure robustness. The main focus is on ensuring that `fieldOptions` and `enabledFields` are always initialized, preventing possible `NullPointerException`s during metadata refresh operations.


## 🛠️ Changes Implemented
<!-- Detail the specific modifications, additions, or removals made in this pull request -->
**Null safety and initialization improvements:**

* Updated `MetadataRefreshOptions` to set default values for `fieldOptions` and `enabledFields` using Lombok's `@Builder.Default`, ensuring these fields are never null when an instance is created.
* Modified `MetadataRefreshService.buildFetchMetadata` to defensively initialize `fieldOptions` and `enabledFields` if they are null, further safeguarding against null-related errors during runtime.

**Testing enhancements:**

* Added a new parameterized test in `MetadataRefreshServiceTest` to verify that `buildFetchMetadata` correctly handles all null and non-null combinations of `fieldOptions` and `enabledFields`, ensuring robust behavior and preventing regressions.



## 🧪 Testing Strategy
<!-- Describe the testing methodology used to verify the correctness of these changes -->
<!-- Include testing approach, scenarios covered, and edge cases considered -->


## 📸 Visual Changes _(if applicable)_
<!-- Attach screenshots or videos demonstrating UI/UX modifications -->


## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [X] Code adheres to project style guidelines and conventions
- [X] Branch synchronized with latest `develop` branch
- [X] Automated unit/integration tests added/updated to cover changes
- [X] All tests pass locally (`./gradlew test` for backend)
- [X] Manual testing completed in local development environment
- [X] Flyway migration versioning follows correct sequence _(if database schema modified)_
- [ ] Documentation pull request submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(required for features or enhancements that introduce user-facing or visual changes)_


## 💬 Additional Context _(optional)_
<!-- Provide any supplementary information, implementation considerations, or discussion points for reviewers -->
