### PR TITLE
feat: Add support for folder as series

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/util/PathPatternResolver.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/util/PathPatternResolver.java
@@ -238,7 +238,7 @@ public class PathPatternResolver {
         return result.toString();
     }
 
-    private String truncatePathComponent(String component, int maxBytes) {
+    public String truncatePathComponent(String component, int maxBytes) {
         if (component == null || component.isEmpty()) {
             return component;
         }
@@ -288,7 +288,7 @@ public class PathPatternResolver {
         return result.toString();
     }
 
-    private String truncateFilenameWithExtension(String filename) {
+    public String truncateFilenameWithExtension(String filename) {
         int lastDotIndex = filename.lastIndexOf('.');
         if (lastDotIndex == -1 || lastDotIndex == 0) {
             // No extension or dot is at start (hidden file), treat as normal component

--- a/booklore-ui/src/app/features/book/service/library-shelf-menu.service.ts
+++ b/booklore-ui/src/app/features/book/service/library-shelf-menu.service.ts
@@ -190,7 +190,7 @@ export class LibraryShelfMenuService {
 
     return [
       {
-        label: (isPublicShelf ? 'Public Shelf - ' : '') + (disableOptions ? 'Read only' : 'Options'),
+        label: 'Options',
         items: [
           {
             label: 'Edit Magic Shelf',

--- a/booklore-ui/src/app/features/settings/file-naming-pattern/file-naming-pattern.component.ts
+++ b/booklore-ui/src/app/features/settings/file-naming-pattern/file-naming-pattern.component.ts
@@ -95,7 +95,7 @@ export class FileNamingPatternComponent implements OnInit {
   }
 
   validatePattern(pattern: string): boolean {
-    const validPatternRegex = /^[\w\s\-{}\[\]\/().<>.,:'"]*$/;
+    const validPatternRegex = /^[\w\s\-{}\[\]\/().<>.,:'"#]*$/;
     return validPatternRegex.test(pattern);
   }
 


### PR DESCRIPTION
## Description
Adds support for using folders as the series for any books in its path. The primary use-case, for me at least, is to separate multiple comic series of the same name despite being published in different years.

Fixes #1461 

**Edit**: It appears that restarting the application resets the book series to whatever it has in its metadata at the moment

## Changes
- **Backend**: Adds a new library processor based off the existing file as book processor
- **Frontend**: Adds a new option for the library type dropdown

## Testing
Haven't tested extensively, nor have I written any tests. I did try using it with my own comic library following the naming convention recommended by Kavita.

## Visual Changes
<img width="1018" height="403" alt="image" src="https://github.com/user-attachments/assets/87865c18-752d-42e7-baed-2bce78612763" />

## Checklist
- [x] Code adheres to project style guidelines and conventions
- [x] Branch synchronized with latest `develop` branch
- [ ] Automated unit/integration tests added/updated to cover changes
- [ ] All tests pass locally (`./gradlew test` for backend)
- [ ] Manual testing completed in local development environment
- [ ] Documentation pull request submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(required for features or enhancements that introduce user-facing or visual changes)_
