### PR TITLE
fix: Bookdrop responsive UI

### DIFF
--- a/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
+++ b/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
@@ -2,13 +2,12 @@
   <form [formGroup]="metadataForm" class="metapicker flex flex-col w-full">
     <div class="flex-grow overflow-auto">
       <div class="metaheader relative flex items-center">
-        <label class="md:w-[8rem]"></label>
+        <label class="md:w-[8rem] text-sm"></label>
         <div class="flex w-full items-center">
-          <p class="w-1/2 pr-3" style="text-align:right">File Metadata</p>
+          <p class="w-1/2">File Data</p>
           <div class="midbuttons">
             <p-button
               size="small"
-              severity="success"
               icon="pi pi-angle-left"
               class="mx-2"
               [outlined]="true"
@@ -18,7 +17,6 @@
             ></p-button>
             <p-button
               size="small"
-              severity="success"
               icon="pi pi-angle-double-left"
               class="mx-2"
               [outlined]="true"
@@ -26,89 +24,163 @@
               tooltipPosition="bottom"
               (onClick)="copyAll()"
             ></p-button>
+            <p-button
+              size="small"
+              severity="warn"
+              icon="pi pi-refresh"
+              class="mx-2"
+              [outlined]="true"
+              pTooltip="Reset all fields to original values"
+              tooltipPosition="bottom"
+              (onClick)="confirmReset()"
+            ></p-button>
           </div>
-          <p class="w-1/2 pl-3">Fetched</p>
-        </div>
-        <div class="ml-auto absolute" style="right:1rem">
-          <p-button
-            size="small"
-            severity="warn"
-            icon="pi pi-refresh"
-            [outlined]="true"
-            pTooltip="Reset all fields to original values"
-            tooltipPosition="left"
-            (onClick)="confirmReset()"
-          ></p-button>
+          <p class="w-1/2">Fetched Data</p>
         </div>
       </div>
       <div class="metacontent">
-        <div class="meta-row flex items-center">
-          <label class="md:w-[8rem] text-sm">Cover</label>
+        <div class="meta-row field-thumbnail">
+          <label class="md:w-[8rem] text-sm"></label>
           <div class="flex w-full items-center justify-center">
-            <p-image class="thumbnail" [src]="metadataForm.get('thumbnailUrl')?.value" alt="Image" appendTo="body" lazyLoad [preview]="true"></p-image>
-            <input type="hidden" id="thumbnailUrl" formControlName="thumbnailUrl" class="md:!w-1/2"/>
+            <div class="flex w-1/2">
+              @if (metadataForm.get('thumbnailUrl')?.value) {
+                <p-image
+                  class="thumbnail"
+                  [src]="metadataForm.get('thumbnailUrl')?.value"
+                  alt="Image"
+                  appendTo="body"
+                  lazyLoad
+                  [preview]="true"
+                  [ngClass]="{
+                    'changed': isValueCopied('thumbnailUrl'),
+                  }"
+                ></p-image>
+              }
+              @else {
+                <div class="thumbnail text-sm">No cover image</div>
+              }
+              <input type="hidden" id="thumbnailUrl" formControlName="thumbnailUrl"/>
+            </div>
             <p-button
               size="small"
-              [icon]="isValueSaved('thumbnailUrl') ? 'pi pi-check' : (hoveredFields['thumbnailUrl'] && isValueCopied('thumbnailUrl') ? 'pi pi-times' : 'pi pi-arrow-left')"
+              [icon]="isValueSaved('thumbnailUrl') ? 'pi pi-check' : (isValueCopied('thumbnailUrl') ? 'pi pi-refresh' : 'pi pi-angle-left')"
               [outlined]="true"
-              [ngClass]="
-              {
-                'green-outlined-button': isValueCopied('thumbnailUrl') && !hoveredFields['thumbnailUrl'],
-                'red-outlined-button': isValueCopied('thumbnailUrl') && hoveredFields['thumbnailUrl']
-              }"
               class="arrow-button"
-              (click)="hoveredFields['thumbnailUrl'] && isValueCopied('thumbnailUrl') ? resetField('thumbnailUrl') : copyFetchedToCurrent('thumbnailUrl')"
-              (mouseenter)="onMouseEnter('thumbnailUrl')"
-              (mouseleave)="onMouseLeave('thumbnailUrl')"/>
-            <input type="hidden" [value]="fetchedMetadata.thumbnailUrl" class="md:!w-1/2" readonly/>
-            <p-image class="thumbnail" [src]="fetchedMetadata.thumbnailUrl!" alt="Image" appendTo="body" lazyLoad [preview]="true"></p-image>
+              [severity]="isValueCopied('thumbnailUrl') ? 'warn' : null"
+              [disabled]="!isFetchedDifferent('thumbnailUrl') && !isValueCopied('thumbnailUrl')"
+              (click)="isValueCopied('thumbnailUrl') ? resetField('thumbnailUrl') : copyFetchedToCurrent('thumbnailUrl')"
+            />
+            <div class="flex w-1/2">
+              @if (fetchedMetadata.thumbnailUrl) {
+                <p-image
+                class="thumbnail"
+                [src]="fetchedMetadata.thumbnailUrl!"
+                alt="Image"
+                appendTo="body"
+                lazyLoad
+                [preview]="true"
+                ></p-image>
+              }
+              @else {
+                <div class="thumbnail text-sm">Cover image not found</div>
+              }
+              <input type="hidden" [value]="fetchedMetadata.thumbnailUrl" readonly/>
+            </div>
           </div>
         </div>
         @for (field of metadataFieldsTop; track field) {
-          <div class="meta-row flex items-center field-{{field.controlName}}">
+          <div class="meta-row field-{{field.controlName}}">
             <label for="{{field.controlName}}" class="md:w-[8rem] text-sm">{{ field.label }}</label>
-            <div class="meta-fields flex w-full">
+            <div class="meta-fields">
               <input
                 pSize="small"
                 fluid
                 pInputText
                 id="{{field.controlName}}"
                 formControlName="{{field.controlName}}"
-                class="dest md:!w-1/2"
+                class="dest"
                 [ngClass]="{
-                  'outlined-input-green': isValueCopied(field.controlName) && !hoveredFields[field.controlName],
+                  'changed': isValueChanged(field.controlName),
                 }"
               />
               <p-button
                 size="small"
-                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (hoveredFields[field.controlName] && isValueCopied(field.controlName) ? 'pi pi-times' : 'pi pi-arrow-left')"
+                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
                 [outlined]="true"
-                [ngClass]="
-                {
-                  'green-outlined-button': isValueCopied(field.controlName) && !hoveredFields[field.controlName],
-                  'red-outlined-button': isValueCopied(field.controlName) && hoveredFields[field.controlName],
-                  'notneeded' : !fetchedMetadata[field.fetchedKey]
+                [ngClass]="{
+                  'nosrc' : !fetchedMetadata[field.fetchedKey]
                 }"
                 class="arrow-button"
-                (click)="hoveredFields[field.controlName] && isValueCopied(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
-                (mouseenter)="onMouseEnter(field.controlName)"
-                (mouseleave)="onMouseLeave(field.controlName)"/>
-              <input 
-                pSize="small"
-                pInputText
-                [value]="fetchedMetadata[field.fetchedKey] ?? null"
-                class="src md:!w-1/2"
-                disabled
+                [severity]="isValueChanged(field.controlName) ? 'warn' : null"
+                [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
+                (click)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+              />
+              @if (fetchedMetadata[field.fetchedKey]) {
+                <input 
+                  pSize="small"
+                  pInputText
+                  [value]="fetchedMetadata[field.fetchedKey] ?? null"
+                  class="src"
+                  disabled
+                  [ngClass]="{
+                    'diff': isFetchedDifferent(field.controlName),
+                  }"
+                />
+              }
+            </div>
+          </div>
+        }
+        @for (field of metadataPublishDate; track field) {
+          <div class="meta-row field-{{field.controlName}}">
+            <label for="{{field.controlName}}" class="md:w-[8rem] text-sm">{{ field.label }}</label>
+            <div class="meta-fields">
+              <p-datepicker
+                size="small"
+                fluid
+                inputId="{{field.controlName}}"
+                formControlName="{{field.controlName}}"
+                dataType="string"
+                dateFormat="yy-mm-dd"
+                [keepInvalid]="true"
+                [showIcon]="true"
+                [iconDisplay]="'input'"
+                appendTo="body"
+                class="dest"
                 [ngClass]="{
-                  'notneeded': !fetchedMetadata[field.fetchedKey],
-                }"/>
+                  'changed': isValueChanged(field.controlName),
+                }">
+              </p-datepicker>
+              <p-button
+                size="small"
+                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
+                [outlined]="true"
+                [ngClass]="{
+                  'nosrc' : !fetchedMetadata[field.fetchedKey]
+                }"
+                class="arrow-button"
+                [severity]="isValueChanged(field.controlName) ? 'warn' : null"
+                [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
+                (click)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+              />
+              @if (fetchedMetadata[field.fetchedKey]) {
+                <input 
+                  pSize="small"
+                  pInputText
+                  [value]="fetchedMetadata[field.fetchedKey] ?? null"
+                  class="src"
+                  disabled
+                  [ngClass]="{
+                    'diff': isFetchedDifferent(field.controlName),
+                  }"
+                />
+              }
             </div>
           </div>
         }
         @for (field of metadataChips; track field) {
-          <div class="meta-row flex items-center field-{{field.controlName}}">
+          <div class="meta-row field-{{field.controlName}}">
             <label for="{{field.controlName}}" class="md:w-[8rem] text-sm">{{ field.label }}</label>
-            <div class="meta-fields flex w-full items-center">
+            <div class="meta-fields">
               <p-autoComplete
                 size="small"
                 formControlName="{{field.controlName}}"
@@ -117,115 +189,123 @@
                 [dropdown]="false"
                 [forceSelection]="false"
                 class="dest w-full"
-                [ngClass]="{'outlined-input-green': isValueCopied(field.controlName) && !hoveredFields[field.controlName]}"
-                (onBlur)="onAutoCompleteBlur(field.controlName, $event)"/>
+                [ngClass]="{
+                  'changed': isValueChanged(field.controlName),
+                }"
+                (onBlur)="onAutoCompleteBlur(field.controlName, $event)"
+              />
               <p-button
                 size="small"
-                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (hoveredFields[field.controlName] && isValueCopied(field.controlName) ? 'pi pi-times' : 'pi pi-arrow-left')"
+                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
                 [outlined]="true"
-                [ngClass]="
-                {
-                  'green-outlined-button': isValueCopied(field.controlName) && !hoveredFields[field.controlName],
-                  'red-outlined-button': isValueCopied(field.controlName) && hoveredFields[field.controlName],
-                  'notneeded' : !fetchedMetadata[field.fetchedKey]
+                [ngClass]="{
+                  'nosrc' : !fetchedMetadata[field.fetchedKey]
                 }"
                 class="arrow-button"
-                (click)="hoveredFields[field.controlName] && isValueCopied(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
-                (mouseenter)="onMouseEnter(field.controlName)"
-                (mouseleave)="onMouseLeave(field.controlName)"/>
-              <p-autoComplete
-                size="small"
-                [ngModel]="fetchedMetadata[field.fetchedKey] ?? []"
-                [ngModelOptions]="{standalone:true}"
-                [disabled]="true"
-                [multiple]="true"
-                [typeahead]="false"
-                [dropdown]="false"
-                [forceSelection]="false"
-                class="src w-full"
-                [ngClass]="{
-                  'notneeded': !fetchedMetadata[field.fetchedKey],
-                }"/>
+                [severity]="isValueChanged(field.controlName) ? 'warn' : null"
+                [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
+                (click)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+              />
+              @if (fetchedMetadata[field.fetchedKey]) {
+                <p-autoComplete
+                  size="small"
+                  [ngModel]="fetchedMetadata[field.fetchedKey] ?? []"
+                  [ngModelOptions]="{standalone:true}"
+                  [disabled]="true"
+                  [multiple]="true"
+                  [typeahead]="false"
+                  [dropdown]="false"
+                  [forceSelection]="false"
+                  class="src w-full"
+                  [ngClass]="{
+                    'diff': isFetchedDifferent(field.controlName),
+                  }"
+                />
+              }
             </div>
           </div>
         }
         @for (field of metadataDescription; track field) {
-          <div class="meta-row flex items-center field-{{field.controlName}}">
+          <div class="meta-row field-{{field.controlName}}">
             <label for="{{field.controlName}}" class="md:w-[8rem] text-sm">{{ field.label }}</label>
-            <div class="meta-fields flex w-full items-center">
+            <div class="meta-fields">
               <textarea
+                pTextarea
                 rows="4"
                 pSize="small"
-                pTextarea
                 id="{{field.controlName}}"
                 formControlName="{{field.controlName}}"
-                class="dest md:!w-1/2"
-                [ngClass]="{'outlined-input-green': isValueCopied(field.controlName) && !hoveredFields[field.controlName]}"
+                class="dest"
+                [ngClass]="{
+                  'changed': isValueChanged(field.controlName),
+                }"
               ></textarea>
               <p-button
                 size="small"
-                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (hoveredFields[field.controlName] && isValueCopied(field.controlName) ? 'pi pi-times' : 'pi pi-arrow-left')"
+                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
                 [outlined]="true"
-                [ngClass]="
-                {
-                  'green-outlined-button': isValueCopied(field.controlName) && !hoveredFields[field.controlName],
-                  'red-outlined-button': isValueCopied(field.controlName) && hoveredFields[field.controlName],
-                  'notneeded' : !fetchedMetadata[field.fetchedKey]
+                [ngClass]="{
+                  'nosrc' : !fetchedMetadata[field.fetchedKey]
                 }"
                 class="arrow-button"
-                (click)="hoveredFields[field.controlName] && isValueCopied(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
-                (mouseenter)="onMouseEnter(field.controlName)"
-                (mouseleave)="onMouseLeave(field.controlName)"/>
-              <textarea
-                rows="4"
-                pSize="small"
-                pInputText
-                [value]="fetchedMetadata[field.fetchedKey] ?? null"
-                class="src md:!w-1/2"
-                disabled
-                [ngClass]="{
-                  'notneeded': !fetchedMetadata[field.fetchedKey],
-                }"></textarea>
+                [severity]="isValueChanged(field.controlName) ? 'warn' : null"
+                [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
+                (click)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+              />
+              @if (fetchedMetadata[field.fetchedKey]) {
+                <textarea
+                  pTextarea
+                  rows="4"
+                  pSize="small"
+                  [value]="fetchedMetadata[field.fetchedKey] ?? null"
+                  class="src"
+                  disabled
+                  [ngClass]="{
+                    'diff': isFetchedDifferent(field.controlName),
+                  }"
+                ></textarea>
+              }
             </div>
           </div>
         }
         @for (field of metadataFieldsBottom; track field) {
-          <div class="meta-row flex items-cente field-{{field.controlName}}">
+          <div class="meta-row field-{{field.controlName}}">
             <label for="{{field.controlName}}" class="md:w-[8rem] text-sm">{{ field.label }}</label>
-            <div class="meta-fields flex w-full">
+            <div class="meta-fields">
               <input
                 pInputText
                 pSize="small"
                 id="{{field.controlName}}"
                 formControlName="{{field.controlName}}"
-                class="dest md:!w-1/2"
+                class="dest"
                 [ngClass]="{
-                  'outlined-input-green': isValueCopied(field.controlName) && !hoveredFields[field.controlName],
+                  'changed': isValueChanged(field.controlName),
                 }"
               />
               <p-button
                 size="small"
-                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (hoveredFields[field.controlName] && isValueCopied(field.controlName) ? 'pi pi-times' : 'pi pi-arrow-left')"
+                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
                 [outlined]="true"
-                [ngClass]="
-                {
-                  'green-outlined-button': isValueCopied(field.controlName) && !hoveredFields[field.controlName],
-                  'red-outlined-button': isValueCopied(field.controlName) && hoveredFields[field.controlName],
-                  'notneeded' : !fetchedMetadata[field.fetchedKey]
+                [ngClass]="{
+                  'nosrc' : !fetchedMetadata[field.fetchedKey]
                 }"
                 class="arrow-button"
-                (click)="hoveredFields[field.controlName] && isValueCopied(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
-                (mouseenter)="onMouseEnter(field.controlName)"
-                (mouseleave)="onMouseLeave(field.controlName)"/>
-              <input
-                pInputText
-                pSize="small"
-                [value]="fetchedMetadata[field.fetchedKey] ?? null"
-                class="src md:!w-1/2"
-                disabled
-                [ngClass]="{
-                  'notneeded': !fetchedMetadata[field.fetchedKey],
-                }"/>
+                [severity]="isValueChanged(field.controlName) ? 'warn' : null"
+                [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
+                (click)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+              />
+              @if (fetchedMetadata[field.fetchedKey]) {
+                <input
+                  pInputText
+                  pSize="small"
+                  [value]="fetchedMetadata[field.fetchedKey] ?? null"
+                  class="src"
+                  disabled
+                  [ngClass]="{
+                    'diff': isFetchedDifferent(field.controlName),
+                  }"
+                />
+              }
             </div>
           </div>
         }
@@ -236,7 +316,7 @@
   <form [formGroup]="metadataForm" class="metaeditor flex w-full">
     <div class="flex-grow overflow-auto">
       <div class="metaheader relative flex items-center">
-        <p class="text-sm flex items-center" style="gap: 0.5rem">
+        <p class="text-sm missingmd">
           Unable to fetch metadata for this file
         </p>
         <p-button
@@ -249,9 +329,9 @@
           (onClick)="confirmReset()"
         ></p-button>
       </div>
-      <div class="flex flex-col p-4 md:flex-row">
+      <div class="metabody flex flex-col p-4 md:flex-row">
         <div class="flex items-start justify-center md:w-[20%] md:h-full">
-          <div class="w-full md:h-full">
+          <div class="w-full md:h-full field-thumbnail">
             <img 
               [src]="metadataForm.get('thumbnailUrl')?.value"
               alt="Book Thumbnail"
@@ -260,10 +340,9 @@
             <input type="hidden" id="thumbnailUrl" formControlName="thumbnailUrl"/>
           </div>
         </div>
-
         <div class="metacontent md:w-[80%]">
           @for (field of metadataFieldsTop; track field) {
-            <div class="meta-row flex items-center">
+            <div class="meta-row field-{{field.controlName}}">
               <label for="{{field.controlName}}" class="w-[8rem] text-sm">{{ field.label }}</label>
               <div class="flex w-full">
                 <input
@@ -272,39 +351,136 @@
                   pInputText
                   id="{{field.controlName}}"
                   formControlName="{{field.controlName}}"
+                  [ngClass]="{
+                    'changed': isValueChanged(field.controlName),
+                  }"
+                />
+                <p-button
+                  size="small"
+                  icon="pi pi-refresh"
+                  [outlined]="true"
+                  class="arrow-button"
+                  severity="warn"
+                  [disabled]="!isValueChanged(field.controlName)"
+                  (click)="resetField(field.controlName)"
+                />
+              </div>
+            </div>
+          }
+
+          @for (field of metadataPublishDate; track field) {
+            <div class="meta-row field-{{field.controlName}}">
+              <label for="{{field.controlName}}" class="w-[8rem] text-sm">{{ field.label }}</label>
+              <div class="flex w-full">
+                <p-datepicker
+                  size="small"
+                  fluid
+                  inputId="{{field.controlName}}"
+                  formControlName="{{field.controlName}}"
+                  dataType="string"
+                  dateFormat="yy-mm-dd"
+                  [keepInvalid]="true"
+                  [showIcon]="true"
+                  [iconDisplay]="'input'"
+                  appendTo="body"
+                  class="w-full"
+                  [ngClass]="{
+                    'changed': isValueChanged(field.controlName),
+                  }">
+                </p-datepicker>
+                <p-button
+                  size="small"
+                  icon="pi pi-refresh"
+                  [outlined]="true"
+                  class="arrow-button"
+                  severity="warn"
+                  [disabled]="!isValueChanged(field.controlName)"
+                  (click)="resetField(field.controlName)"
                 />
               </div>
             </div>
           }
 
           @for (field of metadataChips; track field) {
-            <div class="meta-row flex items-center">
+            <div class="meta-row field-{{field.controlName}}">
               <label for="{{field.controlName}}" class="w-[8rem] text-sm">{{ field.label }}</label>
               <div class="flex w-full">
-                <p-autoComplete formControlName="{{field.controlName}}" [multiple]="true" [typeahead]="false" [dropdown]="false" [forceSelection]="false" class="w-full" (onBlur)="onAutoCompleteBlur(field.controlName, $event)"></p-autoComplete>
+                <p-autoComplete
+                  size="small"
+                  formControlName="{{field.controlName}}"
+                  [multiple]="true"
+                  [typeahead]="false"
+                  [dropdown]="false"
+                  [forceSelection]="false"
+                  class="w-full"
+                  [ngClass]="{
+                    'changed': isValueChanged(field.controlName),
+                  }"
+                  (onBlur)="onAutoCompleteBlur(field.controlName, $event)"
+                />
+                <p-button
+                  size="small"
+                  icon="pi pi-refresh"
+                  [outlined]="true"
+                  class="arrow-button"
+                  severity="warn"
+                  [disabled]="!isValueChanged(field.controlName)"
+                  (click)="resetField(field.controlName)"
+                />
               </div>
             </div>
           }
 
           @for (field of metadataDescription; track field) {
-            <div class="meta-row flex items-center">
+            <div class="meta-row field-{{field.controlName}}">
               <label for="{{field.controlName}}" class="w-[8rem] text-sm">{{ field.label }}</label>
               <div class="flex w-full">
-                <textarea fluid rows="4" pSize="small" pTextarea id="{{field.controlName}}" formControlName="{{field.controlName}}"></textarea>
+                <textarea
+                  pTextarea
+                  fluid
+                  rows="4"
+                  pSize="small"
+                  id="{{field.controlName}}"
+                  formControlName="{{field.controlName}}"
+                  [ngClass]="{
+                    'changed': isValueChanged(field.controlName),
+                  }"
+                ></textarea>
+                <p-button
+                  size="small"
+                  icon="pi pi-refresh"
+                  [outlined]="true"
+                  class="arrow-button"
+                  severity="warn"
+                  [disabled]="!isValueChanged(field.controlName)"
+                  (click)="resetField(field.controlName)"
+                />
               </div>
             </div>
           }
 
           @for (field of metadataFieldsBottom; track field) {
-            <div class="meta-row flex items-center">
+            <div class="meta-row field-{{field.controlName}}">
               <label for="{{field.controlName}}" class="w-[8rem] text-sm">{{ field.label }}</label>
               <div class="flex w-full">
                 <input
+                  pSize="small"
                   fluid
                   pInputText
-                  pSize="small"
                   id="{{field.controlName}}"
                   formControlName="{{field.controlName}}"
+                  [ngClass]="{
+                    'changed': isValueChanged(field.controlName),
+                  }"
+                />
+                <p-button
+                  size="small"
+                  icon="pi pi-refresh"
+                  [outlined]="true"
+                  class="arrow-button"
+                  severity="warn"
+                  [disabled]="!isValueChanged(field.controlName)"
+                  (click)="resetField(field.controlName)"
                 />
               </div>
             </div>

--- a/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.scss
+++ b/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.scss
@@ -1,38 +1,57 @@
 .thumbnail {
-  width: 10rem;
-  height: 14rem;
+  border: 1px solid var(--border-color);
   border-radius: 0.5rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   margin: 0 auto 1rem;
+}
+
+::ng-deep .metapicker .thumbnail {
+  img {
+    border-radius: 0.5rem;
+    max-height: 14rem;
+    max-width: 10em;
+  }
 
   @media (max-width: 768px) {
-    max-width: 50%;
+    margin-bottom: 0;
   }
 }
-.metaeditor .thumbnail {
-  width: 100%;
+
+.metapicker div.thumbnail {
+  background-color: var(--p-inputtext-disabled-background);
+  color: var(--p-inputtext-disabled-color);
+  width: 9rem;
+  height: 14rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+::ng-deep .metaeditor img.thumbnail {
+  border-radius: 0.5rem;
+  max-width: 100%;
+  max-height: 100%;
   height: auto;
+  width: auto;
+  
+  @media (max-width: 768px) {
+    max-height: 14em;
+  }
 }
 
-.arrow-button {
-  padding-left: 1rem;
-  padding-right: 1rem;
+.metaeditor .arrow-button {
+  padding: 0;
 }
 
-.green-outlined-button {
-  --p-button-outlined-primary-border-color: forestgreen;
-  --p-button-outlined-primary-color: forestgreen;
-}
-
-.red-outlined-button {
-  --p-button-outlined-primary-border-color: #E32636;
-  --p-button-outlined-primary-color: #E32636;
-}
-
-input.outlined-input-green,
-textarea.outlined-input-green,
-::ng-deep p-autocomplete.outlined-input-green ul.p-autocomplete-input-multiple {
-  border: 1px solid forestgreen !important;
+.thumbnail.changed,
+input.changed,
+textarea.changed,
+::ng-deep p-datepicker.changed input,
+::ng-deep p-autocomplete.changed ul.p-autocomplete-input-multiple {
+  border: 1px solid var(--p-button-outlined-warn-border-color) !important;
 }
 
 ::ng-deep .p-inputchips {
@@ -52,14 +71,58 @@ textarea.outlined-input-green,
 }
 
 .metapicker label,
-.metaeditor label {
+.metaeditor label,
+.missingmd {
   color: var(--text-color-secondary);
 }
 
+::ng-deep .metapicker {
+  .dest, .src {
+    width: calc(50% - 2rem);
+  }
+
+  .arrow-button {
+    margin: auto 1rem;
+  }
+
+  @media (min-width: 768px) {
+    .arrow-button.nosrc button[disabled] {
+      display: none;
+    }
+  }
+
+  input.diff,
+  textarea.diff,
+  .p-autocomplete.diff .p-chip-label {
+    color: var(--p-primary-color) !important;
+  }
+
+  .src .p-chip.p-disabled {
+    color: var(--p-inputtext-disabled-color) !important;
+    opacity: 1;
+  }
+
+  .src .p-chip-remove-icon {
+    display: none;
+  }
+
+  .src li.p-autocomplete-input-chip {
+    width: 1px;
+  }
+}
+
 .metaheader {
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px dotted var(--border-color);
   padding: 1rem;
   justify-content: space-between;
+
+  p {
+    text-align: center;
+
+    @media (max-width: 768px) {
+      font-size: 0.875rem;
+    }
+  }
 }
 
 .metaheader .midbuttons {
@@ -69,11 +132,41 @@ textarea.outlined-input-green,
 .metacontent {
   padding: 1rem;
 }
+
 .metaeditor .metacontent {
   padding: 0 0 0 1rem;
 
   @media (max-width: 768px) {
     padding: 0;
+  }
+
+  ::ng-deep button {
+    border-left-width: 0;
+    border-radius: 0 6px 6px 0;
+
+    &:disabled {
+      opacity: 1;
+      border-color: var(--p-inputtext-border-color) !important;
+
+      span {
+        opacity: 0.6;
+      }
+    }
+  }
+
+  ::ng-deep input,
+  ::ng-deep ul,
+  textarea {
+    border-radius: 6px 0 0 6px;
+  }
+
+  .field-authors,
+  .field-categories,
+  .field-moods,
+  .field-tags {
+    ::ng-deep button {
+      line-height: 2em;
+    }
   }
 }
 
@@ -91,55 +184,54 @@ textarea.outlined-input-green,
   }
 }
 
+@media (min-width: 768px) {
+  .metaheader,
+  .metapicker .metacontent,
+  .metaeditor .metabody {
+    padding-left: 3.25rem;
+  }
+}
+
 .meta-row {
+  display: flex;
+  align-items: center;
   margin-bottom: 0.5em;
+  
+  label {
+    margin: auto 0;
+  }
+}
+
+.meta-fields {
+  display: flex;
+  align-items: center;
+  width: 100%;
+
+}
+
+.field-description .meta-fields {
+  align-items: stretch;
+
+  .src {
+    resize: none;
+  }
 }
 
 @media (max-width: 768px) {
   .meta-row {
-    margin-bottom: 1em;
-  }
-
-  .metapicker .meta-row {
     flex-wrap: wrap;
-    
+    margin-bottom: 1em;
+
     label {
       width: 100%;
     }
   }
-  
-  .metapicker .meta-fields {
-    justify-content: center;
-
-    .dest {
-      width: 50%;
-      order: 1;
-      margin-right: 0.25rem;
-    }
-
-    p-button {
-      padding: 0;
-      order: 3;
-    }
-
-    ::ng-deep button {
-      border-left-width: 0;
-      border-radius: 0 6px 6px 0;
-    }
-
-    .src {
-      width: 50%;
-      order: 2;
-      border-radius: 6px 0 0 6px;
-      margin-left: 0.25rem;
-
-      ::ng-deep ul {
-        border-radius: 6px 0 0 6px;
-      }
-    }
-  }
 
   .metapicker {
+    .field-thumbnail label {
+      display: none;
+    }
+
     .field-title,
     .field-subtitle,
     .field-publisher,
@@ -156,13 +248,31 @@ textarea.outlined-input-green,
       }
 
       .dest {
-        width: 100% !important;
+        flex: 1 !important;
+        width: auto !important;
         margin: 0 0 2px 0;
+
+        &:not(:only-child) {
+          border-radius: 6px 0 0 6px;
+
+          ::ng-deep ul {
+            border-radius: 6px 0 0 6px;
+          }
+        }
+      }
+
+      .arrow-button {
+        margin: 0;
+        padding: 0;
+      }
+
+      ::ng-deep button {
+        border-left-width: 0;
+        border-radius: 0 6px 6px 0;
       }
 
       .src {
-        flex: 1 !important;
-        width: auto !important;
+        width: 100% !important;
         margin: 0;
       }
     }

--- a/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.html
+++ b/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.html
@@ -155,7 +155,7 @@
         @for (file of bookdropFileUis; track file) {
 
           <div class="file-item">
-            <div class="file-row">
+            <div class="file-row" [ngClass]="file.showDetails ? ' expanded' : ''">
               <p-checkbox
                 [binary]="true"
                 [(ngModel)]="file.selected"

--- a/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.scss
+++ b/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.scss
@@ -8,7 +8,9 @@
   border: 1px solid var(--p-content-border-color);
 
   @media (max-width: 768px) {
-    height: calc(100dvh - 4.9rem);
+    height: calc(100dvh - 4.4rem);
+    border-radius: 0;
+    border-width: 1px 0 0;
   }
 }
 
@@ -157,9 +159,10 @@
 
 .default-controls {
   display: flex;
+  flex-grow: 1;
   gap: 1rem;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
 
   p-select {
     width: 8rem;
@@ -174,7 +177,6 @@
 
     p-select {
       flex-basis: 50%;
-      max-width: 250px;
     }
   }
 }
@@ -271,6 +273,9 @@ p-inputgroup.disabled {
   padding: 1rem;
   flex-wrap: wrap;
 }
+.file-row.expanded {
+  border-bottom-style: dotted;
+}
 
 .status-indicator {
   font-size: 0.75rem;
@@ -331,7 +336,7 @@ div.cover-image {
 .file-library {
   display: flex;
   gap: 1rem;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
 
   @media (max-width: 768px) {
@@ -345,7 +350,6 @@ div.cover-image {
 
   @media (max-width: 768px) {
     flex-basis: 50%;
-    max-width: 250px;
   }
 }
 
@@ -387,10 +391,18 @@ div.cover-image {
 
 .footer-left {
   justify-content: flex-start;
+
+  @media (max-width: 540px) {
+    order: 2;
+  }
 }
 
 .footer-right {
   justify-content: flex-end;
+
+  @media (max-width: 540px) {
+    order: 3;
+  }
 }
 
 .footer-center {
@@ -398,13 +410,24 @@ div.cover-image {
   display: flex;
   justify-content: center;
 
+  .p-paginator {
+    flex-wrap: nowrap;
+    padding: 0;
+  }
+
   @media (max-width: 768px) {
+    ::ng-deep .p-paginator .p-paginator-jtp-dropdown span {
+      font-size: var(--p-select-sm-font-size);
+      padding-block: var(--p-select-sm-padding-y);
+      padding-inline: var(--p-select-sm-padding-x);
+    }
+  }
+  
+  @media (max-width: 540px) {
+    order: 1;
     width: 100%;
   }
-}
 
-.p-paginator {
-  flex-wrap: nowrap;
 }
 
 .spacer {

--- a/booklore-ui/src/assets/layout/styles/layout/_content.scss
+++ b/booklore-ui/src/assets/layout/styles/layout/_content.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   min-height: 100dvh;
   justify-content: space-between;
-  padding: 5rem 1.1rem 2rem 3.6rem;
+  padding: 5rem 1.1rem 1.1rem 3.6rem;
   transition: margin-left variables.$transitionDuration;
   position: fixed;
   width: 100%;

--- a/booklore-ui/src/assets/layout/styles/layout/_menu.scss
+++ b/booklore-ui/src/assets/layout/styles/layout/_menu.scss
@@ -4,11 +4,11 @@
 .layout-sidebar {
   position: fixed;
   width: 225px;
-  height: calc(100dvh - 6rem);
+  height: calc(100dvh - 6.1rem);
   z-index: 999;
   overflow-y: auto;
   user-select: none;
-  top: 4.9rem;
+  top: 5rem;
   left: 1.1rem;
   transition: transform variables.$transitionDuration, left variables.$transitionDuration;
   background-color: var(--card-background);

--- a/booklore-ui/src/assets/layout/styles/layout/_responsive.scss
+++ b/booklore-ui/src/assets/layout/styles/layout/_responsive.scss
@@ -14,7 +14,7 @@
     &.layout-overlay {
       .layout-main-container {
         margin-left: 0;
-        padding: 5rem 1.1rem 2rem 3.6rem;
+        padding: 5rem 1.1rem 1.1rem 3.6rem;
       }
 
       .layout-sidebar {
@@ -47,7 +47,7 @@
 
         .layout-main-container {
           margin-left: 0;
-          padding: 5rem 1rem 2rem 1.5rem;
+          padding: 5rem 1.1rem 1.1rem 1.1rem;
         }
       }
     }
@@ -65,7 +65,7 @@
 
   .layout-wrapper {
     .layout-main-container {
-      padding: 4.4rem 0.5rem 0.5rem 0.5rem;
+      padding-left: 1.1rem;
     }
 
     .layout-sidebar {
@@ -97,6 +97,14 @@
         display: block;
         animation: fadein variables.$transitionDuration;
       }
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .layout-wrapper {
+    .layout-main-container {
+      padding: 4.4rem 0 0;
     }
   }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Further work on the Bookdrop UI to make it work better at different screen sizes

## 🛠️ Changes Implemented

- Fully usable in mobile mode with all desktop options available.
- Quicker scanning: coloured fetched metadata fields that are different from file metadata and removed empty controls for metadata fields that are empty.
- Added date picker for published date fields.
- Fixed button states: removed hover state for mobile compatibility. Button changes to reset symbol when field has been changed. When fetched field is same as file field the copy button is disabled.
- Field outline colour set to same colour as reset buttons when changed for visual/logical consistency.
- Consistent display of fields for books that had no metadata fetched.

## 🧪 Testing Strategy
Manual verification using browser dev tools switcher for desktop / mobile comparison.

## 📸 Visual Changes _(if applicable)_
Desktop:
<img width="453" height="428" alt="bookdrop-desktop" src="https://github.com/user-attachments/assets/7505c27b-2043-4360-b7b5-e989d61925ea" />

Mobile:
<img width="188" height="333" alt="bookdrop-mobile" src="https://github.com/user-attachments/assets/2faf10df-2c86-4bbb-811d-066d7ac395bf" />

## ⚠️ Required Pre-Submission Checklist
- [x] Code adheres to project style guidelines and conventions
- [x] Branch synchronized with latest `develop` branch
- [x] Manual testing completed in local development environment

## 💬 Additional Context _(optional)_
Comparing to the regular book metadata editor, bookdrop is clearly missing the autocomplete suggestions for all the tag fields so you can maintain some consistency in your tagging, authors etc.

However the more I look at this the more I think this is just duplicated effort. I think it would be better if bookdrop just auto-imported any books it detects in its folder onto its own shelf. Then users could edit the books on that shelf using the single user interface that has added benefits such as multiple metadata sources, while requiring only one set of code to maintain. See #2025 