### PR TITLE
Fix: Ignore access denied when doing library scan instead of failing (fixes #1342)

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileHelper.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileHelper.java
@@ -33,7 +33,9 @@ public class LibraryFileHelper {
         boolean supportsSupplementaryFiles = processor.supportsSupplementaryFiles();
 
         try (Stream<Path> stream = Files.walk(libraryPath, FileVisitOption.FOLLOW_LINKS)) {
-            return stream.filter(Files::isRegularFile)
+            return stream
+                    .filter(Files::isReadable)
+                    .filter(Files::isRegularFile)
                     .filter(path -> !FileUtils.shouldIgnore(path))
                     .map(fullPath -> {
                         String fileName = fullPath.getFileName().toString();

--- a/booklore-api/src/main/java/com/adityachandel/booklore/util/FileUtils.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/util/FileUtils.java
@@ -8,8 +8,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
+import com.adityachandel.booklore.model.entity.BookEntity;
 
 @UtilityClass
 @Slf4j
@@ -60,12 +63,19 @@ public class FileUtils {
         }
     }
 
+    private List<String> systemDirs = Arrays.asList(
+      // synology
+      "#recycle",
+      "@eaDir",
+      // calibre
+      ".caltrash"
+    );
     public boolean shouldIgnore(Path path) {
         if (!path.getFileName().toString().isEmpty() && path.getFileName().toString().charAt(0) == '.') {
             return true;
         }
         for (Path part : path) {
-            if (".caltrash".equals(part.toString())) {
+            if (systemDirs.contains(part.toString())) {
                 return true;
             }
         }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description

Fixes #1342

## 🛠️ Changes Implemented

* Update library scan to check Files::isReadable first to make sure we don't get an error trying to read the file
* Also explicitly ignore synology system and trash directories

## 🧪 Testing Strategy

~Honestly eyeballed it, I will be attempting to build my own docker image and deploying it and seeing if it works~
Tried out using docker compose dev image, and everything still scanned successfully though this runs as root, so isn't actually able to test access denied

## 📸 Visual Changes _(if applicable)_

N/A


## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [X] Code adheres to project style guidelines and conventions
- [X] Branch synchronized with latest `develop` branch
- [ ] Automated unit/integration tests added/updated to cover changes
- [X] All tests pass locally (`./gradlew test` for backend)
- [x] Manual testing completed in local development environment
- [ ] Flyway migration versioning follows correct sequence _(if database schema modified)_
- [ ] Documentation pull request submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(required for features or enhancements that introduce user-facing or visual changes)_


## 💬 Additional Context _(optional)_
<!-- Provide any supplementary information, implementation considerations, or discussion points for reviewers -->
