### PR TITLE
fix: Ignore access denied when doing library scan instead of failing (fixes #1342, #2122)

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileHelper.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileHelper.java
@@ -5,19 +5,24 @@ import com.adityachandel.booklore.model.entity.LibraryEntity;
 import com.adityachandel.booklore.model.entity.LibraryPathEntity;
 import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.util.FileUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 @Component
+@Slf4j
 public class LibraryFileHelper {
 
     public List<LibraryFile> getLibraryFiles(LibraryEntity libraryEntity, LibraryFileProcessor processor) throws IOException {
@@ -31,30 +36,50 @@ public class LibraryFileHelper {
     private List<LibraryFile> findLibraryFiles(LibraryPathEntity pathEntity, LibraryEntity libraryEntity, LibraryFileProcessor processor) throws IOException {
         Path libraryPath = Path.of(pathEntity.getPath());
         boolean supportsSupplementaryFiles = processor.supportsSupplementaryFiles();
+        List<LibraryFile> libraryFiles = new ArrayList<>();
 
-        try (Stream<Path> stream = Files.walk(libraryPath, FileVisitOption.FOLLOW_LINKS)) {
-            return stream
-                    .filter(Files::isReadable)
-                    .filter(Files::isRegularFile)
-                    .filter(path -> !FileUtils.shouldIgnore(path))
-                    .map(fullPath -> {
-                        String fileName = fullPath.getFileName().toString();
-                        Optional<BookFileExtension> bookExtension = BookFileExtension.fromFileName(fileName);
+        Files.walkFileTree(libraryPath, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new SimpleFileVisitor<>() {
+            @Override
+            @NonNull
+            public FileVisitResult visitFile(@NonNull Path file, @NonNull BasicFileAttributes attrs) {
+                if (FileUtils.shouldIgnore(file) || !Files.isReadable(file) || !Files.isRegularFile(file)) {
+                    return FileVisitResult.CONTINUE;
+                }
 
-                        if (bookExtension.isEmpty() && !supportsSupplementaryFiles) {
-                            return null;
-                        }
+                String fileName = file.getFileName().toString();
+                Optional<BookFileExtension> bookExtension = BookFileExtension.fromFileName(fileName);
 
-                        return LibraryFile.builder()
-                                .libraryEntity(libraryEntity)
-                                .libraryPathEntity(pathEntity)
-                                .fileSubPath(FileUtils.getRelativeSubPath(pathEntity.getPath(), fullPath))
-                                .fileName(fileName)
-                                .bookFileType(bookExtension.map(BookFileExtension::getType).orElse(null))
-                                .build();
-                    })
-                    .filter(Objects::nonNull)
-                    .toList();
-        }
+                if (bookExtension.isEmpty() && !supportsSupplementaryFiles) {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                libraryFiles.add(LibraryFile.builder()
+                        .libraryEntity(libraryEntity)
+                        .libraryPathEntity(pathEntity)
+                        .fileSubPath(FileUtils.getRelativeSubPath(pathEntity.getPath(), file))
+                        .fileName(fileName)
+                        .bookFileType(bookExtension.map(BookFileExtension::getType).orElse(null))
+                        .build());
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            @NonNull
+            public FileVisitResult visitFileFailed(@NonNull Path file, IOException e) {
+                log.error("Failed read path [{}]: {}", file, e.getMessage(), e);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            @NonNull
+            public FileVisitResult preVisitDirectory(@NonNull Path dir, @NonNull BasicFileAttributes attrs) throws IOException {
+                if (FileUtils.shouldIgnore(dir) || !Files.isReadable(dir)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+
+                return super.preVisitDirectory(dir, attrs);
+            }
+        });
+        return libraryFiles;
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/util/FileUtils.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/util/FileUtils.java
@@ -74,13 +74,14 @@ public class FileUtils {
         return "";
     }
 
-    private List<String> systemDirs = Arrays.asList(
+    final private List<String> systemDirs = Arrays.asList(
       // synology
       "#recycle",
       "@eaDir",
       // calibre
       ".caltrash"
     );
+
     public boolean shouldIgnore(Path path) {
         if (!path.getFileName().toString().isEmpty() && path.getFileName().toString().charAt(0) == '.') {
             return true;

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/library/LibraryFileHelperTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/library/LibraryFileHelperTest.java
@@ -1,0 +1,58 @@
+package com.adityachandel.booklore.service.library;
+
+import com.adityachandel.booklore.model.dto.LibraryPath;
+import com.adityachandel.booklore.model.dto.settings.LibraryFile;
+import com.adityachandel.booklore.model.entity.LibraryEntity;
+import com.adityachandel.booklore.model.entity.LibraryPathEntity;
+import com.adityachandel.booklore.model.enums.LibraryScanMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class LibraryFileHelperTest {
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    private LibraryFileProcessor processor;
+
+    @Test
+    void testGetLibraryFiles_HandlesInaccessibleDirectories() throws IOException {
+        LibraryFileHelper libraryFileHelper = new LibraryFileHelper();
+
+        Files.createFile(tempDir.resolve("happy.epub"));
+        Files.createDirectory(tempDir.resolve("some_other_random_named_dir"), PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("---------")));
+        Files.createFile(tempDir.resolve("zzzz_happ.epub"));
+
+        LibraryPathEntity libraryPath = new LibraryPathEntity();
+        libraryPath.setId(10L);
+        libraryPath.setPath(tempDir.toString());
+
+        LibraryEntity testLibrary = LibraryEntity.builder()
+                .name("Test Library")
+                .icon("book")
+                .scanMode(LibraryScanMode.FILE_AS_BOOK)
+                .watch(false)
+                .libraryPaths(List.of(libraryPath))
+                .build();
+
+        List<LibraryFile> libraryFiles = libraryFileHelper.getLibraryFiles(testLibrary, processor);
+        assertEquals(libraryFiles.stream().map(LibraryFile::getFileName).sorted().toList(), List.of("happy.epub", "zzzz_happ.epub"));
+    }
+}

--- a/booklore-api/src/test/java/com/adityachandel/booklore/util/FileUtilsTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/util/FileUtilsTest.java
@@ -162,6 +162,18 @@ class FileUtilsTest {
     }
 
     @Test
+    void testShouldIgnore_pathWithRecycle_returnsTrue() {
+        Path caltrashPath = tempDir.resolve("#recycle").resolve("file.txt");
+        assertTrue(FileUtils.shouldIgnore(caltrashPath));
+    }
+
+    @Test
+    void testShouldIgnore_pathWithRecycleInSubdirectory_returnsTrue() {
+        Path caltrashPath = tempDir.resolve("subdir").resolve("#recycle").resolve("file.txt");
+        assertTrue(FileUtils.shouldIgnore(caltrashPath));
+    }
+
+    @Test
     void testShouldIgnore_emptyFileName_returnsFalse() {
         Path emptyPath = tempDir.resolve("");
         assertFalse(FileUtils.shouldIgnore(emptyPath));


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description

If library scan encounters a directory or file it can't scan, move on, instead of failing entirely
fixes #1342 and improves fix done in #2122

## 🛠️ Changes Implemented

Switch to simple walk class which gives more control over error conditions
Simple test to confirm its working?

## 🧪 Testing Strategy

1) Updated docker compose to have `user: '1000:1000'` for backend
2) Created directory inside books dir that was set to root not 1000
3) scanned


## 📸 Visual Changes _(if applicable)_
<!-- Attach screenshots or videos demonstrating UI/UX modifications -->


## ⚠️ Required Pre-Submission Checklist
<!-- ⛔ Pull requests will NOT be considered for review unless ALL required items are completed -->
<!-- All items below are MANDATORY prerequisites for submission -->
- [X] Code adheres to project style guidelines and conventions
- [X] Branch synchronized with latest `develop` branch
- [X] Automated unit/integration tests added/updated to cover changes
- [X] All tests pass locally (`./gradlew test` for backend)
- [X] Manual testing completed in local development environment
- [ ] Flyway migration versioning follows correct sequence _(if database schema modified)_
- [ ] Documentation pull request submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(required for features or enhancements that introduce user-facing or visual changes)_


## 💬 Additional Context _(optional)_

First implementation wasn't as fully tested as I'd like sorry
It took time to get java env setup, and I figured it was a straight forward fix (it wasn't)
This one should work now, i've deployed it via `docker.io/halkeye/dev-booklore:pr-2122-5` to test with

Solution was found via https://stackoverflow.com/a/44035822