### PR TITLE
feat(metadata): prefer Kindle for Amazon metadata

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -54,6 +54,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
     private static final Pattern DP_SEPARATOR_PATTERN = Pattern.compile("/dp/");
     private static final Pattern REVIEWED_IN_ON_PATTERN = Pattern.compile("(?i)(?:Reviewed in|Rezension aus|Beoordeeld in|Recensie uit|Commenté en|Recensito in|Revisado en)\\s+(.+?)\\s+(?:on|vom|op|le|il|el)\\s+(.+)");
     private static final Pattern JAPANESE_REVIEW_DATE_PATTERN = Pattern.compile("(\\d{4}年\\d{1,2}月\\d{1,2}日).+");
+    private static final Pattern RATING_PATTERN = Pattern.compile("(\\d[.,]\\d)");
     private static final String[] TITLE_SELECTORS = {"#productTitle", "#ebooksProductTitle", "h1#title", "span#productTitle"};
     private static final String[] DATE_PATTERNS = {
             "MMMM d, yyyy", "d MMMM yyyy", "d. MMMM yyyy", "MMM d, yyyy",
@@ -233,7 +234,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
     private String extractAmazonBookId(Element item) {
         String bookLink = null;
-        for (String type : new String[]{"Paperback", "Hardcover"}) {
+        for (String type : new String[]{"Kindle", "Paperback", "Hardcover"}) {
             Element link = item.select("a:containsOwn(" + type + ")").first();
             if (link != null) {
                 bookLink = link.attr("href");
@@ -606,17 +607,14 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
     private Double getRating(Document doc) {
         try {
-            Element reviewDiv = doc.selectFirst("div#averageCustomerReviews_feature_div");
-            if (reviewDiv != null) {
-                Element ratingSpan = reviewDiv.selectFirst("span#acrPopover span.a-size-base.a-color-base");
-                if (ratingSpan == null) {
-                    ratingSpan = reviewDiv.selectFirst("span#acrPopover span.a-size-small.a-color-base");
-                }
-                if (ratingSpan != null) {
-                    String text = ratingSpan.text().trim();
-                    if (!text.isEmpty()) {
-                        String normalizedText = text.replace(',', '.');
-                        return Double.parseDouble(normalizedText);
+            Element acrPopover = doc.selectFirst("#acrPopover");
+            if (acrPopover != null) {
+                String title = acrPopover.attr("title").trim();
+                if (!title.isEmpty()) {
+                    Matcher matcher = RATING_PATTERN.matcher(title);
+                    if (matcher.find()) {
+                        String ratingStr = matcher.group(1).replace(',', '.');
+                        return Double.parseDouble(ratingStr);
                     }
                 }
             }
@@ -736,15 +734,11 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
     private Integer getReviewCount(Document doc) {
         try {
-            Element reviewDiv = doc.select("div#averageCustomerReviews_feature_div").first();
-            if (reviewDiv != null) {
-                Element reviewCountElement = reviewDiv.getElementById("acrCustomerReviewText");
-                if (reviewCountElement != null) {
-                    String reviewCountRaw = reviewCountElement.text().split(" ")[0];
-                    String reviewCountClean = NON_DIGIT_PATTERN.matcher(reviewCountRaw).replaceAll("");
-                    if (!reviewCountClean.isEmpty()) {
-                        return Integer.parseInt(reviewCountClean);
-                    }
+            Element reviewCountElement = doc.selectFirst("#acrCustomerReviewText");
+            if (reviewCountElement != null) {
+                String reviewCountClean = NON_DIGIT_PATTERN.matcher(reviewCountElement.text()).replaceAll("");
+                if (!reviewCountClean.isEmpty()) {
+                    return Integer.parseInt(reviewCountClean);
                 }
             }
         } catch (Exception e) {

--- a/booklore-api/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -1,0 +1,312 @@
+package org.booklore.service.metadata.parser;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for AmazonBookParser.
+ *
+ * These tests verify:
+ * - Rating extraction from acrPopover title attribute across different locales
+ * - Review count extraction from acrCustomerReviewText
+ * - Format prioritization (Kindle > Paperback > Hardcover)
+ */
+class AmazonBookParserTest {
+
+    private static final Pattern RATING_PATTERN = Pattern.compile("(\\d[.,]\\d)");
+    private static final Pattern NON_DIGIT_PATTERN = Pattern.compile("[^\\d]");
+
+    @Nested
+    @DisplayName("Rating Extraction Tests")
+    class RatingExtractionTests {
+
+        @ParameterizedTest
+        @DisplayName("Should extract rating from various locale formats")
+        @CsvSource({
+            "'4.6 out of 5 stars', 4.6",           // US English
+            "'4.7 out of 5 stars', 4.7",           // US English
+            "'5.0 out of 5 stars', 5.0",           // US English perfect rating
+            "'4,4 von 5 Sternen', 4.4",            // German
+            "'4,8 von 5 Sternen', 4.8",            // German
+            "'5,0 von 5 Sternen', 5.0",            // German perfect rating
+            "'5つ星のうち4.2', 4.2",                // Japanese
+            "'5つ星のうち4.8', 4.8",                // Japanese
+            "'5つ星のうち5.0', 5.0",                // Japanese perfect rating
+            "'4,5 sur 5 étoiles', 4.5",            // French
+            "'4,3 de 5 estrellas', 4.3",           // Spanish
+            "'4.5 out of 5', 4.5",                 // Abbreviated English
+        })
+        void shouldExtractRatingFromTitle(String title, double expectedRating) {
+            Matcher matcher = RATING_PATTERN.matcher(title);
+            assertThat(matcher.find()).isTrue();
+
+            String ratingStr = matcher.group(1).replace(',', '.');
+            double rating = Double.parseDouble(ratingStr);
+
+            assertThat(rating).isEqualTo(expectedRating);
+        }
+
+        @Test
+        @DisplayName("Should not match integer-only values like '5' in title")
+        void shouldNotMatchIntegerOnly() {
+            // The pattern should only match X.X or X,X format, not standalone integers
+            String title = "5 stars";
+            Matcher matcher = RATING_PATTERN.matcher(title);
+            assertThat(matcher.find()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Should extract rating from HTML element")
+        void shouldExtractRatingFromHtmlElement() {
+            String html = """
+                <html><body>
+                    <span id="acrPopover" title="4.6 out of 5 stars"></span>
+                </body></html>
+                """;
+
+            Document doc = Jsoup.parse(html);
+            var acrPopover = doc.selectFirst("#acrPopover");
+
+            assertThat(acrPopover).isNotNull();
+            String title = acrPopover.attr("title");
+
+            Matcher matcher = RATING_PATTERN.matcher(title);
+            assertThat(matcher.find()).isTrue();
+            assertThat(Double.parseDouble(matcher.group(1))).isEqualTo(4.6);
+        }
+
+        @Test
+        @DisplayName("Should extract rating from German HTML element")
+        void shouldExtractRatingFromGermanHtmlElement() {
+            String html = """
+                <html><body>
+                    <span id="acrPopover" title="4,4 von 5 Sternen"></span>
+                </body></html>
+                """;
+
+            Document doc = Jsoup.parse(html);
+            var acrPopover = doc.selectFirst("#acrPopover");
+
+            assertThat(acrPopover).isNotNull();
+            String title = acrPopover.attr("title");
+
+            Matcher matcher = RATING_PATTERN.matcher(title);
+            assertThat(matcher.find()).isTrue();
+            String ratingStr = matcher.group(1).replace(',', '.');
+            assertThat(Double.parseDouble(ratingStr)).isEqualTo(4.4);
+        }
+
+        @Test
+        @DisplayName("Should extract rating from Japanese HTML element")
+        void shouldExtractRatingFromJapaneseHtmlElement() {
+            String html = """
+                <html><body>
+                    <span id="acrPopover" title="5つ星のうち4.2"></span>
+                </body></html>
+                """;
+
+            Document doc = Jsoup.parse(html);
+            var acrPopover = doc.selectFirst("#acrPopover");
+
+            assertThat(acrPopover).isNotNull();
+            String title = acrPopover.attr("title");
+
+            Matcher matcher = RATING_PATTERN.matcher(title);
+            assertThat(matcher.find()).isTrue();
+            assertThat(Double.parseDouble(matcher.group(1))).isEqualTo(4.2);
+        }
+    }
+
+    @Nested
+    @DisplayName("Review Count Extraction Tests")
+    class ReviewCountExtractionTests {
+
+        @ParameterizedTest
+        @DisplayName("Should extract review count from various formats")
+        @CsvSource({
+            "'(19,933)', 19933",                   // US format with comma
+            "'(12,434)', 12434",                   // US format
+            "'(15.847)', 15847",                   // German format with period as thousands separator
+            "'(12,607)', 12607",                   // Japanese format
+            "'(1,234,567)', 1234567",              // Large number
+            "'(42)', 42",                          // Small number
+            "'19,933 ratings', 19933",             // With text
+        })
+        void shouldExtractReviewCount(String text, int expectedCount) {
+            String reviewCountClean = NON_DIGIT_PATTERN.matcher(text).replaceAll("");
+            int count = Integer.parseInt(reviewCountClean);
+
+            assertThat(count).isEqualTo(expectedCount);
+        }
+
+        @Test
+        @DisplayName("Should extract review count from HTML element")
+        void shouldExtractReviewCountFromHtmlElement() {
+            String html = """
+                <html><body>
+                    <span id="acrCustomerReviewText">(19,933)</span>
+                </body></html>
+                """;
+
+            Document doc = Jsoup.parse(html);
+            var reviewCountElement = doc.selectFirst("#acrCustomerReviewText");
+
+            assertThat(reviewCountElement).isNotNull();
+            String reviewCountClean = NON_DIGIT_PATTERN.matcher(reviewCountElement.text()).replaceAll("");
+
+            assertThat(Integer.parseInt(reviewCountClean)).isEqualTo(19933);
+        }
+
+        @Test
+        @DisplayName("Should extract review count from German HTML element")
+        void shouldExtractReviewCountFromGermanHtmlElement() {
+            String html = """
+                <html><body>
+                    <span id="acrCustomerReviewText">(15.847)</span>
+                </body></html>
+                """;
+
+            Document doc = Jsoup.parse(html);
+            var reviewCountElement = doc.selectFirst("#acrCustomerReviewText");
+
+            assertThat(reviewCountElement).isNotNull();
+            String reviewCountClean = NON_DIGIT_PATTERN.matcher(reviewCountElement.text()).replaceAll("");
+
+            assertThat(Integer.parseInt(reviewCountClean)).isEqualTo(15847);
+        }
+    }
+
+    @Nested
+    @DisplayName("Format Link Extraction Tests")
+    class FormatLinkExtractionTests {
+
+        @Test
+        @DisplayName("Should find Kindle link first when present")
+        void shouldFindKindleLinkFirst() {
+            String html = """
+                <html><body>
+                    <div data-asin="FALLBACK123">
+                        <a href="/dp/B00KINDLE1/ref=xyz">Kindle</a>
+                        <a href="/dp/1234567890/ref=xyz">Paperback</a>
+                        <a href="/dp/0987654321/ref=xyz">Hardcover</a>
+                    </div>
+                </body></html>
+                """;
+
+            Document doc = Jsoup.parse(html);
+            var item = doc.selectFirst("div[data-asin]");
+
+            String bookLink = null;
+            for (String type : new String[]{"Kindle", "Paperback", "Hardcover"}) {
+                var link = item.select("a:containsOwn(" + type + ")").first();
+                if (link != null) {
+                    bookLink = link.attr("href");
+                    break;
+                }
+            }
+
+            assertThat(bookLink).contains("B00KINDLE1");
+        }
+
+        @Test
+        @DisplayName("Should fall back to Paperback when Kindle not present")
+        void shouldFallBackToPaperback() {
+            String html = """
+                <html><body>
+                    <div data-asin="FALLBACK123">
+                        <a href="/dp/1234567890/ref=xyz">Paperback</a>
+                        <a href="/dp/0987654321/ref=xyz">Hardcover</a>
+                    </div>
+                </body></html>
+                """;
+
+            Document doc = Jsoup.parse(html);
+            var item = doc.selectFirst("div[data-asin]");
+
+            String bookLink = null;
+            for (String type : new String[]{"Kindle", "Paperback", "Hardcover"}) {
+                var link = item.select("a:containsOwn(" + type + ")").first();
+                if (link != null) {
+                    bookLink = link.attr("href");
+                    break;
+                }
+            }
+
+            assertThat(bookLink).contains("1234567890");
+        }
+
+        @Test
+        @DisplayName("Should fall back to Hardcover when Kindle and Paperback not present")
+        void shouldFallBackToHardcover() {
+            String html = """
+                <html><body>
+                    <div data-asin="FALLBACK123">
+                        <a href="/dp/0987654321/ref=xyz">Hardcover</a>
+                    </div>
+                </body></html>
+                """;
+
+            Document doc = Jsoup.parse(html);
+            var item = doc.selectFirst("div[data-asin]");
+
+            String bookLink = null;
+            for (String type : new String[]{"Kindle", "Paperback", "Hardcover"}) {
+                var link = item.select("a:containsOwn(" + type + ")").first();
+                if (link != null) {
+                    bookLink = link.attr("href");
+                    break;
+                }
+            }
+
+            assertThat(bookLink).contains("0987654321");
+        }
+
+        @Test
+        @DisplayName("Should use data-asin fallback when no format links present")
+        void shouldUseDataAsinFallback() {
+            String html = """
+                <html><body>
+                    <div data-asin="FALLBACK123">
+                        <a href="/dp/something/ref=xyz">Some other link</a>
+                    </div>
+                </body></html>
+                """;
+
+            Document doc = Jsoup.parse(html);
+            var item = doc.selectFirst("div[data-asin]");
+
+            String bookLink = null;
+            for (String type : new String[]{"Kindle", "Paperback", "Hardcover"}) {
+                var link = item.select("a:containsOwn(" + type + ")").first();
+                if (link != null) {
+                    bookLink = link.attr("href");
+                    break;
+                }
+            }
+
+            // When no format link found, should fall back to data-asin
+            String asin = bookLink != null ? extractAsinFromUrl(bookLink) : item.attr("data-asin");
+
+            assertThat(asin).isEqualTo("FALLBACK123");
+        }
+    }
+
+    private String extractAsinFromUrl(String url) {
+        String[] parts = url.split("/dp/");
+        if (parts.length > 1) {
+            String[] asinParts = parts[1].split("/");
+            return asinParts[0];
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## 📝 Description

This change prioritizes the kindle version of a given book when fetching metadata from Amazon over the current paperback/hardback prioritization. Kindle versions, being the only e-book versions on Amazon, usually have more applicable metadata for a given e-book.

**Linked Issue:** Fixes #1284

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement to existing feature
- [ ] Refactor (no behavior change)
- [ ] Breaking change (existing functionality affected)
- [ ] Documentation update

## 🔧 Changes

<!-- List the specific modifications made -->
- Updates Amazon book ID extractor to prefer the Kindle version, if it exists
- Updates Amazon review count and rating extraction logic to also work for Kindle ASINs

## 🧪 Testing (MANDATORY)

**Manual testing steps you performed:**
<!-- Walk through the exact steps you took to verify your change works. Be specific. -->
1. Built the docker image `ghcr.io/lyallcooper/booklore:develop-bff7319f` on my fork
2. Ran it against my existing booklore installation
3. Fetched/updated metadata using the Amazon provider for various books
4. Confirmed that Kindle ASIN was fetched instead of paperback or hardcover ASIN
5. Confirmed that all relevant metadata were fetched as expected, using the Kindle version metadata

**Regression testing:**
<!-- How did you verify that existing related features still work after your change? -->
- Re-fetched metadata for various books in my library, checking to see that all information was fetched correctly

**Edge cases covered:**
<!-- What boundary conditions or unusual inputs did you test? -->
- Books that don't have a Kindle version fall back correctly to paperback/hardcover version with correct data

**Test output:**
<!-- Paste the actual terminal output from running tests. Not "all pass", the real output. -->

<details>
<summary>Backend test output (<code>./gradlew test</code>)</summary>

```
All 2 654 tests pass, 15 skipped in 1m 38s

  349 files  +  145    349 suites  +145   1m 38s ⏱️ + 1m 12s
2 669 tests +1 076  2 654 ✅ +1 065  15 💤 +11  0 ❌ ±0 
2 726 runs  +1 076  2 711 ✅ +1 065  15 💤 +11  0 ❌ ±0 

Results for commit https://github.com/lyallcooper/booklore/commit/bff7319f0611dc1502abcb9e6bb3d980eca3ab30. ± Comparison against earlier commit https://github.com/lyallcooper/booklore/commit/eb2a7537bd0306a7497fedeab232f4d39227229e.
```

</details>

<details>
<summary>Frontend test output (<code>ng test</code>)</summary>

```
 RUN  v4.0.18 /home/runner/work/booklore/booklore/booklore-ui

 ✓  booklore  src/app/features/magic-shelf/service/book-rule-evaluator-metadata-presence.spec.ts (85 tests) 192ms
 ✓  booklore  src/app/features/magic-shelf/service/book-rule-evaluator.service.spec.ts (199 tests) 425ms
 ✓  booklore  src/app/features/magic-shelf/service/magic-shelf-utils.spec.ts (46 tests) 35ms
 ✓  booklore  src/app/features/book/service/library-health.service.spec.ts (6 tests) 63ms
 ✓  booklore  src/app/app.component.spec.ts (7 tests) 330ms
 ✓  booklore  src/app/features/magic-shelf/component/magic-shelf-component.spec.ts (73 tests) 899ms
 ✓  booklore  src/app/core/security/auth-initializer.spec.ts (2 tests) 32ms
 ✓  booklore  src/app/app.spec.ts (1 test) 3ms

 Test Files  8 passed (8)
      Tests  419 passed (419)
   Start at  12:37:55
   Duration  6.04s (transform 1.15s, setup 3.02s, import 4.52s, tests 1.98s, environment 5.74s)

```

</details>

## 📸 Screen Recording / Screenshots (MANDATORY)

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/0a4fccd2-7581-47a2-a304-c9a82248f50e"></video> | <video src="https://github.com/user-attachments/assets/438bb041-e380-4862-9df3-f6732289f1fc"></video> | 

---

## ✅ Pre-Submission Checklist

> **All boxes must be checked before requesting review.** Incomplete PRs will be closed without review. No exceptions.

- [x] This PR is linked to an approved issue
- [x] Code follows project [backend and frontend conventions](../CONTRIBUTING.md#backend-conventions)
- [x] Branch is up to date with `develop` (merge conflicts resolved)
- [x] I ran the full stack locally (backend + frontend + database) and verified the change works
- [x] Automated tests added or updated to cover changes (backend **and** frontend)
- [x] All tests pass locally and output is pasted above
- [x] Screen recording or screenshots are attached above proving the change works
- [x] PR is a single focused change (one bug fix OR one feature, not multiple unrelated changes)
- [x] PR is reasonably scoped (PRs over 1000+ changed lines will be closed, split into smaller PRs)
- [x] No unsolicited refactors, cleanups, or "improvements" are bundled in
- [x] Flyway migration versioning is correct _(if schema was modified)_
- [x] Documentation PR submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(if user-facing changes)_

### 🤖 AI-Assisted Contributions

> **If any part of this PR was generated or assisted by AI tools (Copilot, Claude, ChatGPT, etc.), all items below are mandatory.** You are fully responsible for every line you submit. "The AI wrote it" is not an excuse, and AI-generated PRs that clearly haven't been reviewed are the #1 reason PRs get closed.

- [x] I have read and understand every line of this PR and can explain any part of it during review
- [x] I personally ran the code and verified it works (not just trusted the AI's output)
- [x] PR is scoped to a single logical change, not a dump of everything the AI suggested
- [x] Tests validate actual behavior, not just coverage (AI-generated tests often assert nothing meaningful)
- [x] No dead code, placeholder comments, `TODO`s, or unused scaffolding left behind by AI
- [x] I did not submit refactors, style changes, or "improvements" the AI suggested beyond the scope of the issue