### PR TITLE
fix: handle access denied errors on monitoring - Fixes #1342 again

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileHelper.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileHelper.java
@@ -6,20 +6,17 @@ import com.adityachandel.booklore.model.entity.LibraryPathEntity;
 import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.util.FileUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 @Component
 @Slf4j
@@ -36,50 +33,25 @@ public class LibraryFileHelper {
     private List<LibraryFile> findLibraryFiles(LibraryPathEntity pathEntity, LibraryEntity libraryEntity, LibraryFileProcessor processor) throws IOException {
         Path libraryPath = Path.of(pathEntity.getPath());
         boolean supportsSupplementaryFiles = processor.supportsSupplementaryFiles();
-        List<LibraryFile> libraryFiles = new ArrayList<>();
+        try (Stream<Path> stream = FileUtils.walk(libraryPath, FileVisitOption.FOLLOW_LINKS)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .map(fullPath -> {
+                        String fileName = fullPath.getFileName().toString();
+                        Optional<BookFileExtension> bookExtension = BookFileExtension.fromFileName(fileName);
 
-        Files.walkFileTree(libraryPath, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new SimpleFileVisitor<>() {
-            @Override
-            @NonNull
-            public FileVisitResult visitFile(@NonNull Path file, @NonNull BasicFileAttributes attrs) {
-                if (FileUtils.shouldIgnore(file) || !Files.isReadable(file) || !Files.isRegularFile(file)) {
-                    return FileVisitResult.CONTINUE;
-                }
+                        if (bookExtension.isEmpty() && !supportsSupplementaryFiles) {
+                            return null;
+                        }
 
-                String fileName = file.getFileName().toString();
-                Optional<BookFileExtension> bookExtension = BookFileExtension.fromFileName(fileName);
-
-                if (bookExtension.isEmpty() && !supportsSupplementaryFiles) {
-                    return FileVisitResult.CONTINUE;
-                }
-
-                libraryFiles.add(LibraryFile.builder()
-                        .libraryEntity(libraryEntity)
-                        .libraryPathEntity(pathEntity)
-                        .fileSubPath(FileUtils.getRelativeSubPath(pathEntity.getPath(), file))
-                        .fileName(fileName)
-                        .bookFileType(bookExtension.map(BookFileExtension::getType).orElse(null))
-                        .build());
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            @NonNull
-            public FileVisitResult visitFileFailed(@NonNull Path file, IOException e) {
-                log.error("Failed read path [{}]: {}", file, e.getMessage(), e);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            @NonNull
-            public FileVisitResult preVisitDirectory(@NonNull Path dir, @NonNull BasicFileAttributes attrs) throws IOException {
-                if (FileUtils.shouldIgnore(dir) || !Files.isReadable(dir)) {
-                    return FileVisitResult.SKIP_SUBTREE;
-                }
-
-                return super.preVisitDirectory(dir, attrs);
-            }
-        });
-        return libraryFiles;
+                        return LibraryFile.builder()
+                                .libraryEntity(libraryEntity)
+                                .libraryPathEntity(pathEntity)
+                                .fileSubPath(FileUtils.getRelativeSubPath(pathEntity.getPath(), fullPath))
+                                .fileName(fileName)
+                                .bookFileType(bookExtension.map(BookFileExtension::getType).orElse(null))
+                                .build();
+                    }).filter(Objects::nonNull).toList();
+        }
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/monitoring/MonitoringService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/monitoring/MonitoringService.java
@@ -3,6 +3,7 @@ package com.adityachandel.booklore.service.monitoring;
 import com.adityachandel.booklore.model.dto.Library;
 import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.service.watcher.LibraryFileEventProcessor;
+import com.adityachandel.booklore.util.FileUtils;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
@@ -70,16 +71,14 @@ public class MonitoringService {
 
         library.getPaths().forEach(libraryPath -> {
             Path rootPath = Paths.get(libraryPath.getPath());
-            if (Files.isDirectory(rootPath)) {
-                try (Stream<Path> pathStream = Files.walk(rootPath)) {
-                    pathStream.filter(Files::isDirectory).forEach(path -> {
-                        if (registerPath(path, library.getId())) {
-                            registeredCount[0]++;
-                        }
-                    });
-                } catch (IOException e) {
-                    log.error("Failed to register paths for library '{}': {}", library.getName(), e.getMessage(), e);
-                }
+            try (Stream<Path> pathStream = FileUtils.walk(rootPath)) {
+                pathStream.filter(Files::isDirectory).forEach(path -> {
+                    if (registerPath(path, library.getId())) {
+                        registeredCount[0]++;
+                    }
+                });
+            } catch (IOException e) {
+                log.error("Failed to register paths for library '{}': {}", library.getName(), e.getMessage(), e);
             }
         });
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/util/FileUtils.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/util/FileUtils.java
@@ -8,13 +8,21 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import com.adityachandel.booklore.model.entity.BookEntity;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.jspecify.annotations.NonNull;
 
 @UtilityClass
 @Slf4j
@@ -103,5 +111,45 @@ public class FileUtils {
             }
         }
         return false;
+    }
+
+    public static Stream<Path> walk(Path start, FileVisitOption... options) throws IOException {
+        return walk(start, Integer.MAX_VALUE, options);
+    }
+
+    // Drop in replacement for Files.walk that should handle io errors by ignoring them. Allows for unaccessible directories like trash inside of a library.
+    public Stream<Path> walk(Path path, int maxDepth, FileVisitOption... options) throws IOException {
+        final List<Path> files = new ArrayList<>();
+
+        Files.walkFileTree(path, Set.of(options), maxDepth, new SimpleFileVisitor<>() {
+            @Override
+            @NonNull
+            public FileVisitResult visitFile(@NonNull Path file, @NonNull BasicFileAttributes attrs) {
+                if (FileUtils.shouldIgnore(file) || !Files.isReadable(file)) {
+                    return FileVisitResult.CONTINUE;
+                }
+                files.add(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            @NonNull
+            public FileVisitResult visitFileFailed(@NonNull Path file, IOException e) {
+                log.error("Failed read path [{}]: {}", file, e.getMessage(), e);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            @NonNull
+            public FileVisitResult preVisitDirectory(@NonNull Path dir, @NonNull BasicFileAttributes attrs) throws IOException {
+                if (FileUtils.shouldIgnore(dir) || !Files.isReadable(dir)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                files.add(dir);
+                return super.preVisitDirectory(dir, attrs);
+            }
+        });
+
+        return files.stream();
     }
 }

--- a/booklore-api/src/test/java/com/adityachandel/booklore/util/FileUtilsTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/util/FileUtilsTest.java
@@ -6,9 +6,11 @@ import com.adityachandel.booklore.model.entity.LibraryPathEntity;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -193,5 +195,22 @@ class FileUtilsTest {
         Long size = FileUtils.getFileSizeInKb(file);
         assertNotNull(size, "File size should not be null for existing file");
         assertTrue(size >= 0, "File size should be non-negative");
+    }
+
+    @Test
+    void testWalk_HandlesInaccessibleDirectories() throws IOException {
+        Files.createFile(tempDir.resolve("happy.epub"));
+        Files.createDirectory(tempDir.resolve("some_other_random_named_dir"), PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("---------")));
+        Files.createFile(tempDir.resolve("zzzz_happ.epub"));
+
+        LibraryPathEntity libraryPath = new LibraryPathEntity();
+        libraryPath.setId(10L);
+        libraryPath.setPath(tempDir.toString());
+
+        // expected root directory, and two files, and not the directory that is in-accessible
+        List<String> expectedFiles = List.of("", File.separator + "happy.epub", File.separator + "zzzz_happ.epub");
+        List<String> actualFiles = FileUtils.walk(tempDir).map(path -> path.toString().replace(tempDir.toString(), "")).sorted().toList();
+
+        assertEquals(expectedFiles, actualFiles);
     }
 }


### PR DESCRIPTION
## 🚀 Pull Request

### 📝 Description

Fixes #1342 - Preventing startup on synology based devices mapped to volumes

```
booklore-894b9f6d4-2lv9p booklore Caused by: java.io.UncheckedIOException: java.nio.file.AccessDeniedException: /books/#recycle
booklore-894b9f6d4-2lv9p booklore       at java.base/java.nio.file.FileTreeIterator.fetchNextIfNeeded(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.nio.file.FileTreeIterator.hasNext(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.Iterator.forEachRemaining(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at com.adityachandel.booklore.service.monitoring.MonitoringService.lambda$registerLibrary$3(MonitoringService.java:75) ~[!/:0.0.1-SNAPSHOT]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.ArrayList.forEach(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at com.adityachandel.booklore.service.monitoring.MonitoringService.registerLibrary(MonitoringService.java:71) ~[!/:0.0.1-SNAPSHOT]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at com.adityachandel.booklore.service.monitoring.MonitoringService.registerLibraries(MonitoringService.java:61) ~[!/:0.0.1-SNAPSHOT]
booklore-894b9f6d4-2lv9p booklore       at com.adityachandel.booklore.service.library.LibraryService.initializeMonitoring(LibraryService.java:68) ~[!/:0.0.1-SNAPSHOT]
booklore-894b9f6d4-2lv9p booklore       at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor$LifecycleMethod.invoke(InitDestroyAnnotationBeanPostProcessor.java:457) ~[spring-beans-6.2.14.jar!/:6.2.14]
booklore-894b9f6d4-2lv9p booklore       at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor$LifecycleMetadata.invokeInitMethods(InitDestroyAnnotationBeanPostProcessor.java:401) ~[spring-beans-6.2.14.jar!/:6.2.14]
booklore-894b9f6d4-2lv9p booklore       at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.postProcessBeforeInitialization(InitDestroyAnnotationBeanPostProcessor.java:219) ~[spring-beans-6.2.14.jar!/:6.2.14]
booklore-894b9f6d4-2lv9p booklore       ... 69 common frames omitted
booklore-894b9f6d4-2lv9p booklore Caused by: java.nio.file.AccessDeniedException: /books/#recycle
booklore-894b9f6d4-2lv9p booklore       at java.base/sun.nio.fs.UnixException.translateToIOException(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/sun.nio.fs.UnixException.rethrowAsIOException(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/sun.nio.fs.UnixException.rethrowAsIOException(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.nio.file.Files.newDirectoryStream(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.nio.file.FileTreeWalker.visit(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       at java.base/java.nio.file.FileTreeWalker.next(Unknown Source) ~[na:na]
booklore-894b9f6d4-2lv9p booklore       ... 98 common frames omitted
```

### 🛠️ Changes Implemented

- Creates a new FileUtils.walk which should be a drop in replacement for Files.walk but doesnt return access denied and ignored files/directories

### 🧪 Testing Strategy

- Built image and deployed to my synology
- Added new unit tests

### 📸 Visual Changes _(if applicable)_

n/a


---

## ⚠️ Required Pre-Submission Checklist

### **Please Read - This Checklist is Mandatory**

> **Important Notice:** We've experienced several production bugs recently due to incomplete pre-submission checks. To maintain code quality and prevent issues from reaching production, we're enforcing stricter adherence to this checklist.
>
> **All checkboxes below must be completed before requesting review.** PRs that haven't completed these requirements will be sent back for completion.

#### **Mandatory Requirements** _(please check ALL boxes)_:

- [X] **Code adheres to project style guidelines and conventions**
- [X] **Branch synchronized with latest `develop` branch** _(please resolve any merge conflicts)_
- [ ] **🚨 CRITICAL: Automated unit tests added/updated to cover changes** _(MANDATORY for ALL Spring Boot backend and Angular frontend changes - this is non-negotiable)_
- [X] **🚨 CRITICAL: All tests pass locally** _(run `./gradlew test` for Spring Boot backend, and `ng test` for Angular frontend - NO EXCEPTIONS)_
- [X] **🚨 CRITICAL: Manual testing completed in local development environment** _(verify your changes work AND no existing functionality is broken - test related features thoroughly)_
- [ ] **Flyway migration versioning follows correct sequence** _(if database schema was modified)_
- [X] **Documentation PR submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs)** _(required for features or enhancements that introduce user-facing or visual changes)_

#### **Why This Matters:**

Recent production incidents have been traced back to:

- **Incomplete testing coverage (especially backend)**
- Merge conflicts not resolved before merge
- Missing documentation for new features

**Backend changes without tests will not be accepted.** By completing this checklist thoroughly, you're helping maintain the quality and stability of Booklore for all users.

**Note to Reviewers:** Please verify the checklist is complete before beginning your review. If items are unchecked, kindly ask the contributor to complete them first.

---

### 💬 Additional Context _(optional)_

<!-- Provide any supplementary information, implementation considerations, or discussion points for reviewers -->
