### PR TITLE
fix(additional-file-uploader): add file size validation with UI feedback

### DIFF
--- a/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.html
+++ b/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.html
@@ -43,7 +43,6 @@
 
   <!-- File Upload -->
   <p-fileupload class="file-upload" name="file"
-    [maxFileSize]="maxFileSizeBytes"
     [customUpload]="true"
     [multiple]="false"
     (onSelect)="onFilesSelect($event)"
@@ -81,7 +80,7 @@
                 @for (uploadFile of this.files; track uploadFile; let i = $index) {
                   <div class="file-row">
                     <div class="file-info">
-                      <p-badge [value]="uploadFile.status" [severity]="getBadgeSeverity(uploadFile.status)" class="file-badge"/>
+                      <p-badge [value]="getFileStatusLabel(uploadFile)" [severity]="getBadgeSeverity(uploadFile.status)" class="file-badge"/>
                       <span class="file-name">
                         {{ uploadFile.file.name }}
                       </span>

--- a/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.ts
+++ b/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.ts
@@ -104,10 +104,26 @@ export class AdditionalFileUploaderComponent implements OnInit, OnDestroy {
     // Only take the first file for single file upload
     if (newFiles.length > 0) {
       const file = newFiles[0];
-      this.files = [{
-        file,
-        status: 'Pending'
-      }];
+
+      if (this.maxFileSizeBytes && file.size > this.maxFileSizeBytes) {
+        const errorMsg = `File exceeds maximum size of ${this.formatSize(this.maxFileSizeBytes)}`;
+        this.files = [{
+          file,
+          status: 'Failed',
+          errorMessage: errorMsg
+        }];
+        this.messageService.add({
+          severity: 'error',
+          summary: 'File Too Large',
+          detail: `${file.name} exceeds the maximum file size of ${this.formatSize(this.maxFileSizeBytes)}`,
+          life: 5000
+        });
+      } else {
+        this.files = [{
+          file,
+          status: 'Pending'
+        }];
+      }
     }
   }
 
@@ -183,6 +199,24 @@ export class AdditionalFileUploaderComponent implements OnInit, OnDestroy {
         return 'danger';
       default:
         return 'info';
+    }
+  }
+
+  getFileStatusLabel(uploadFile: UploadingFile): string {
+    if (uploadFile.status === 'Failed' && uploadFile.errorMessage?.includes('exceeds maximum size')) {
+      return 'Too Large';
+    }
+    switch (uploadFile.status) {
+      case 'Pending':
+        return 'Ready';
+      case 'Uploading':
+        return 'Uploading';
+      case 'Uploaded':
+        return 'Uploaded';
+      case 'Failed':
+        return 'Failed';
+      default:
+        return uploadFile.status;
     }
   }
 


### PR DESCRIPTION
## Summary
- Add file size validation in `onFilesSelect` to check files before upload
- Show toast notification when a file exceeds the maximum size limit
- Display "Too Large" badge in the file list for oversized files (matching `book-uploader` behavior)

## Test plan
- [ ] Try uploading a file larger than the configured max size limit
- [ ] Verify toast notification appears with file name and size limit
- [ ] Verify file appears in the list with a red "Too Large" badge
- [ ] Verify hovering over the error icon shows the error message tooltip
- [ ] Verify files under the size limit can still be uploaded normally