### PR TITLE
fix(metadata-update): ensure per-book transaction isolation in bulk updates to prevent race conditions

### DIFF
--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/BookMetadataServiceConcurrencyTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/BookMetadataServiceConcurrencyTest.java
@@ -1,0 +1,97 @@
+package com.adityachandel.booklore.service.metadata;
+
+import com.adityachandel.booklore.mapper.BookMapper;
+import com.adityachandel.booklore.mapper.BookMetadataMapper;
+import com.adityachandel.booklore.mapper.MetadataClearFlagsMapper;
+import com.adityachandel.booklore.model.dto.request.BulkMetadataUpdateRequest;
+import com.adityachandel.booklore.model.entity.BookEntity;
+import com.adityachandel.booklore.model.entity.BookMetadataEntity;
+import com.adityachandel.booklore.model.enums.MetadataProvider;
+import com.adityachandel.booklore.repository.BookMetadataRepository;
+import com.adityachandel.booklore.repository.BookRepository;
+import com.adityachandel.booklore.service.NotificationService;
+import com.adityachandel.booklore.service.book.BookQueryService;
+import com.adityachandel.booklore.service.metadata.extractor.CbxMetadataExtractor;
+import com.adityachandel.booklore.service.metadata.parser.BookParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BookMetadataServiceConcurrencyTest {
+
+    @Mock
+    private BookRepository bookRepository;
+    @Mock
+    private BookMapper bookMapper;
+    @Mock
+    private BookMetadataMapper bookMetadataMapper;
+    @Mock
+    private BookMetadataUpdater bookMetadataUpdater;
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private BookMetadataRepository bookMetadataRepository;
+    @Mock
+    private BookQueryService bookQueryService;
+    @Mock
+    private Map<MetadataProvider, BookParser> parserMap;
+    @Mock
+    private CbxMetadataExtractor cbxMetadataExtractor;
+    @Mock
+    private MetadataClearFlagsMapper metadataClearFlagsMapper;
+    @Mock
+    private PlatformTransactionManager transactionManager;
+
+    @InjectMocks
+    private BookMetadataService bookMetadataService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void bulkUpdateMetadata_FetchingStrategyVerification() {
+
+        BulkMetadataUpdateRequest request = new BulkMetadataUpdateRequest();
+        request.setBookIds(Set.of(1L, 2L));
+
+        BookEntity book1 = new BookEntity();
+        book1.setId(1L);
+        book1.setMetadata(new BookMetadataEntity());
+
+        BookEntity book2 = new BookEntity();
+        book2.setId(2L);
+        book2.setMetadata(new BookMetadataEntity());
+
+        when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(getUserBook(1L));
+        when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(getUserBook(2L));
+
+        bookMetadataService.bulkUpdateMetadata(request, false, false, false);
+
+        verify(bookRepository, never()).findAllWithMetadataByIds(anySet());
+
+        verify(bookRepository, times(1)).findByIdWithBookFiles(1L);
+        verify(bookRepository, times(1)).findByIdWithBookFiles(2L);
+    }
+    
+    private java.util.Optional<BookEntity> getUserBook(Long id) {
+        BookEntity book = new BookEntity();
+        book.setId(id);
+        book.setMetadata(new BookMetadataEntity());
+        return java.util.Optional.of(book);
+    }
+}


### PR DESCRIPTION

## 🚀 Pull Request

### 📝 Description

<!-- Provide a clear and concise summary of the changes introduced in this pull request -->
<!-- Reference related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->


This pull request refactors the bulkUpdateMetadata method in BookMetadataService to improve transaction handling and per-book error isolation during bulk metadata updates. Instead of fetching all books at once and updating them in a single transaction, each book update is now performed in its own transaction. Additionally, a new concurrency-focused test ensures the updated fetching and transaction strategy works as intended.



### 🛠️ Changes Implemented

<!-- Detail the specific modifications, additions, or removals made in this pull request -->
**Bulk metadata update refactor:**

* Changed `bulkUpdateMetadata` to process each book ID individually, wrapping each update in its own new transaction using `TransactionTemplate` and `PlatformTransactionManager`, which improves error isolation and transactional consistency. Errors for individual books are logged without halting the entire bulk operation.


**Testing improvements:**

* Added `BookMetadataServiceConcurrencyTest` to verify that the new per-book fetching and transaction strategy is used, ensuring that `findAllWithMetadataByIds` is no longer called and that each book is fetched individually for update.

### 🧪 Testing Strategy

<!-- Describe the testing methodology used to verify the correctness of these changes -->
<!-- Include testing approach, scenarios covered, and edge cases considered -->

### 📸 Visual Changes _(if applicable)_

<!-- Attach screenshots or videos demonstrating UI/UX modifications -->


---

## ⚠️ Required Pre-Submission Checklist

### **Please Read - This Checklist is Mandatory**

> **Important Notice:** We've experienced several production bugs recently due to incomplete pre-submission checks. To maintain code quality and prevent issues from reaching production, we're enforcing stricter adherence to this checklist.
>
> **All checkboxes below must be completed before requesting review.** PRs that haven't completed these requirements will be sent back for completion.

#### **Mandatory Requirements** _(please check ALL boxes)_:

- [x] **Code adheres to project style guidelines and conventions**
- [x] **Branch synchronized with latest `develop` branch** _(please resolve any merge conflicts)_
- [x] **🚨 CRITICAL: Automated unit tests added/updated to cover changes** _(MANDATORY for ALL Spring Boot backend and Angular frontend changes - this is non-negotiable)_
- [x] **🚨 CRITICAL: All tests pass locally** _(run `./gradlew test` for Spring Boot backend, and `ng test` for Angular frontend - NO EXCEPTIONS)_
- [x] **🚨 CRITICAL: Manual testing completed in local development environment** _(verify your changes work AND no existing functionality is broken - test related features thoroughly)_
- [ ] **Flyway migration versioning follows correct sequence** _(if database schema was modified)_
- [ ] **Documentation PR submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs)** _(required for features or enhancements that introduce user-facing or visual changes)_

#### **Why This Matters:**

Recent production incidents have been traced back to:

- **Incomplete testing coverage (especially backend)**
- Merge conflicts not resolved before merge
- Missing documentation for new features

**Backend changes without tests will not be accepted.** By completing this checklist thoroughly, you're helping maintain the quality and stability of Booklore for all users.

**Note to Reviewers:** Please verify the checklist is complete before beginning your review. If items are unchecked, kindly ask the contributor to complete them first.

---

### 💬 Additional Context _(optional)_

<!-- Provide any supplementary information, implementation considerations, or discussion points for reviewers -->
