### PR TITLE
fix(auth): resolve DST-related login failure for refresh tokens

### DIFF
--- a/booklore-api/src/main/resources/db/migration/V112__Fix_refresh_token_datetime_precision.sql
+++ b/booklore-api/src/main/resources/db/migration/V112__Fix_refresh_token_datetime_precision.sql
@@ -1,0 +1,3 @@
+ALTER TABLE refresh_token
+    MODIFY COLUMN expiry_date DATETIME(6) NOT NULL,
+    MODIFY COLUMN revocation_date DATETIME(6) NULL;


### PR DESCRIPTION
## 🚀 Pull Request

### 📝 Description

Fixes #2621

Users unable to login due to `Incorrect datetime value` error when refresh token expiry falls within the DST gap (2:00-2:59 AM on March 8, 2026).

### 🛠️ Changes Implemented

- Changed `refresh_token.expiry_date` from `TIMESTAMP` to `DATETIME(6)`
- Changed `refresh_token.revocation_date` from `TIMESTAMP` to `DATETIME(6)`

`TIMESTAMP` performs timezone conversion and rejects non-existent times during DST transitions. `DATETIME` stores values as-is without timezone conversion.

### 🧪 Testing Strategy

Tested directly against MariaDB with timezone set to `America/New_York`:

| Test | Schema | Result |
|------|--------|--------|
| Before fix | `TIMESTAMP` | `ERROR 1292 (22007): Incorrect datetime value` |
| After fix | `DATETIME(6)` | Success |

---

## ⚠️ Required Pre-Submission Checklist

- [x] **Code adheres to project style guidelines and conventions**
- [x] **Branch synchronized with latest `develop` branch**
- [x] **🚨 CRITICAL: Automated unit tests added/updated to cover changes** _(N/A - SQL migration only)_
- [x] **🚨 CRITICAL: All tests pass locally**
- [x] **🚨 CRITICAL: Manual testing completed in local development environment**
- [x] **Flyway migration versioning follows correct sequence**
- [x] **Documentation PR submitted** _(N/A - no user-facing changes)_

### 💬 Additional Context

Root cause identified by community members @smorbickles and @nrrogers.