### PR TITLE
fix(book-browser): resolve footer menu not hiding after navigation back

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.html
@@ -317,14 +317,13 @@
               </virtual-scroller>
             }
           }
-          @if (selectedBooks.size > 0) {
-            @if (userService.userState$ | async; as userState) {
-              <div class="book-browser-footer" [@slideInOut]>
+          @if (userService.userState$ | async; as userState) {
+            <div class="book-browser-footer" [class.footer-hidden]="selectedCount === 0">
                 <div class="footer-content">
                   <div class="footer-left">
                     <div class="selected-count-badge">
                       <i class="pi pi-check-circle"></i>
-                      <span class="selected-count">{{ selectedBooks.size }}</span>
+                      <span class="selected-count">{{ selectedCount }}</span>
                       <span class="selected-label">selected</span>
                     </div>
                   </div>
@@ -441,7 +440,6 @@
                 </div>
               </div>
             }
-          }
         </div>
       </div>
     }

--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.scss
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.scss
@@ -232,6 +232,15 @@
   border: 1px solid rgba(255, 255, 255, 0.5);
   border-width: 1px 1px 0 1px;
   background-color: var(--card-background);
+  transition: transform 0.15s ease-out, opacity 0.15s ease-out;
+  transform: translateY(0);
+  opacity: 1;
+
+  &.footer-hidden {
+    transform: translateY(100%);
+    opacity: 0;
+    pointer-events: none;
+  }
 
   > .footer-content {
     width: 100%;


### PR DESCRIPTION
## 🚀 Pull Request

### 📝 Description

Fixes a bug where the book selection footer menu would not hide after navigating to a book detail page and pressing the back button. The footer would remain visible even after clicking "Deselect all books", and selecting more books would cause duplicate footers to appear.

### 🛠️ Changes Implemented

- Added `ChangeDetectorRef`, `NgZone`, and `ApplicationRef` injections for reliable change detection with route reuse
- Added `selectedCount` component property with subscription to `selectedBooks$` observable
- Changed footer visibility from Angular `@if` control flow to CSS class binding (`[class.footer-hidden]`)
- Added CSS transitions for smooth show/hide animation
- Removed Angular animation trigger `[@slideInOut]` that conflicted with RouteReuseStrategy

### 🧪 Testing Strategy

- Manual testing: Select books → navigate to book detail → press back → click "Deselect all" → verify footer hides
- Manual testing: Verify no duplicate footers appear when selecting/deselecting books after navigation
- Build verification: `npm run build` succeeds without errors
- Automated tests pass

### 📸 Visual Changes _(if applicable)_

No visual changes - footer behavior fix only.

---

## ⚠️ Required Pre-Submission Checklist

### **Please Read - This Checklist is Mandatory**

#### **Mandatory Requirements** _(please check ALL boxes)_:

- [x] **Code adheres to project style guidelines and conventions**
- [x] **Branch synchronized with latest `develop` branch**
- [ ] **🚨 CRITICAL: Automated unit tests added/updated to cover changes**
- [x] **🚨 CRITICAL: All tests pass locally**
- [x] **🚨 CRITICAL: Manual testing completed in local development environment**
- [x] **Flyway migration versioning follows correct sequence** _(N/A - no database changes)_
- [x] **Documentation PR submitted to booklore-docs** _(N/A - bug fix with no user-facing changes)_

---

### 💬 Additional Context _(optional)_

The root cause was the `CustomReuseStrategy` that caches book browser routes. When navigating back, the cached view was reattached but Angular's `@if` control flow and animations didn't work correctly with the reattached view. The fix uses CSS-based visibility instead, which works reliably with route reuse.