### PR TITLE
feat(pwa): Enable fullscreen mode for Android immersive reading

### DIFF
--- a/booklore-ui/public/manifest.webmanifest
+++ b/booklore-ui/public/manifest.webmanifest
@@ -1,7 +1,8 @@
 {
   "name": "booklore",
   "short_name": "booklore",
-  "display": "standalone",
+  "display": "fullscreen",
+  "display_override": ["fullscreen", "standalone", "browser"],
   "scope": "./",
   "start_url": "./",
   "icons": [

--- a/booklore-ui/src/index.html
+++ b/booklore-ui/src/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>BookLore</title>
   <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg"/>
   <link rel="manifest" href="manifest.webmanifest">
 </head>


### PR DESCRIPTION
## Summary

Enables fullscreen mode for the PWA on Android to provide an immersive e-reader experience without the system status bar.

## Changes

- Change PWA manifest `display` mode from `standalone` to `fullscreen` with fallback options
- Update viewport meta tag to include `viewport-fit=cover` for proper safe area support on notched devices

## Why This Matters

This creates a more immersive reading experience comparable to native e-reader apps, maximizing screen real estate for book content.

## Testing

- Install PWA on Android device
- Verify fullscreen mode launches without status bar
- Test on devices with notches/cutouts to ensure content is accessible

Closes #2648