### PR TITLE
feat(email): add format selection to email book dialog

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/dto/request/SendBookByEmailRequest.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/request/SendBookByEmailRequest.java
@@ -20,4 +20,6 @@ public class SendBookByEmailRequest {
 
     @NotNull(message = "Recipient ID cannot be null")
     private Long recipientId;
+
+    private Long bookFileId;  // Optional: if null, uses primary file
 }

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -395,7 +395,7 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
               label: 'Custom Send',
               icon: 'pi pi-envelope',
               command: () => {
-                this.bookDialogHelperService.openCustomSendDialog(this.book.id);
+                this.bookDialogHelperService.openCustomSendDialog(this.book);
               }
             }
           ]

--- a/booklore-ui/src/app/features/book/components/book-browser/book-dialog-helper.service.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-dialog-helper.service.ts
@@ -114,12 +114,12 @@ export class BookDialogHelperService {
     });
   }
 
-  openCustomSendDialog(bookId: number): DynamicDialogRef | null {
+  openCustomSendDialog(book: Book): DynamicDialogRef | null {
     return this.openDialog(BookSenderComponent, {
       showHeader: false,
       styleClass: `${DialogSize.SM} ${DialogStyle.MINIMAL}`,
       data: {
-        bookId: bookId,
+        book: book,
       },
     });
   }

--- a/booklore-ui/src/app/features/book/components/book-sender/book-sender.component.html
+++ b/booklore-ui/src/app/features/book/components/book-sender/book-sender.component.html
@@ -43,6 +43,31 @@
           styleClass="full-width">
         </p-select>
       </div>
+
+      @if (emailableFiles.length > 0) {
+        <div class="form-field">
+          <label class="field-label">File Format</label>
+          <div class="format-options">
+            @for (file of emailableFiles; track file.id) {
+              <div class="format-option" [class.selected]="selectedFileId === file.id">
+                <p-radioButton name="fileFormat" [value]="file.id" [(ngModel)]="selectedFileId"/>
+                <div class="format-info">
+                  <span class="format-type">{{ file.bookType || 'Unknown' }}</span>
+                  @if (file.isPrimary) { <span class="primary-badge">Primary</span> }
+                  <span class="file-size">{{ formatFileSize(file.fileSizeKb) }}</span>
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      @if (showLargeFileWarning) {
+        <div class="warning-banner">
+          <i class="pi pi-exclamation-triangle"></i>
+          <span>This file exceeds 25MB. Some email providers may reject large attachments.</span>
+        </div>
+      }
     </div>
   </div>
 

--- a/booklore-ui/src/app/features/book/components/book-sender/book-sender.component.scss
+++ b/booklore-ui/src/app/features/book/components/book-sender/book-sender.component.scss
@@ -46,3 +46,79 @@
 :host ::ng-deep .full-width {
   width: 100%;
 }
+
+.format-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.format-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.03);
+    border-color: var(--p-primary-400);
+  }
+
+  &.selected {
+    background: rgba(var(--p-primary-500-rgb), 0.1);
+    border-color: var(--p-primary-500);
+  }
+}
+
+.format-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.format-type {
+  font-weight: 500;
+  color: #e5e7eb;
+}
+
+.primary-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.125rem 0.375rem;
+  background: var(--p-primary-500);
+  color: white;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+.file-size {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+.warning-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: rgba(234, 179, 8, 0.1);
+  border: 1px solid rgba(234, 179, 8, 0.3);
+  border-radius: 6px;
+  color: #fbbf24;
+
+  i {
+    font-size: 1rem;
+    margin-top: 0.125rem;
+  }
+
+  span {
+    font-size: 0.85rem;
+    line-height: 1.4;
+  }
+}

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -256,7 +256,7 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
                     label: 'Custom Send',
                     icon: 'pi pi-cog',
                     command: () => {
-                      this.bookDialogHelperService.openCustomSendDialog(book.id);
+                      this.bookDialogHelperService.openCustomSendDialog(book);
                     }
                   }
                 ]

--- a/booklore-ui/src/app/features/settings/email-v2/email.service.ts
+++ b/booklore-ui/src/app/features/settings/email-v2/email.service.ts
@@ -12,7 +12,7 @@ export class EmailService {
 
   private http = inject(HttpClient);
 
-  emailBook(request: { bookId: number, providerId: number, recipientId: number }): Observable<void> {
+  emailBook(request: { bookId: number, providerId: number, recipientId: number, bookFileId?: number }): Observable<void> {
     return this.http.post<void>(`${this.apiUrl}/book`, request);
   }
 


### PR DESCRIPTION
## 🚀 Pull Request

### 📝 Description

Add format selection to the email book dialog, allowing users to choose which file format to send (primary or alternative). Includes file size display and large file warnings for files >25MB.

### 🛠️ Changes Implemented

**Backend:**
- Add optional `bookFileId` field to `SendBookByEmailRequest.java`
- Add `resolveBookFile()` helper method in `SendEmailV2Service.java` to resolve specific file or fallback to primary
- Update email sending methods to use specified book file path via `FileUtils.getBookFullPath(book, bookFile)`

**Frontend:**
- Change `openCustomSendDialog(bookId)` to `openCustomSendDialog(book)` in `book-dialog-helper.service.ts`
- Add format selection with radio buttons in `book-sender.component`:
  - Shows book type and file size for each format
  - "Primary" badge for primary file
  - Pre-selects primary format
- Add large file warning banner (>25MB threshold)
- Add optional `bookFileId` to email service request interface
- Update callers in `book-card.component.ts` and `metadata-viewer.component.ts`

### 🧪 Testing Strategy

- Existing unit tests pass (`./gradlew test --tests "*SendEmailV2ServiceTest*"`)
- Manual testing scenarios:
  - Open book with multiple formats → format options display with sizes
  - Primary file pre-selected with badge
  - Select alternative format → correct file sent
  - Large file (>25MB) → warning banner appears
  - Quick send still uses primary (no UI change)
  - Book with only primary file → shows single option

### 📸 Visual Changes _(if applicable)_

The email book dialog now includes:
- Radio button format selection showing type + size
- "Primary" badge on primary format
- Yellow warning banner for large files

---

## ⚠️ Required Pre-Submission Checklist

### **Please Read - This Checklist is Mandatory**

#### **Mandatory Requirements** _(please check ALL boxes)_:

- [x] **Code adheres to project style guidelines and conventions**
- [x] **Branch synchronized with latest `develop` branch**
- [x] **🚨 CRITICAL: Automated unit tests added/updated to cover changes** _(existing tests cover the service)_
- [x] **🚨 CRITICAL: All tests pass locally** _(backend and frontend tests pass)_
- [ ] **🚨 CRITICAL: Manual testing completed in local development environment**
- [x] **Flyway migration versioning follows correct sequence** _(no database changes)_
- [ ] **Documentation PR submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs)** _(if needed)_

---

### 💬 Additional Context _(optional)_

**Design decisions:**
- Quick send always uses primary format (maintains existing behavior)
- Bulk send uses primary format (no format selection for bulk operations)
- Audiobooks are sendable with warning for large files
- 25MB threshold chosen as common email attachment limit