### PR TITLE
fix(settings): use boxed Integer for ScrollerConfig.maxItems to allow null

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/dto/BookLoreUser.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/BookLoreUser.java
@@ -236,7 +236,7 @@ public class BookLoreUser {
             private String title;
             private boolean enabled;
             private int order;
-            private int maxItems;
+            private Integer maxItems;
             private Long magicShelfId;
             private String sortField;
             private String sortDirection;


### PR DESCRIPTION
## 📝 Description

Fixes Jackson deserialization failure when `maxItems` is `null` in stored user dashboard scroller settings. The `ScrollerConfig.maxItems` field was a primitive `int`, which cannot represent `null`, causing a `MismatchedInputException` on login.

## 🏷️ Type of Change

- [x] Bug fix

## 🔧 Changes

- Changed `ScrollerConfig.maxItems` from primitive `int` to boxed `Integer` in `BookLoreUser.java` to allow `null` values during Jackson deserialization

## 🧪 Testing

- `./gradlew test` — all backend tests pass
- `ng test` (vitest) — all frontend tests pass

## 📸 Screenshots / Video (MANDATORY)

N/A — single-line type change in a DTO, verified via automated tests.

---

## ✅ Pre-Submission Checklist

- [x] Code follows project style guidelines and conventions
- [x] Branch is up to date with `develop` (merge conflicts resolved)
- [x] All tests pass locally (`./gradlew test` for backend, `ng test` for frontend)
- [x] Changes manually verified in local dev environment (including related features)
- [x] PR is reasonably scoped