### PR TITLE
feat(metadata): return full metadata from parsers instead of previews

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -24,6 +24,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -44,7 +45,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
         }
     }
 
-    private static final int COUNT_DETAILED_METADATA_TO_GET = 3;
+    private static final int COUNT_DETAILED_METADATA_TO_GET = 4;
     private static final String BASE_BOOK_URL_SUFFIX = "/dp/";
     private static final Pattern NON_DIGIT_PATTERN = Pattern.compile("[^\\d]");
     private static final Pattern SERIES_FORMAT_PATTERN = Pattern.compile("Book (\\d+(?:\\.\\d+)?) of (\\d+)");
@@ -104,21 +105,28 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
     @Override
     public List<BookMetadata> fetchMetadata(Book book, FetchMetadataRequest fetchMetadataRequest) {
-        String queryUrl = buildQueryUrl(fetchMetadataRequest, book);
-        if (queryUrl == null) {
-            log.error("Query URL is null, cannot proceed.");
+        LinkedList<String> amazonBookIds = getAmazonBookIds(book, fetchMetadataRequest);
+        if (amazonBookIds == null || amazonBookIds.isEmpty()) {
             return Collections.emptyList();
         }
-        try {
-            Document doc = fetchDocument(queryUrl);
-            return extractSearchPreviews(doc);
-        } catch (AmazonAntiScrapingException e) {
-            log.debug("Aborting Amazon search due to anti-scraping (503).");
-            return Collections.emptyList();
-        } catch (Exception e) {
-            log.error("Failed to fetch Amazon search results: {}", e.getMessage(), e);
-            return Collections.emptyList();
+        List<BookMetadata> results = new ArrayList<>();
+        for (int i = 0; i < amazonBookIds.size() && results.size() < COUNT_DETAILED_METADATA_TO_GET; i++) {
+            try {
+                if (i > 0) {
+                    Thread.sleep(ThreadLocalRandom.current().nextLong(500, 1501));
+                }
+                BookMetadata metadata = getBookMetadata(amazonBookIds.get(i));
+                if (metadata != null) {
+                    results.add(metadata);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                log.error("Error fetching metadata for ASIN: {}", amazonBookIds.get(i), e);
+            }
         }
+        return results;
     }
 
     private List<BookMetadata> extractSearchPreviews(Document doc) {

--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/AudibleParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/AudibleParser.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,6 +36,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class AudibleParser implements BookParser, DetailedMetadataProvider {
 
+    private static final int COUNT_DETAILED_METADATA_TO_GET = 4;
     private static final long MIN_REQUEST_INTERVAL_MS = 1500;
     private static final String DEFAULT_DOMAIN = "com";
 
@@ -74,19 +76,28 @@ public class AudibleParser implements BookParser, DetailedMetadataProvider {
 
     @Override
     public List<BookMetadata> fetchMetadata(Book book, FetchMetadataRequest fetchMetadataRequest) {
-        String queryUrl = buildQueryUrl(fetchMetadataRequest, book);
-        if (queryUrl == null) {
-            log.error("Query URL is null, cannot proceed with Audible search.");
+        List<String> audibleIds = getAudibleIds(book, fetchMetadataRequest);
+        if (audibleIds == null || audibleIds.isEmpty()) {
             return Collections.emptyList();
         }
-        try {
-            enforceRateLimit();
-            Document doc = fetchDocument(queryUrl);
-            return extractSearchPreviews(doc);
-        } catch (Exception e) {
-            log.error("Failed to fetch Audible search results: {}", e.getMessage(), e);
-            return Collections.emptyList();
+        List<BookMetadata> results = new ArrayList<>();
+        for (int i = 0; i < audibleIds.size() && results.size() < COUNT_DETAILED_METADATA_TO_GET; i++) {
+            try {
+                if (i > 0) {
+                    Thread.sleep(ThreadLocalRandom.current().nextLong(500, 1501));
+                }
+                BookMetadata metadata = getBookMetadata(audibleIds.get(i));
+                if (metadata != null) {
+                    results.add(metadata);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                log.error("Error fetching metadata for Audible ID: {}", audibleIds.get(i), e);
+            }
         }
+        return results;
     }
 
     private List<BookMetadata> extractSearchPreviews(Document doc) {


### PR DESCRIPTION
## 📝 Description

Switch Amazon, Audible, and GoodReads parsers to return full detailed metadata from `fetchMetadata()` instead of lightweight previews. Adds randomized request delays and a title-only fallback search for GoodReads.

## 🏷️ Type of Change

- [x] Enhancement to existing feature

## 🔧 Changes

- **AmazonBookParser**: `fetchMetadata()` now fetches full metadata for up to 4 results (was 3 previews), with randomized 500–1500ms delays between requests
- **AudibleParser**: `fetchMetadata()` now fetches full metadata for up to 4 results (was previews only), with randomized 500–1500ms delays between requests
- **GoodReadsParser**: `fetchMetadata()` now fetches full metadata for up to 3 results; retries with title-only search (2 results) when title+author yields no matches; delay changed from fixed 2s to randomized 500–1500ms

## 🧪 Testing

<!-- To be filled -->

## 📸 Screenshots / Video (MANDATORY)

<!-- To be filled -->