### PR TITLE
fix(reader): enable text copy in ebook reader

### DIFF
--- a/booklore-ui/src/app/features/readers/ebook-reader/core/event.service.ts
+++ b/booklore-ui/src/app/features/readers/ebook-reader/core/event.service.ts
@@ -228,13 +228,6 @@ export class ReaderEventService {
       this.handleTouchEnd(event, doc);
     }, {passive: false});
 
-    doc.addEventListener('contextmenu', (event: MouseEvent) => {
-      const selection = doc.defaultView?.getSelection();
-      if (selection && !selection.isCollapsed) {
-        event.preventDefault();
-      }
-    });
-
     doc.addEventListener('selectionchange', () => {
       this.handleSelectionChange(doc);
     });

--- a/booklore-ui/src/app/features/readers/ebook-reader/features/selection/selection.service.ts
+++ b/booklore-ui/src/app/features/readers/ebook-reader/features/selection/selection.service.ts
@@ -107,6 +107,10 @@ export class ReaderSelectionService {
 
     if (action.type === 'select') {
       this.clearPreview();
+      if (this.currentSelection?.text) {
+        navigator.clipboard.writeText(this.currentSelection.text);
+      }
+      this.viewManager.clearSelection();
       this.emitState();
     } else if (action.type === 'search' && action.searchText) {
       this.clearPreview();


### PR DESCRIPTION
You couldn't copy text in the ebook reader before. The copy button in the selection popup wasn't actually writing to the clipboard, and right-click copy was being blocked by a preventDefault on the context menu. Fixed both so copying works normally now. Fixes #2700.