### PR TITLE
fix: reset audiobook progress and clear cached progress in UI

### DIFF
--- a/booklore-api/src/main/java/org/booklore/repository/UserBookFileProgressRepository.java
+++ b/booklore-api/src/main/java/org/booklore/repository/UserBookFileProgressRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.jpa.repository.Modifying;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -58,4 +60,12 @@ public interface UserBookFileProgressRepository extends JpaRepository<UserBookFi
             @Param("userId") Long userId,
             @Param("bookIds") Iterable<Long> bookIds
     );
+
+    @Modifying
+    @Query("""
+        DELETE FROM UserBookFileProgressEntity ubfp
+        WHERE ubfp.user.id = :userId
+          AND ubfp.bookFile.book.id IN :bookIds
+    """)
+    int deleteByUserIdAndBookIds(@Param("userId") Long userId, @Param("bookIds") Iterable<Long> bookIds);
 }

--- a/booklore-api/src/main/java/org/booklore/service/progress/ReadingProgressService.java
+++ b/booklore-api/src/main/java/org/booklore/service/progress/ReadingProgressService.java
@@ -431,7 +431,10 @@ public class ReadingProgressService {
         List<Long> bookIdList = new ArrayList<>(bookIds);
 
         switch (type) {
-            case BOOKLORE -> userBookProgressRepository.bulkResetBookloreProgress(userId, bookIdList, now);
+            case BOOKLORE -> {
+                userBookProgressRepository.bulkResetBookloreProgress(userId, bookIdList, now);
+                userBookFileProgressRepository.deleteByUserIdAndBookIds(userId, bookIdList);
+            }
             case KOREADER -> userBookProgressRepository.bulkResetKoreaderProgress(userId, bookIdList);
             case KOBO -> {
                 userBookProgressRepository.bulkResetKoboProgress(userId, bookIdList);

--- a/booklore-ui/src/app/features/book/service/book-patch.service.ts
+++ b/booklore-ui/src/app/features/book/service/book-patch.service.ts
@@ -163,8 +163,13 @@ export class BookPatchService {
         const updatedBooks = (currentState.books || []).map(book => {
           const response = responses.find(r => r.bookId === book.id);
           if (response) {
+            const progressReset: Partial<Book> =
+              type === 'KOREADER' ? {koreaderProgress: undefined} :
+              type === 'KOBO' ? {koboProgress: undefined} :
+              {epubProgress: undefined, pdfProgress: undefined, cbxProgress: undefined, audiobookProgress: undefined};
             return {
               ...book,
+              ...progressReset,
               readStatus: response.readStatus,
               readStatusModifiedTime: response.readStatusModifiedTime,
               dateFinished: response.dateFinished


### PR DESCRIPTION
Resetting reading progress wasn't clearing audiobook progress from the database, and the UI was still showing stale cached values after any kind of reset. Now the backend deletes the file-level progress records too, and the frontend clears the relevant cached fields right after a successful reset. Fixes #2641.