### PR TITLE
feat(ui): add file name column to table view and include filename in search

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-table/book-table.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-table/book-table.component.ts
@@ -63,6 +63,7 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
     {field: 'publishedDate', header: 'Published'},
     {field: 'lastReadTime', header: 'Last Read'},
     {field: 'addedOn', header: 'Added'},
+    {field: 'fileName', header: 'File Name'},
     {field: 'fileSizeKb', header: 'File Size'},
     {field: 'language', header: 'Language'},
     {field: 'isbn', header: 'ISBN'},
@@ -283,6 +284,9 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
 
       case 'addedOn':
         return book.addedOn ? this.datePipe.transform(book.addedOn, 'dd-MMM-yyyy') ?? '' : '';
+
+      case 'fileName':
+        return book.primaryFile?.fileName ?? '';
 
       case 'fileSizeKb':
         return this.formatFileSize(book.fileSizeKb);

--- a/booklore-ui/src/app/features/book/components/book-browser/filters/HeaderFilter.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/filters/HeaderFilter.ts
@@ -40,14 +40,16 @@ export class HeaderFilter implements BookFilter {
               const categories = book.metadata?.categories || [];
               const isbn = book.metadata?.isbn10 || '';
               const isbn13 = book.metadata?.isbn13 || '';
+              const fileName = book.primaryFile?.fileName || '';
 
               const matchesTitle = normalize(title).includes(nTerm);
               const matchesSeries = normalize(series).includes(nTerm);
               const matchesAuthor = authors.some(author => normalize(author).includes(nTerm));
               const matchesCategory = categories.some(category => normalize(category).includes(nTerm));
               const matchesIsbn = normalize(isbn).includes(nTerm) || normalize(isbn13).includes(nTerm);
+              const matchesFileName = normalize(fileName).includes(nTerm);
 
-              return matchesTitle || matchesSeries || matchesAuthor || matchesCategory || matchesIsbn;
+              return matchesTitle || matchesSeries || matchesAuthor || matchesCategory || matchesIsbn || matchesFileName;
             }) || null;
 
             return {...bookState, books: filteredBooks};

--- a/booklore-ui/src/app/features/book/components/book-browser/table-column-preference.service.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/table-column-preference.service.ts
@@ -24,6 +24,7 @@ export class TableColumnPreferenceService {
     {field: 'publishedDate', header: 'Published'},
     {field: 'lastReadTime', header: 'Last Read'},
     {field: 'addedOn', header: 'Added'},
+    {field: 'fileName', header: 'File Name'},
     {field: 'fileSizeKb', header: 'File Size'},
     {field: 'language', header: 'Language'},
     {field: 'isbn', header: 'ISBN'},


### PR DESCRIPTION
Added a File Name column to the table view and made the search bar match against filenames too. So now you can actually find books by their file name on disk. Closes #2710.