### PR TITLE
fix(ui): prevent footer submenu from rendering off screen

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.html
@@ -333,7 +333,7 @@
                     @if (entityType$ | async; as entityType) {
                       <div class="action-buttons-group">
                         @if (hasMetadataMenuItems) {
-                          <p-tieredMenu #menu [model]="metadataMenuItems" [popup]="true" appendTo="body"/>
+                          <p-tieredMenu #menu [model]="metadataMenuItems" [popup]="true" appendTo="body" styleClass="footer-menu"/>
                           <p-button
                             (click)="menu.toggle($event)"
                             pTooltip="Metadata actions"
@@ -402,7 +402,7 @@
                               severity="info"
                               icon="pi pi-ellipsis-v">
                             </p-button>
-                            <p-tieredMenu #menu [model]="moreActionsMenuItems" [popup]="true" appendTo="body"/>
+                            <p-tieredMenu #menu [model]="moreActionsMenuItems" [popup]="true" appendTo="body" styleClass="footer-menu"/>
                           </div>
                         }
                       </div>

--- a/booklore-ui/src/styles.scss
+++ b/booklore-ui/src/styles.scss
@@ -79,3 +79,8 @@ html {
 .p-inputchips input.p-inputtext {
   width: 100% !important;
 }
+
+.footer-menu .p-tieredmenu-submenu {
+  top: auto !important;
+  bottom: 0;
+}


### PR DESCRIPTION
The tiered menu submenus in the book browser footer were rendering off screen due to a PrimeNG bug that always positions them at top: 0. Added a CSS override scoped to footer menus so submenus grow upward instead of downward. Fixes #2531.