### PR TITLE
fix(ui): reload shelves when enabling Kobo sync

### DIFF
--- a/booklore-ui/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo-sync-settings-component.ts
+++ b/booklore-ui/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo-sync-settings-component.ts
@@ -235,9 +235,7 @@ export class KoboSyncSettingsComponent implements OnInit, OnDestroy {
           summary: this.t.translate('settingsDevice.kobo.settingsUpdated'),
           detail: successMessage
         });
-        if (!this.koboSyncSettings.syncEnabled) {
-          this.shelfService.reloadShelves();
-        }
+        this.shelfService.reloadShelves();
       },
       error: () => {
         this.messageService.add({


### PR DESCRIPTION
When you enabled Kobo sync, the Kobo shelf got created on the backend but the sidebar didn't refresh, so you had to reload the page to see it. Just removed a guard that was only calling reloadShelves on disable, now it runs on enable too. Fixes #2528.