### PR TITLE
fix(ui): fix memory leaks and cascading API calls in metadata editor

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/multi-book-metadata-editor/multi-book-metadata-editor-component.ts
+++ b/booklore-ui/src/app/features/metadata/component/multi-book-metadata-editor/multi-book-metadata-editor-component.ts
@@ -76,8 +76,8 @@ export class MultiBookMetadataEditorComponent implements OnInit, OnDestroy {
       switchMap(book =>
         this.bookService.getBookByIdFromAPI(book.id, true)
       ),
-      shareReplay(1),
-      takeUntil(this.destroy$)
+      takeUntil(this.destroy$),
+      shareReplay({bufferSize: 1, refCount: true})
     );
   }
 


### PR DESCRIPTION
Chrome tabs were crashing after editing a bunch of books because every metadata change was triggering redundant API calls for the currently viewed book. Added distinctUntilChanged to prevent that cascade, fixed shareReplay/takeUntil ordering so subscriptions actually get cleaned up, and flattened a bunch of nested subscriptions with proper lifecycle management. Fixes #2489.