### PR TITLE
fix(ui): encode filter values in query params to handle commas in names

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/reader/EpubReaderService.java
+++ b/booklore-api/src/main/java/org/booklore/service/reader/EpubReaderService.java
@@ -26,6 +26,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
 import java.nio.charset.Charset;

--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser-query-params.service.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser-query-params.service.ts
@@ -249,7 +249,7 @@ export class BookBrowserQueryParamsService {
 
   serializeFilters(filters: Record<string, string[]>): string {
     return Object.entries(filters)
-      .map(([k, v]) => `${k}:${v.join('|')}`)
+      .map(([k, v]) => `${k}:${v.map(val => encodeURIComponent(val)).join('|')}`)
       .join(',');
   }
 
@@ -262,7 +262,7 @@ export class BookBrowserQueryParamsService {
       const [key, ...valueParts] = pair.split(':');
       const value = valueParts.join(':');
       if (key && value) {
-        parsedFilters[key] = value.split('|').map(v => v.trim()).filter(Boolean);
+        parsedFilters[key] = value.split('|').map(v => decodeURIComponent(v.trim())).filter(Boolean);
       }
     });
 

--- a/booklore-ui/src/app/features/book/components/series-page/series-page.component.ts
+++ b/booklore-ui/src/app/features/book/components/series-page/series-page.component.ts
@@ -246,7 +246,7 @@ export class SeriesPageComponent implements OnDestroy {
         sort: "title",
         direction: "asc",
         sidebar: true,
-        filter: `${filterKey}:${filterValue}`,
+        filter: `${filterKey}:${encodeURIComponent(filterValue)}`,
       },
     });
   }

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -848,7 +848,7 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
         sort: 'title',
         direction: 'asc',
         sidebar: true,
-        filter: `${filterKey}:${filterValue}`
+        filter: `${filterKey}:${encodeURIComponent(filterValue)}`
       }
     });
   }

--- a/booklore-ui/src/app/features/metadata/component/metadata-manager/metadata-manager.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/metadata-manager/metadata-manager.component.ts
@@ -604,7 +604,7 @@ export class MetadataManagerComponent implements OnInit, OnDestroy {
         sort: 'title',
         direction: 'asc',
         sidebar: true,
-        filter: `${filterKey}:${filterValue}`
+        filter: `${filterKey}:${encodeURIComponent(filterValue)}`
       }
     });
   }


### PR DESCRIPTION
Filter values with commas in the name (like "Smith, John") were breaking query params because the comma conflicted with the delimiter. Now filter values get properly encoded/decoded so names with commas don't mess up the URL parsing anymore. Fixes #2117.