### PR TITLE
feat: disable PDF printing for users without download permission

### DIFF
--- a/booklore-ui/src/app/features/readers/pdf-reader/pdf-reader.component.html
+++ b/booklore-ui/src/app/features/readers/pdf-reader/pdf-reader.component.html
@@ -16,6 +16,7 @@
     [rotation]="rotation"
     [zoom]="zoom"
     [spread]="spread"
+    [enablePrint]="canPrint"
     [customToolbar]="additionalButtons"
     (pagesLoaded)="onPdfPagesLoaded($event)"
     (pageChange)="onPageChange($event)"
@@ -36,7 +37,9 @@
         <pdf-hand-tool></pdf-hand-tool>
         <pdf-select-tool></pdf-select-tool>
         <pdf-rotate-page></pdf-rotate-page>
-        <pdf-print></pdf-print>
+        @if (canPrint) {
+          <pdf-print></pdf-print>
+        }
         <pdf-no-spread></pdf-no-spread>
         <pdf-even-spread></pdf-even-spread>
         <pdf-odd-spread></pdf-odd-spread>

--- a/booklore-ui/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/booklore-ui/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -32,6 +32,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   isLoading = true;
   totalPages: number = 0;
   isDarkTheme = true;
+  canPrint = false;
 
   rotation: 0 | 90 | 180 | 270 = 0;
   authorization = '';
@@ -92,6 +93,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
             this.zoom = pdfPrefs.pdfSettings?.zoom || myself.userSettings.pdfReaderSetting.pageZoom || 'page-fit';
             this.spread = pdfPrefs.pdfSettings?.spread || myself.userSettings.pdfReaderSetting.pageSpread || 'odd';
           }
+          this.canPrint = myself.permissions.canDownload || myself.permissions.admin;
           this.page = pdfMeta.pdfProgress?.page || 1;
           this.bookData = `${API_CONFIG.BASE_URL}/api/v1/books/${this.bookId}/content`;
           const token = this.authService.getOidcAccessToken() || this.authService.getInternalAccessToken();


### PR DESCRIPTION
Ties PDF printing to the existing download permission. If a user doesn't have download access, the print button is hidden and Ctrl+P is blocked in the PDF reader. Admins can always print regardless.