### PR TITLE
feat: add button to fetch metadata from book file

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/BookController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/BookController.java
@@ -120,6 +120,14 @@ public class BookController {
         return ResponseEntity.ok(bookMetadataService.getComicInfoMetadata(bookId));
     }
 
+    @Operation(summary = "Get file metadata", description = "Extract embedded metadata from the book file.")
+    @ApiResponse(responseCode = "200", description = "File metadata returned successfully")
+    @GetMapping("/{bookId}/file-metadata")
+    public ResponseEntity<?> getFileMetadata(
+            @Parameter(description = "ID of the book") @PathVariable long bookId) {
+        return ResponseEntity.ok(bookMetadataService.getFileMetadata(bookId));
+    }
+
     @Operation(summary = "Get book content", description = "Retrieve the binary content of a book for reading. Supports HTTP Range requests for partial content streaming.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Full book content returned"),

--- a/booklore-api/src/main/java/org/booklore/service/metadata/BookMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/BookMetadataService.java
@@ -23,6 +23,7 @@ import org.booklore.repository.BookRepository;
 import org.booklore.service.NotificationService;
 import org.booklore.service.book.BookQueryService;
 import org.booklore.service.metadata.extractor.CbxMetadataExtractor;
+import org.booklore.service.metadata.extractor.MetadataExtractorFactory;
 import org.booklore.service.metadata.parser.BookParser;
 import org.booklore.service.metadata.parser.DetailedMetadataProvider;
 import org.booklore.util.FileUtils;
@@ -58,6 +59,7 @@ public class BookMetadataService {
     private final BookQueryService bookQueryService;
     private final Map<MetadataProvider, BookParser> parserMap;
     private final CbxMetadataExtractor cbxMetadataExtractor;
+    private final MetadataExtractorFactory metadataExtractorFactory;
     private final MetadataClearFlagsMapper metadataClearFlagsMapper;
     private final PlatformTransactionManager transactionManager;
 
@@ -145,6 +147,16 @@ public class BookMetadataService {
             return null;
         }
         return cbxMetadataExtractor.extractMetadata(new File(FileUtils.getBookFullPath(bookEntity)));
+    }
+
+    public BookMetadata getFileMetadata(long bookId) {
+        log.info("Extracting file metadata for book ID: {}", bookId);
+        BookEntity bookEntity = bookRepository.findById(bookId).orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
+        var primaryFile = bookEntity.getPrimaryBookFile();
+        if (primaryFile == null) {
+            throw ApiError.GENERIC_BAD_REQUEST.createException("Book has no file to extract metadata from");
+        }
+        return metadataExtractorFactory.extractMetadata(primaryFile.getBookType(), new File(FileUtils.getBookFullPath(bookEntity)));
     }
 
     @Transactional

--- a/booklore-ui/src/app/features/book/service/book.service.ts
+++ b/booklore-ui/src/app/features/book/service/book.service.ts
@@ -690,6 +690,10 @@ export class BookService {
     return this.http.post<void>(`${this.url}/${bookId}/regenerate-cover`, {});
   }
 
+  getFileMetadata(bookId: number): Observable<BookMetadata> {
+    return this.http.get<BookMetadata>(`${this.url}/${bookId}/file-metadata`);
+  }
+
   generateCustomCover(bookId: number): Observable<void> {
     return this.http.post<void>(`${this.url}/${bookId}/generate-custom-cover`, {});
   }

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.html
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.html
@@ -161,7 +161,6 @@
                   <p-button [pTooltip]="t('unlockCoverTooltip')" tooltipPosition="top" size="small" icon="pi pi-lock" [outlined]="true" (onClick)="toggleLock('audiobookCover')" severity="warn"></p-button>
                 }
               </div>
-              `
             </div>
           }
         </div>
@@ -967,6 +966,18 @@
           }
 
           <div class="actions-right">
+            @if (!book.isPhysical) {
+              <p-button
+                [label]="isFetchingFromFile ? t('fetchingBtn') : t('fetchFromFileBtn')"
+                [icon]="isFetchingFromFile ? 'pi pi-spin pi-spinner' : 'pi pi-file'"
+                [outlined]="true"
+                severity="secondary"
+                (onClick)="fetchFromFile(book.id)"
+                [disabled]="isFetchingFromFile"
+                [pTooltip]="t('fetchFromFileTooltip')"
+                tooltipPosition="top">
+              </p-button>
+            }
             <p-button
               [label]="isAutoFetching ? t('fetchingBtn') : t('autoFetchBtn')"
               [icon]="isAutoFetching ? 'pi pi-spin pi-spinner' : 'pi pi-bolt'"
@@ -1025,6 +1036,17 @@
               </div>
             }
             <div class="mobile-lock-actions">
+              @if (!book.isPhysical) {
+                <p-button
+                  icon="pi pi-file"
+                  [outlined]="true"
+                  severity="secondary"
+                  (onClick)="fetchFromFile(book.id)"
+                  [disabled]="isFetchingFromFile"
+                  [pTooltip]="t('fetchFromFileBtn')"
+                  tooltipPosition="top">
+                </p-button>
+              }
               <p-button
                 icon="pi pi-bolt"
                 [outlined]="true"

--- a/booklore-ui/src/i18n/en/metadata.json
+++ b/booklore-ui/src/i18n/en/metadata.json
@@ -83,6 +83,8 @@
     "unlockAllBtn": "Unlock All",
     "lockAllBtn": "Lock All",
     "saveBtn": "Save",
+    "fetchFromFileBtn": "From File",
+    "fetchFromFileTooltip": "Load metadata embedded in the book file",
     "previousBookTooltip": "Go to previous book",
     "nextBookTooltip": "Go to next book",
     "autoFetchTooltip": "Automatically fetch metadata using default sources",
@@ -125,7 +127,9 @@
       "customAudiobookCoverGenerated": "Custom audiobook cover generated successfully.",
       "customAudiobookCoverPartialDetail": "Cover generated but failed to refresh display. Please refresh the page.",
       "customAudiobookCoverFailed": "Failed to generate custom audiobook cover",
-      "audiobookUploadFailed": "An error occurred while uploading the audiobook cover"
+      "audiobookUploadFailed": "An error occurred while uploading the audiobook cover",
+      "fileMetadataLoaded": "Metadata loaded from book file. Review and save.",
+      "fileMetadataFailed": "Failed to extract metadata from book file"
     }
   },
   "picker": {

--- a/booklore-ui/src/i18n/es/metadata.json
+++ b/booklore-ui/src/i18n/es/metadata.json
@@ -83,6 +83,8 @@
     "unlockAllBtn": "Desbloquear todo",
     "lockAllBtn": "Bloquear todo",
     "saveBtn": "Guardar",
+    "fetchFromFileBtn": "Del archivo",
+    "fetchFromFileTooltip": "Cargar metadatos incrustados en el archivo del libro",
     "previousBookTooltip": "Ir al libro anterior",
     "nextBookTooltip": "Ir al libro siguiente",
     "autoFetchTooltip": "Obtener metadatos automáticamente usando fuentes predeterminadas",
@@ -125,7 +127,9 @@
       "customAudiobookCoverGenerated": "Portada personalizada del audiolibro generada correctamente.",
       "customAudiobookCoverPartialDetail": "Portada generada pero no se pudo actualizar la visualización. Por favor recarga la página.",
       "customAudiobookCoverFailed": "Error al generar portada personalizada del audiolibro",
-      "audiobookUploadFailed": "Ocurrió un error al subir la portada del audiolibro"
+      "audiobookUploadFailed": "Ocurrió un error al subir la portada del audiolibro",
+      "fileMetadataLoaded": "Metadatos cargados del archivo del libro. Revisa y guarda.",
+      "fileMetadataFailed": "Error al extraer metadatos del archivo del libro"
     }
   },
   "picker": {


### PR DESCRIPTION
Adds a "From File" button in the metadata editor that pulls embedded metadata straight from the book file itself (EPUB OPF, PDF properties, ComicInfo.xml, etc.) and fills in the form. You can review everything before saving. The button is hidden for physical books since they have no file to read from.