### PR TITLE
feat: add configurable sidebar width setting

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.scss
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.scss
@@ -447,7 +447,7 @@
   z-index: 50;
 
   @media (max-width: 991px) {
-    width: 225px;
+    width: var(--sidebar-width, 225px);
     position: fixed;
     top: 3.85rem;
     right: 0;
@@ -478,7 +478,7 @@
     }
 
     &.active {
-      width: 225px;
+      width: var(--sidebar-width, 225px);
       opacity: 1;
       pointer-events: auto;
       margin-left: 1rem;

--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.component.scss
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.component.scss
@@ -7,7 +7,7 @@
 }
 
 :host ::ng-deep .cdk-virtual-scroll-orientation-vertical .cdk-virtual-scroll-content-wrapper {
-  width: 190px !important;
+  width: calc(var(--sidebar-width, 225px) - 35px) !important;
   min-width: unset;
 }
 

--- a/booklore-ui/src/app/features/settings/view-preferences-parent/view-preferences-parent.component.html
+++ b/booklore-ui/src/app/features/settings/view-preferences-parent/view-preferences-parent.component.html
@@ -17,5 +17,39 @@
     <app-sidebar-sorting-preferences></app-sidebar-sorting-preferences>
     <div class="section-divider"><hr></div>
     <app-meta-center-view-mode-component></app-meta-center-view-mode-component>
+    <div class="section-divider"><hr></div>
+
+    <div class="preferences-section">
+      <div class="section-header">
+        <h3 class="section-title">
+          <i class="pi pi-objects-column"></i>
+          {{ t('layout.sectionTitle') }}
+        </h3>
+      </div>
+
+      <div class="settings-card">
+        <div class="setting-item">
+          <div class="setting-info">
+            <div class="setting-label-row">
+              <label class="setting-label">{{ t('layout.sidebarWidth', {value: sidebarWidth}) }}</label>
+              <div class="slider-container">
+                <p-slider
+                  [(ngModel)]="sidebarWidth"
+                  [min]="175"
+                  [max]="400"
+                  [step]="1"
+                  (onChange)="onSidebarWidthChange()"
+                  (onSlideEnd)="saveSidebarWidth()">
+                </p-slider>
+              </div>
+            </div>
+            <p class="setting-description">
+              <i class="pi pi-info-circle"></i>
+              {{ t('layout.sidebarWidthDesc') }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </ng-container>

--- a/booklore-ui/src/app/features/settings/view-preferences-parent/view-preferences-parent.component.scss
+++ b/booklore-ui/src/app/features/settings/view-preferences-parent/view-preferences-parent.component.scss
@@ -16,3 +16,93 @@
 }
 
 @include settings.settings-section-divider;
+
+.preferences-section {
+  @media (min-width: 768px) {
+    padding: 0 1rem;
+  }
+}
+
+.section-header {
+  @include settings.settings-section-header;
+  margin-bottom: 1rem;
+}
+
+.section-title {
+  @include settings.settings-section-title;
+  margin: 0;
+}
+
+.settings-card {
+  @include settings.settings-card;
+}
+
+.setting-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+
+  &:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 1rem;
+  }
+}
+
+.setting-info {
+  flex: 1;
+  min-width: 0;
+
+  .setting-label {
+    display: block;
+    font-weight: settings.$settings-section-title-weight;
+    color: var(--p-text-color);
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .setting-label-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+    flex-wrap: wrap;
+
+    .setting-label {
+      margin-bottom: 0;
+      flex-shrink: 0;
+      min-width: 180px;
+    }
+  }
+
+  .setting-description {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    color: var(--p-text-muted-color);
+    font-size: settings.$settings-section-description-size;
+    line-height: 1.5;
+    margin: 0;
+
+    .pi {
+      color: var(--p-primary-color);
+      margin-top: 0.125rem;
+      flex-shrink: 0;
+    }
+  }
+}
+
+.slider-container {
+  flex: 1;
+  min-width: 200px;
+  max-width: 300px;
+
+  @media (max-width: 768px) {
+    min-width: 180px;
+    max-width: 250px;
+  }
+}

--- a/booklore-ui/src/app/features/settings/view-preferences-parent/view-preferences-parent.component.ts
+++ b/booklore-ui/src/app/features/settings/view-preferences-parent/view-preferences-parent.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject, OnInit} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {TableModule} from 'primeng/table';
 import {ToastModule} from 'primeng/toast';
@@ -6,7 +6,10 @@ import {ViewPreferencesComponent} from './view-preferences/view-preferences.comp
 import {SidebarSortingPreferencesComponent} from './sidebar-sorting-preferences/sidebar-sorting-preferences.component';
 import {MetaCenterViewModeComponent} from './meta-center-view-mode/meta-center-view-mode-component';
 import {FilterPreferencesComponent} from './filter-preferences/filter-preferences.component';
-import {TranslocoDirective} from '@jsverse/transloco';
+import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
+import {Slider} from 'primeng/slider';
+import {MessageService} from 'primeng/api';
+import {LocalStorageService} from '../../../shared/service/local-storage.service';
 
 @Component({
   selector: 'app-view-preferences-parent',
@@ -20,10 +23,33 @@ import {TranslocoDirective} from '@jsverse/transloco';
     MetaCenterViewModeComponent,
     FilterPreferencesComponent,
     TranslocoDirective,
+    Slider,
   ],
   templateUrl: './view-preferences-parent.component.html',
   styleUrl: './view-preferences-parent.component.scss'
 })
-export class ViewPreferencesParentComponent {
+export class ViewPreferencesParentComponent implements OnInit {
 
+  sidebarWidth = 225;
+
+  private localStorageService = inject(LocalStorageService);
+  private messageService = inject(MessageService);
+  private t = inject(TranslocoService);
+
+  ngOnInit(): void {
+    this.sidebarWidth = this.localStorageService.get<number>('sidebarWidth') ?? 225;
+  }
+
+  onSidebarWidthChange(): void {
+    document.documentElement.style.setProperty('--sidebar-width', this.sidebarWidth + 'px');
+  }
+
+  saveSidebarWidth(): void {
+    this.localStorageService.set('sidebarWidth', this.sidebarWidth);
+    this.messageService.add({
+      severity: 'success',
+      summary: this.t.translate('settingsView.layout.saved'),
+      detail: this.t.translate('settingsView.layout.savedDetail')
+    });
+  }
 }

--- a/booklore-ui/src/app/shared/layout/component/layout-main/app.layout.component.html
+++ b/booklore-ui/src/app/shared/layout/component/layout-main/app.layout.component.html
@@ -1,6 +1,6 @@
 <div class="layout-wrapper" [ngClass]="containerClass">
   <app-topbar></app-topbar>
-  <div class="layout-sidebar layout-sidebar-custom">
+  <div class="layout-sidebar">
     <app-sidebar></app-sidebar>
   </div>
   <div class="layout-main-container">

--- a/booklore-ui/src/app/shared/layout/component/layout-main/app.layout.component.ts
+++ b/booklore-ui/src/app/shared/layout/component/layout-main/app.layout.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, Renderer2, ViewChild} from '@angular/core';
+import {Component, OnDestroy, OnInit, Renderer2, ViewChild} from '@angular/core';
 import {NavigationEnd, Router, RouterOutlet} from '@angular/router';
 import {filter, Subscription} from 'rxjs';
 import {LayoutService} from "./service/app.layout.service";
@@ -6,6 +6,7 @@ import {AppSidebarComponent} from "../layout-sidebar/app.sidebar.component";
 import {AppTopBarComponent} from '../layout-topbar/app.topbar.component';
 import {NgClass} from '@angular/common';
 import {ToastModule} from 'primeng/toast';
+import {LocalStorageService} from '../../../service/local-storage.service';
 
 @Component({
   selector: 'app-layout',
@@ -18,7 +19,7 @@ import {ToastModule} from 'primeng/toast';
   ],
   templateUrl: './app.layout.component.html'
 })
-export class AppLayoutComponent implements OnDestroy {
+export class AppLayoutComponent implements OnInit, OnDestroy {
 
   overlayMenuOpenSubscription: Subscription;
 
@@ -30,7 +31,7 @@ export class AppLayoutComponent implements OnDestroy {
 
   @ViewChild(AppTopBarComponent) appTopbar!: AppTopBarComponent;
 
-  constructor(public layoutService: LayoutService, public renderer: Renderer2, public router: Router) {
+  constructor(public layoutService: LayoutService, public renderer: Renderer2, public router: Router, private localStorageService: LocalStorageService) {
     this.overlayMenuOpenSubscription = this.layoutService.overlayOpen$.subscribe(() => {
       if (!this.menuOutsideClickListener) {
         this.menuOutsideClickListener = this.renderer.listen('document', 'click', (event) => {
@@ -50,6 +51,11 @@ export class AppLayoutComponent implements OnDestroy {
         this.hideMenu();
         this.hideProfileMenu();
       });
+  }
+
+  ngOnInit(): void {
+    const width = this.localStorageService.get<number>('sidebarWidth') ?? 225;
+    document.documentElement.style.setProperty('--sidebar-width', width + 'px');
   }
 
   isOutsideClicked(event: MouseEvent): boolean {

--- a/booklore-ui/src/app/shared/layout/component/layout-menu/app.menu.component.html
+++ b/booklore-ui/src/app/shared/layout/component/layout-menu/app.menu.component.html
@@ -1,15 +1,32 @@
 <ng-container *transloco="let t; prefix: 'layout.menu'">
 <div class="menu-container">
   <div>
-    <ul class="layout-menu">
-      @if (homeMenu$ | async; as homeMenu) {
-        @for (item of homeMenu; track item.label; let i = $index) {
-          @if (!item.separator) {
-            <li app-menuitem [item]="item" [index]="i" [root]="true" menuKey="home"></li>
+    <div class="home-menu-section">
+      <ul class="layout-menu">
+        @if (homeMenu$ | async; as homeMenu) {
+          @for (item of homeMenu; track item.label; let i = $index) {
+            @if (!item.separator) {
+              <li app-menuitem [item]="item" [index]="i" [root]="true" menuKey="home"></li>
+            }
           }
         }
-      }
-    </ul>
+      </ul>
+      <i class="pi pi-objects-column sidebar-width-btn"
+         (click)="widthPanel.toggle($event)"></i>
+      <p-popover #widthPanel appendTo="body">
+        <div class="sidebar-width-popover">
+          <label class="sidebar-width-popover-label">{{ sidebarWidth }}px</label>
+          <p-slider
+            [(ngModel)]="sidebarWidth"
+            [min]="175"
+            [max]="400"
+            [step]="1"
+            (onChange)="onSidebarWidthChange()"
+            (onSlideEnd)="saveSidebarWidth()">
+          </p-slider>
+        </div>
+      </p-popover>
+    </div>
 
     <ul class="layout-menu">
       @if (libraryMenu$ | async; as libraryMenu) {

--- a/booklore-ui/src/app/shared/layout/component/layout-menu/app.menu.component.scss
+++ b/booklore-ui/src/app/shared/layout/component/layout-menu/app.menu.component.scss
@@ -4,6 +4,44 @@
   height: 100%;
 }
 
+.home-menu-section {
+  position: relative;
+
+  .sidebar-width-btn {
+    position: absolute;
+    top: 0.125rem;
+    right: 0.5rem;
+    font-size: 0.8rem;
+    color: var(--p-surface-500);
+    cursor: pointer;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: var(--p-primary-color);
+    }
+  }
+}
+
+.sidebar-width-popover {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 200px;
+  padding: 0.25rem;
+
+  .sidebar-width-popover-label {
+    font-size: 0.8rem;
+    color: var(--p-text-muted-color);
+    white-space: nowrap;
+    min-width: 38px;
+    text-align: right;
+  }
+
+  p-slider {
+    flex: 1;
+  }
+}
+
 .version-info {
   padding: 1rem;
   text-align: center;

--- a/booklore-ui/src/app/shared/layout/component/layout-menu/app.menu.component.ts
+++ b/booklore-ui/src/app/shared/layout/component/layout-menu/app.menu.component.ts
@@ -15,11 +15,15 @@ import {MagicShelfService, MagicShelfState} from '../../../../features/magic-she
 import {MenuItem} from 'primeng/api';
 import {DialogLauncherService} from '../../../services/dialog-launcher.service';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
+import {Slider} from 'primeng/slider';
+import {FormsModule} from '@angular/forms';
+import {Popover} from 'primeng/popover';
+import {LocalStorageService} from '../../../service/local-storage.service';
 
 @Component({
   selector: 'app-menu',
   standalone: true,
-  imports: [AppMenuitemComponent, MenuModule, AsyncPipe, TranslocoDirective],
+  imports: [AppMenuitemComponent, MenuModule, AsyncPipe, TranslocoDirective, Slider, FormsModule, Popover],
   templateUrl: './app.menu.component.html',
   styleUrl: './app.menu.component.scss',
 })
@@ -41,6 +45,7 @@ export class AppMenuComponent implements OnInit {
   private userService = inject(UserService);
   private magicShelfService = inject(MagicShelfService);
   private t = inject(TranslocoService);
+  private localStorageService = inject(LocalStorageService);
 
   librarySortField: 'name' | 'id' = 'name';
   librarySortOrder: 'asc' | 'desc' = 'desc';
@@ -48,9 +53,12 @@ export class AppMenuComponent implements OnInit {
   shelfSortOrder: 'asc' | 'desc' = 'asc';
   magicShelfSortField: 'name' | 'id' = 'name';
   magicShelfSortOrder: 'asc' | 'desc' = 'asc';
+  sidebarWidth = 225;
 
 
   ngOnInit(): void {
+    this.sidebarWidth = this.localStorageService.get<number>('sidebarWidth') ?? 225;
+
     this.versionService.getVersion().subscribe((data) => {
       this.versionInfo = data;
     });
@@ -99,6 +107,14 @@ export class AppMenuComponent implements OnInit {
         },
       ])
     );
+  }
+
+  onSidebarWidthChange(): void {
+    document.documentElement.style.setProperty('--sidebar-width', this.sidebarWidth + 'px');
+  }
+
+  saveSidebarWidth(): void {
+    this.localStorageService.set('sidebarWidth', this.sidebarWidth);
   }
 
   private initMenus(): void {

--- a/booklore-ui/src/app/shared/layout/component/layout-menu/app.menuitem.component.scss
+++ b/booklore-ui/src/app/shared/layout/component/layout-menu/app.menuitem.component.scss
@@ -72,6 +72,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   margin-left: 0.35rem;
+  font-size: 0.985rem;
 }
 
 .menu-item-end-content {

--- a/booklore-ui/src/app/shared/layout/component/layout-sidebar/app.sidebar.component.scss
+++ b/booklore-ui/src/app/shared/layout/component/layout-sidebar/app.sidebar.component.scss
@@ -1,3 +1,0 @@
-.layout-sidebar-custom {
-  width: 250px !important;
-}

--- a/booklore-ui/src/assets/layout/styles/layout/_menu.scss
+++ b/booklore-ui/src/assets/layout/styles/layout/_menu.scss
@@ -3,7 +3,7 @@
 
 .layout-sidebar {
   position: fixed;
-  width: 225px;
+  width: var(--sidebar-width, 225px);
   height: calc(100dvh - 6.1rem);
   z-index: 999;
   overflow-y: auto;

--- a/booklore-ui/src/assets/layout/styles/layout/_responsive.scss
+++ b/booklore-ui/src/assets/layout/styles/layout/_responsive.scss
@@ -35,7 +35,7 @@
 
     &.layout-static {
       .layout-main-container {
-        padding-left: 255px;
+        padding-left: calc(var(--sidebar-width, 225px) + 30px);
         box-sizing: border-box;
       }
 

--- a/booklore-ui/src/i18n/en/settings-view.json
+++ b/booklore-ui/src/i18n/en/settings-view.json
@@ -114,5 +114,12 @@
     "prefsUpdated": "Preferences Updated",
     "metaCenterSaved": "Your metadata center view preference has been saved.",
     "seriesViewSaved": "Your series view mode preference has been saved."
+  },
+  "layout": {
+    "sectionTitle": "Layout",
+    "sidebarWidth": "Sidebar Width: {{value}}px",
+    "sidebarWidthDesc": "Controls the width of the navigation sidebar and the book filter panel.",
+    "saved": "Preferences Updated",
+    "savedDetail": "Your sidebar width preference has been saved."
   }
 }

--- a/booklore-ui/src/i18n/es/settings-view.json
+++ b/booklore-ui/src/i18n/es/settings-view.json
@@ -114,5 +114,12 @@
     "prefsUpdated": "Preferencias actualizadas",
     "metaCenterSaved": "Tu preferencia de vista del centro de metadatos se ha guardado.",
     "seriesViewSaved": "Tu preferencia de modo de vista de series se ha guardado."
+  },
+  "layout": {
+    "sectionTitle": "Diseño",
+    "sidebarWidth": "Ancho de la barra lateral: {{value}}px",
+    "sidebarWidthDesc": "Controla el ancho de la barra de navegación lateral y del panel de filtros de libros.",
+    "saved": "Preferencias actualizadas",
+    "savedDetail": "Tu preferencia de ancho de la barra lateral se ha guardado."
   }
 }


### PR DESCRIPTION
Adds a sidebar width slider to the app settings (175px to 400px). The width applies to both the nav sidebar and the book filter panel through a CSS custom property. Also cleaned up some dead CSS that was never actually being applied.