### PR TITLE
feat: add grouped field dropdown and composite fields to magic shelf

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/dto/RuleField.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/RuleField.java
@@ -70,6 +70,32 @@ public enum RuleField {
     @JsonProperty("ageRating")
     AGE_RATING,
     @JsonProperty("contentRating")
-    CONTENT_RATING
+    CONTENT_RATING,
+    @JsonProperty("addedOn")
+    ADDED_ON,
+    @JsonProperty("lubimyczytacRating")
+    LUBIMYCZYTAC_RATING,
+    @JsonProperty("description")
+    DESCRIPTION,
+    @JsonProperty("narrator")
+    NARRATOR,
+    @JsonProperty("audibleRating")
+    AUDIBLE_RATING,
+    @JsonProperty("audibleReviewCount")
+    AUDIBLE_REVIEW_COUNT,
+    @JsonProperty("abridged")
+    ABRIDGED,
+    @JsonProperty("audiobookDuration")
+    AUDIOBOOK_DURATION,
+    @JsonProperty("isPhysical")
+    IS_PHYSICAL,
+    @JsonProperty("seriesStatus")
+    SERIES_STATUS,
+    @JsonProperty("seriesGaps")
+    SERIES_GAPS,
+    @JsonProperty("seriesPosition")
+    SERIES_POSITION,
+    @JsonProperty("readingProgress")
+    READING_PROGRESS
 }
 

--- a/booklore-api/src/main/java/org/booklore/model/dto/RuleOperator.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/RuleOperator.java
@@ -34,5 +34,11 @@ public enum RuleOperator {
     @JsonProperty("excludes_all")
     EXCLUDES_ALL,
     @JsonProperty("includes_all")
-    INCLUDES_ALL
+    INCLUDES_ALL,
+    @JsonProperty("within_last")
+    WITHIN_LAST,
+    @JsonProperty("older_than")
+    OLDER_THAN,
+    @JsonProperty("this_period")
+    THIS_PERIOD
 }

--- a/booklore-api/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
+++ b/booklore-api/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.booklore.model.dto.GroupRule;
 import org.booklore.model.dto.Rule;
 import org.booklore.model.dto.RuleField;
+import org.booklore.model.dto.RuleOperator;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.UserBookProgressEntity;
 import org.springframework.data.jpa.domain.Specification;
@@ -13,10 +14,9 @@ import org.springframework.stereotype.Service;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -28,22 +28,26 @@ public class BookRuleEvaluatorService {
 
     private final ObjectMapper objectMapper;
 
+    private static final Set<RuleField> COMPOSITE_FIELDS = Set.of(
+            RuleField.SERIES_STATUS, RuleField.SERIES_GAPS, RuleField.SERIES_POSITION
+    );
+
     public Specification<BookEntity> toSpecification(GroupRule groupRule, Long userId) {
         return (root, query, cb) -> {
             Join<BookEntity, UserBookProgressEntity> progressJoin = root.join("userBookProgress", JoinType.LEFT);
 
             Predicate userPredicate = cb.or(
-                cb.isNull(progressJoin.get("user").get("id")),
-                cb.equal(progressJoin.get("user").get("id"), userId)
+                    cb.isNull(progressJoin.get("user").get("id")),
+                    cb.equal(progressJoin.get("user").get("id"), userId)
             );
 
-            Predicate rulePredicate = buildPredicate(groupRule, cb, root, progressJoin);
+            Predicate rulePredicate = buildPredicate(groupRule, query, cb, root, progressJoin, userId);
 
             return cb.and(userPredicate, rulePredicate);
         };
     }
 
-    private Predicate buildPredicate(GroupRule group, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
+    private Predicate buildPredicate(GroupRule group, CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin, Long userId) {
         if (group.getRules() == null || group.getRules().isEmpty()) {
             return cb.conjunction();
         }
@@ -59,11 +63,11 @@ public class BookRuleEvaluatorService {
 
             if ("group".equals(type)) {
                 GroupRule subGroup = objectMapper.convertValue(ruleObj, GroupRule.class);
-                predicates.add(buildPredicate(subGroup, cb, root, progressJoin));
+                predicates.add(buildPredicate(subGroup, query, cb, root, progressJoin, userId));
             } else {
                 try {
                     Rule rule = objectMapper.convertValue(ruleObj, Rule.class);
-                    Predicate rulePredicate = buildRulePredicate(rule, cb, root, progressJoin);
+                    Predicate rulePredicate = buildRulePredicate(rule, query, cb, root, progressJoin, userId);
                     if (rulePredicate != null) {
                         predicates.add(rulePredicate);
                     }
@@ -82,8 +86,12 @@ public class BookRuleEvaluatorService {
                 : cb.or(predicates.toArray(new Predicate[0]));
     }
 
-    private Predicate buildRulePredicate(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
+    private Predicate buildRulePredicate(Rule rule, CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin, Long userId) {
         if (rule.getField() == null || rule.getOperator() == null) return null;
+
+        if (COMPOSITE_FIELDS.contains(rule.getField())) {
+            return buildCompositeFieldPredicate(rule, query, cb, root, progressJoin, userId);
+        }
 
         return switch (rule.getOperator()) {
             case EQUALS -> buildEquals(rule, cb, root, progressJoin);
@@ -97,12 +105,303 @@ public class BookRuleEvaluatorService {
             case LESS_THAN -> buildLessThan(rule, cb, root, progressJoin);
             case LESS_THAN_EQUAL_TO -> buildLessThanEqual(rule, cb, root, progressJoin);
             case IN_BETWEEN -> buildInBetween(rule, cb, root, progressJoin);
-            case IS_EMPTY -> buildIsEmpty(rule, cb, root, progressJoin);
-            case IS_NOT_EMPTY -> cb.not(buildIsEmpty(rule, cb, root, progressJoin));
+            case IS_EMPTY -> buildIsEmpty(rule, query, cb, root, progressJoin);
+            case IS_NOT_EMPTY -> cb.not(buildIsEmpty(rule, query, cb, root, progressJoin));
             case INCLUDES_ANY -> buildIncludesAny(rule, cb, root, progressJoin);
             case EXCLUDES_ALL -> buildExcludesAll(rule, cb, root, progressJoin);
             case INCLUDES_ALL -> buildIncludesAll(rule, cb, root, progressJoin);
+            case WITHIN_LAST -> buildWithinLast(rule, cb, root, progressJoin);
+            case OLDER_THAN -> buildOlderThan(rule, cb, root, progressJoin);
+            case THIS_PERIOD -> buildThisPeriod(rule, cb, root, progressJoin);
         };
+    }
+
+    private Predicate buildWithinLast(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
+        Expression<?> field = getFieldExpression(rule.getField(), cb, root, progressJoin);
+        if (field == null) return cb.conjunction();
+
+        Instant threshold = computeRelativeDateThreshold(rule);
+        if (threshold == null) return cb.conjunction();
+
+        if (rule.getField() == RuleField.PUBLISHED_DATE) {
+            LocalDateTime ldt = threshold.atZone(ZoneId.systemDefault()).toLocalDateTime();
+            return cb.greaterThanOrEqualTo(field.as(LocalDateTime.class), ldt);
+        }
+        return cb.greaterThanOrEqualTo(field.as(Instant.class), threshold);
+    }
+
+    private Predicate buildOlderThan(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
+        Expression<?> field = getFieldExpression(rule.getField(), cb, root, progressJoin);
+        if (field == null) return cb.conjunction();
+
+        Instant threshold = computeRelativeDateThreshold(rule);
+        if (threshold == null) return cb.conjunction();
+
+        if (rule.getField() == RuleField.PUBLISHED_DATE) {
+            LocalDateTime ldt = threshold.atZone(ZoneId.systemDefault()).toLocalDateTime();
+            return cb.lessThan(field.as(LocalDateTime.class), ldt);
+        }
+        return cb.lessThan(field.as(Instant.class), threshold);
+    }
+
+    private Predicate buildThisPeriod(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
+        Expression<?> field = getFieldExpression(rule.getField(), cb, root, progressJoin);
+        if (field == null) return cb.conjunction();
+
+        String period = rule.getValue() != null ? rule.getValue().toString().toLowerCase() : "year";
+        LocalDate now = LocalDate.now();
+        LocalDate start = switch (period) {
+            case "week" -> now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+            case "month" -> now.withDayOfMonth(1);
+            default -> now.withDayOfYear(1);
+        };
+
+        Instant startInstant = start.atStartOfDay(ZoneId.systemDefault()).toInstant();
+
+        if (rule.getField() == RuleField.PUBLISHED_DATE) {
+            LocalDateTime ldt = startInstant.atZone(ZoneId.systemDefault()).toLocalDateTime();
+            return cb.greaterThanOrEqualTo(field.as(LocalDateTime.class), ldt);
+        }
+        return cb.greaterThanOrEqualTo(field.as(Instant.class), startInstant);
+    }
+
+    private Instant computeRelativeDateThreshold(Rule rule) {
+        if (rule.getValue() == null) return null;
+        int amount;
+        try {
+            amount = ((Number) rule.getValue()).intValue();
+        } catch (ClassCastException e) {
+            try {
+                amount = Integer.parseInt(rule.getValue().toString());
+            } catch (NumberFormatException ex) {
+                return null;
+            }
+        }
+        String unit = rule.getValueEnd() != null ? rule.getValueEnd().toString().toLowerCase() : "days";
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime threshold = switch (unit) {
+            case "weeks" -> now.minusWeeks(amount);
+            case "months" -> now.minusMonths(amount);
+            case "years" -> now.minusYears(amount);
+            default -> now.minusDays(amount);
+        };
+        return threshold.atZone(ZoneId.systemDefault()).toInstant();
+    }
+
+    private Predicate buildCompositeFieldPredicate(Rule rule, CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin, Long userId) {
+        boolean negate = rule.getOperator() == RuleOperator.NOT_EQUALS;
+        String value = rule.getValue() != null ? rule.getValue().toString().toLowerCase() : "";
+        Predicate hasSeries = cb.and(
+                cb.isNotNull(root.get("metadata").get("seriesName")),
+                cb.notEqual(cb.trim(root.get("metadata").get("seriesName").as(String.class)), "")
+        );
+
+        Predicate result = switch (rule.getField()) {
+            case SERIES_STATUS -> buildSeriesStatusPredicate(value, query, cb, root, hasSeries, userId);
+            case SERIES_GAPS -> buildSeriesGapsPredicate(value, query, cb, root, hasSeries);
+            case SERIES_POSITION -> buildSeriesPositionPredicate(value, query, cb, root, progressJoin, hasSeries, userId);
+            default -> cb.conjunction();
+        };
+
+        return negate ? cb.not(result) : result;
+    }
+
+    private Predicate buildSeriesStatusPredicate(String value, CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Predicate hasSeries, Long userId) {
+        Predicate condition = switch (value) {
+            case "reading" -> seriesHasReadStatus(query, cb, root, userId, List.of("READING", "RE_READING"));
+            case "not_started" -> cb.not(seriesHasReadStatus(query, cb, root, userId, List.of("READ", "READING", "RE_READING", "PARTIALLY_READ")));
+            case "fully_read" -> seriesAllRead(query, cb, root, userId);
+            case "completed" -> seriesOwnsLastBook(query, cb, root);
+            case "ongoing" -> cb.and(seriesHasTotal(query, cb, root), cb.not(seriesOwnsLastBook(query, cb, root)));
+            default -> cb.conjunction();
+        };
+        return cb.and(hasSeries, condition);
+    }
+
+    private Predicate seriesHasReadStatus(CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Long userId, List<String> statuses) {
+        Subquery<Long> sub = query.subquery(Long.class);
+        Root<BookEntity> subRoot = sub.from(BookEntity.class);
+        Join<Object, Object> subProgress = subRoot.join("userBookProgress", JoinType.INNER);
+
+        sub.select(cb.literal(1L)).where(
+                cb.equal(subRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.equal(subProgress.get("user").get("id"), userId),
+                subProgress.get("readStatus").as(String.class).in(statuses)
+        );
+        return cb.exists(sub);
+    }
+
+    private Predicate seriesAllRead(CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Long userId) {
+        Subquery<Long> notReadSub = query.subquery(Long.class);
+        Root<BookEntity> nrRoot = notReadSub.from(BookEntity.class);
+        Join<Object, Object> nrProgress = nrRoot.join("userBookProgress", JoinType.INNER);
+        notReadSub.select(cb.literal(1L)).where(
+                cb.equal(nrRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.equal(nrProgress.get("user").get("id"), userId),
+                cb.notEqual(nrProgress.get("readStatus").as(String.class), "READ")
+        );
+
+        return cb.and(
+                seriesHasReadStatus(query, cb, root, userId, List.of("READ")),
+                cb.not(cb.exists(notReadSub))
+        );
+    }
+
+    private Predicate seriesOwnsLastBook(CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root) {
+        Subquery<Integer> totalSub = query.subquery(Integer.class);
+        Root<BookEntity> totalRoot = totalSub.from(BookEntity.class);
+        totalSub.select(cb.max(totalRoot.get("metadata").get("seriesTotal"))).where(
+                cb.equal(totalRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.isNotNull(totalRoot.get("metadata").get("seriesTotal"))
+        );
+
+        Subquery<Long> existsSub = query.subquery(Long.class);
+        Root<BookEntity> subRoot = existsSub.from(BookEntity.class);
+        existsSub.select(cb.literal(1L)).where(
+                cb.equal(subRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.equal(
+                        cb.function("FLOOR", Integer.class, subRoot.get("metadata").get("seriesNumber")),
+                        totalSub
+                )
+        );
+        return cb.exists(existsSub);
+    }
+
+    private Predicate seriesHasTotal(CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root) {
+        Subquery<Long> sub = query.subquery(Long.class);
+        Root<BookEntity> subRoot = sub.from(BookEntity.class);
+        sub.select(cb.literal(1L)).where(
+                cb.equal(subRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.isNotNull(subRoot.get("metadata").get("seriesTotal"))
+        );
+        return cb.exists(sub);
+    }
+
+    private Predicate buildSeriesGapsPredicate(String value, CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Predicate hasSeries) {
+        Predicate condition = switch (value) {
+            case "any_gap" -> seriesHasAnyGap(query, cb, root);
+            case "missing_first" -> seriesMissingFirst(query, cb, root);
+            case "missing_latest" -> cb.and(seriesHasTotal(query, cb, root), cb.not(seriesOwnsLastBook(query, cb, root)));
+            case "duplicate_number" -> seriesHasDuplicateNumber(query, cb, root);
+            default -> cb.conjunction();
+        };
+        return cb.and(hasSeries, condition);
+    }
+
+    private Predicate seriesHasAnyGap(CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root) {
+        Subquery<Long> countSub = query.subquery(Long.class);
+        Root<BookEntity> cRoot = countSub.from(BookEntity.class);
+        countSub.select(cb.countDistinct(cb.function("FLOOR", Integer.class, cRoot.get("metadata").get("seriesNumber")))).where(
+                cb.equal(cRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.isNotNull(cRoot.get("metadata").get("seriesNumber"))
+        );
+
+        Subquery<Integer> maxSub = query.subquery(Integer.class);
+        Root<BookEntity> mRoot = maxSub.from(BookEntity.class);
+        maxSub.select(cb.max(cb.function("FLOOR", Integer.class, mRoot.get("metadata").get("seriesNumber")))).where(
+                cb.equal(mRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.isNotNull(mRoot.get("metadata").get("seriesNumber"))
+        );
+
+        return cb.lt(countSub, maxSub.as(Long.class));
+    }
+
+    private Predicate seriesMissingFirst(CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root) {
+        Subquery<Long> sub = query.subquery(Long.class);
+        Root<BookEntity> subRoot = sub.from(BookEntity.class);
+        sub.select(cb.literal(1L)).where(
+                cb.equal(subRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.equal(cb.function("FLOOR", Integer.class, subRoot.get("metadata").get("seriesNumber")), 1)
+        );
+        return cb.not(cb.exists(sub));
+    }
+
+    private Predicate seriesHasDuplicateNumber(CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root) {
+        Subquery<Long> totalSub = query.subquery(Long.class);
+        Root<BookEntity> tRoot = totalSub.from(BookEntity.class);
+        totalSub.select(cb.count(tRoot)).where(
+                cb.equal(tRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.isNotNull(tRoot.get("metadata").get("seriesNumber"))
+        );
+
+        Subquery<Long> distinctSub = query.subquery(Long.class);
+        Root<BookEntity> dRoot = distinctSub.from(BookEntity.class);
+        distinctSub.select(cb.countDistinct(dRoot.get("metadata").get("seriesNumber"))).where(
+                cb.equal(dRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.isNotNull(dRoot.get("metadata").get("seriesNumber"))
+        );
+
+        return cb.gt(totalSub, distinctSub);
+    }
+
+    private Predicate buildSeriesPositionPredicate(String value, CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin, Predicate hasSeries, Long userId) {
+        Predicate hasNumber = cb.isNotNull(root.get("metadata").get("seriesNumber"));
+        Predicate condition = switch (value) {
+            case "next_unread" -> isNextUnread(query, cb, root, progressJoin, userId);
+            case "first_in_series" -> isFirstInSeries(query, cb, root);
+            case "last_in_series" -> isLastInSeries(query, cb, root);
+            default -> cb.conjunction();
+        };
+        return cb.and(hasSeries, hasNumber, condition);
+    }
+
+    private Predicate isFirstInSeries(CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root) {
+        Subquery<Float> minSub = query.subquery(Float.class);
+        Root<BookEntity> mRoot = minSub.from(BookEntity.class);
+        minSub.select(cb.min(mRoot.get("metadata").get("seriesNumber"))).where(
+                cb.equal(mRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.isNotNull(mRoot.get("metadata").get("seriesNumber"))
+        );
+        return cb.equal(root.get("metadata").get("seriesNumber"), minSub);
+    }
+
+    private Predicate isLastInSeries(CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root) {
+        Subquery<Float> maxSub = query.subquery(Float.class);
+        Root<BookEntity> mRoot = maxSub.from(BookEntity.class);
+        maxSub.select(cb.max(mRoot.get("metadata").get("seriesNumber"))).where(
+                cb.equal(mRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.isNotNull(mRoot.get("metadata").get("seriesNumber"))
+        );
+        return cb.equal(root.get("metadata").get("seriesNumber"), maxSub);
+    }
+
+    private Predicate isNextUnread(CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin, Long userId) {
+        Predicate notRead = cb.or(
+                cb.isNull(progressJoin.get("readStatus")),
+                cb.notEqual(progressJoin.get("readStatus").as(String.class), "READ")
+        );
+
+        Subquery<Long> lowerUnreadSub = query.subquery(Long.class);
+        Root<BookEntity> luRoot = lowerUnreadSub.from(BookEntity.class);
+        Join<Object, Object> luProgress = luRoot.join("userBookProgress", JoinType.LEFT);
+        lowerUnreadSub.select(cb.literal(1L)).where(
+                cb.equal(luRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.isNotNull(luRoot.get("metadata").get("seriesNumber")),
+                cb.lt(luRoot.get("metadata").get("seriesNumber"), root.get("metadata").get("seriesNumber")),
+                cb.or(
+                        cb.isNull(luProgress.get("readStatus")),
+                        cb.notEqual(luProgress.get("readStatus").as(String.class), "READ")
+                ),
+                cb.or(
+                        cb.isNull(luProgress.get("user").get("id")),
+                        cb.equal(luProgress.get("user").get("id"), userId)
+                )
+        );
+        Predicate noLowerUnread = cb.not(cb.exists(lowerUnreadSub));
+
+        Subquery<Long> priorReadSub = query.subquery(Long.class);
+        Root<BookEntity> prRoot = priorReadSub.from(BookEntity.class);
+        Join<Object, Object> prProgress = prRoot.join("userBookProgress", JoinType.INNER);
+        priorReadSub.select(cb.literal(1L)).where(
+                cb.equal(prRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
+                cb.isNotNull(prRoot.get("metadata").get("seriesNumber")),
+                cb.lt(prRoot.get("metadata").get("seriesNumber"), root.get("metadata").get("seriesNumber")),
+                cb.equal(prProgress.get("user").get("id"), userId),
+                cb.equal(prProgress.get("readStatus").as(String.class), "READ")
+        );
+        Predicate hasPriorRead = cb.exists(priorReadSub);
+
+        return cb.and(notRead, noLowerUnread, hasPriorRead);
     }
 
     private Predicate buildEquals(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
@@ -117,7 +416,9 @@ public class BookRuleEvaluatorService {
 
         Object value = normalizeValue(rule.getValue(), rule.getField());
 
-        if (value instanceof LocalDateTime) {
+        if (value instanceof Boolean) {
+            return cb.equal(field, value);
+        } else if (value instanceof LocalDateTime) {
             return cb.equal(field, value);
         } else if (rule.getField() == RuleField.READ_STATUS) {
             if ("UNSET".equals(value.toString())) {
@@ -137,25 +438,25 @@ public class BookRuleEvaluatorService {
     private Predicate buildContains(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         String ruleVal = rule.getValue().toString().toLowerCase();
         return buildStringPredicate(rule.getField(), root, progressJoin, cb,
-            nameField -> cb.like(cb.lower(nameField), "%" + escapeLike(ruleVal) + "%"));
+                nameField -> cb.like(cb.lower(nameField), "%" + escapeLike(ruleVal) + "%"));
     }
 
     private Predicate buildStartsWith(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         String ruleVal = rule.getValue().toString().toLowerCase();
         return buildStringPredicate(rule.getField(), root, progressJoin, cb,
-            nameField -> cb.like(cb.lower(nameField), escapeLike(ruleVal) + "%"));
+                nameField -> cb.like(cb.lower(nameField), escapeLike(ruleVal) + "%"));
     }
 
     private Predicate buildEndsWith(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         String ruleVal = rule.getValue().toString().toLowerCase();
         return buildStringPredicate(rule.getField(), root, progressJoin, cb,
-            nameField -> cb.like(cb.lower(nameField), "%" + escapeLike(ruleVal)));
+                nameField -> cb.like(cb.lower(nameField), "%" + escapeLike(ruleVal)));
     }
 
     private Predicate buildStringPredicate(RuleField field, Root<BookEntity> root,
-                                          Join<BookEntity, UserBookProgressEntity> progressJoin,
-                                          CriteriaBuilder cb,
-                                          java.util.function.Function<Expression<String>, Predicate> predicateBuilder) {
+                                           Join<BookEntity, UserBookProgressEntity> progressJoin,
+                                           CriteriaBuilder cb,
+                                           java.util.function.Function<Expression<String>, Predicate> predicateBuilder) {
         if (isArrayField(field)) {
             Join<?, ?> arrayJoin = createArrayFieldJoin(field, root);
             Expression<String> nameField = getArrayFieldNameExpression(field, arrayJoin);
@@ -170,32 +471,32 @@ public class BookRuleEvaluatorService {
 
     private Predicate buildGreaterThan(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         return buildComparisonPredicate(rule, cb, root, progressJoin,
-            (field, dateValue) -> cb.greaterThan(field.as(LocalDateTime.class), dateValue),
-            (field, numValue) -> cb.gt(field.as(Number.class), numValue));
+                (field, dateValue) -> cb.greaterThan(field.as(LocalDateTime.class), dateValue),
+                (field, numValue) -> cb.gt(field.as(Double.class), numValue));
     }
 
     private Predicate buildGreaterThanEqual(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         return buildComparisonPredicate(rule, cb, root, progressJoin,
-            (field, dateValue) -> cb.greaterThanOrEqualTo(field.as(LocalDateTime.class), dateValue),
-            (field, numValue) -> cb.ge(field.as(Number.class), numValue));
+                (field, dateValue) -> cb.greaterThanOrEqualTo(field.as(LocalDateTime.class), dateValue),
+                (field, numValue) -> cb.ge(field.as(Double.class), numValue));
     }
 
     private Predicate buildLessThan(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         return buildComparisonPredicate(rule, cb, root, progressJoin,
-            (field, dateValue) -> cb.lessThan(field.as(LocalDateTime.class), dateValue),
-            (field, numValue) -> cb.lt(field.as(Number.class), numValue));
+                (field, dateValue) -> cb.lessThan(field.as(LocalDateTime.class), dateValue),
+                (field, numValue) -> cb.lt(field.as(Double.class), numValue));
     }
 
     private Predicate buildLessThanEqual(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         return buildComparisonPredicate(rule, cb, root, progressJoin,
-            (field, dateValue) -> cb.lessThanOrEqualTo(field.as(LocalDateTime.class), dateValue),
-            (field, numValue) -> cb.le(field.as(Number.class), numValue));
+                (field, dateValue) -> cb.lessThanOrEqualTo(field.as(LocalDateTime.class), dateValue),
+                (field, numValue) -> cb.le(field.as(Double.class), numValue));
     }
 
     private Predicate buildComparisonPredicate(Rule rule, CriteriaBuilder cb, Root<BookEntity> root,
-                                              Join<BookEntity, UserBookProgressEntity> progressJoin,
-                                              BiFunction<Expression<?>, LocalDateTime, Predicate> dateComparator,
-                                              BiFunction<Expression<?>, Double, Predicate> numberComparator) {
+                                               Join<BookEntity, UserBookProgressEntity> progressJoin,
+                                               BiFunction<Expression<?>, LocalDateTime, Predicate> dateComparator,
+                                               BiFunction<Expression<?>, Double, Predicate> numberComparator) {
         Expression<?> field = getFieldExpression(rule.getField(), cb, root, progressJoin);
         if (field == null) return cb.conjunction();
 
@@ -227,9 +528,9 @@ public class BookRuleEvaluatorService {
         return cb.between(field.as(Double.class), ((Number) start).doubleValue(), ((Number) end).doubleValue());
     }
 
-    private Predicate buildIsEmpty(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
+    private Predicate buildIsEmpty(Rule rule, CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         if (isArrayField(rule.getField())) {
-            Subquery<Long> subquery = cb.createQuery().subquery(Long.class);
+            Subquery<Long> subquery = query.subquery(Long.class);
             Root<BookEntity> subRoot = subquery.from(BookEntity.class);
 
             if (rule.getField() == RuleField.SHELF) {
@@ -281,10 +582,10 @@ public class BookRuleEvaluatorService {
     }
 
     private Predicate buildFieldInPredicate(RuleField ruleField,
-                                           java.util.function.Function<Expression<?>, Expression<?>> fieldTransformer,
-                                           List<String> ruleList,
-                                           CriteriaBuilder cb,
-                                           Join<BookEntity, UserBookProgressEntity> progressJoin) {
+                                            java.util.function.Function<Expression<?>, Expression<?>> fieldTransformer,
+                                            List<String> ruleList,
+                                            CriteriaBuilder cb,
+                                            Join<BookEntity, UserBookProgressEntity> progressJoin) {
         Expression<?> field = fieldTransformer.apply(getFieldExpression(ruleField, cb, null, progressJoin));
         if (field == null) return cb.conjunction();
 
@@ -296,8 +597,8 @@ public class BookRuleEvaluatorService {
 
             if (hasUnset && !nonUnsetValues.isEmpty()) {
                 return cb.or(
-                    cb.isNull(field),
-                    field.as(String.class).in(nonUnsetValues)
+                        cb.isNull(field),
+                        field.as(String.class).in(nonUnsetValues)
                 );
             } else if (hasUnset) {
                 return cb.isNull(field);
@@ -313,7 +614,7 @@ public class BookRuleEvaluatorService {
     private Expression<?> getFieldExpression(RuleField field, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         return switch (field) {
             case LIBRARY -> root.get("library").get("id");
-            case SHELF -> null; // Shelf is handled specially as a join field
+            case SHELF -> null;
             case READ_STATUS -> progressJoin.get("readStatus");
             case DATE_FINISHED -> progressJoin.get("dateFinished");
             case LAST_READ_TIME -> progressJoin.get("lastReadTime");
@@ -340,6 +641,23 @@ public class BookRuleEvaluatorService {
             case RANOBEDB_RATING -> root.get("metadata").get("ranobedbRating");
             case AGE_RATING -> root.get("metadata").get("ageRating");
             case CONTENT_RATING -> root.get("metadata").get("contentRating");
+            case ADDED_ON -> root.get("addedOn");
+            case LUBIMYCZYTAC_RATING -> root.get("metadata").get("lubimyczytacRating");
+            case DESCRIPTION -> root.get("metadata").get("description");
+            case NARRATOR -> root.get("metadata").get("narrator");
+            case AUDIBLE_RATING -> root.get("metadata").get("audibleRating");
+            case AUDIBLE_REVIEW_COUNT -> root.get("metadata").get("audibleReviewCount");
+            case ABRIDGED -> root.get("metadata").get("abridged");
+            case AUDIOBOOK_DURATION -> root.join("bookFiles", JoinType.LEFT).get("durationSeconds");
+            case IS_PHYSICAL -> root.get("isPhysical");
+            case READING_PROGRESS -> {
+                Expression<Float> koreader = cb.coalesce(progressJoin.get("koreaderProgressPercent"), 0f);
+                Expression<Float> kobo = cb.coalesce(progressJoin.get("koboProgressPercent"), 0f);
+                Expression<Float> pdf = cb.coalesce(progressJoin.get("pdfProgressPercent"), 0f);
+                Expression<Float> epub = cb.coalesce(progressJoin.get("epubProgressPercent"), 0f);
+                Expression<Float> cbx = cb.coalesce(progressJoin.get("cbxProgressPercent"), 0f);
+                yield cb.function("GREATEST", Float.class, koreader, kobo, pdf, epub, cbx);
+            }
             case FILE_TYPE -> cb.function("SUBSTRING_INDEX", String.class,
                     root.get("fileName"), cb.literal("."), cb.literal(-1));
             default -> null;
@@ -348,8 +666,8 @@ public class BookRuleEvaluatorService {
 
     private boolean isArrayField(RuleField field) {
         return field == RuleField.AUTHORS || field == RuleField.CATEGORIES ||
-               field == RuleField.MOODS || field == RuleField.TAGS ||
-               field == RuleField.GENRE || field == RuleField.SHELF;
+                field == RuleField.MOODS || field == RuleField.TAGS ||
+                field == RuleField.GENRE || field == RuleField.SHELF;
     }
 
     private Join<?, ?> createArrayFieldJoin(RuleField field, Root<BookEntity> root) {
@@ -411,7 +729,7 @@ public class BookRuleEvaluatorService {
             return parseDate(value);
         }
 
-        if (field == RuleField.DATE_FINISHED || field == RuleField.LAST_READ_TIME) {
+        if (field == RuleField.DATE_FINISHED || field == RuleField.LAST_READ_TIME || field == RuleField.ADDED_ON) {
             LocalDateTime parsed = parseDate(value);
             if (parsed != null) {
                 return parsed.atZone(ZoneId.systemDefault()).toInstant();
@@ -421,6 +739,10 @@ public class BookRuleEvaluatorService {
 
         if (field == RuleField.READ_STATUS) {
             return value.toString();
+        }
+
+        if (field == RuleField.ABRIDGED || field == RuleField.IS_PHYSICAL) {
+            return Boolean.valueOf(value.toString());
         }
 
         if (value instanceof Number) {
@@ -458,7 +780,7 @@ public class BookRuleEvaluatorService {
 
     private String escapeLike(String value) {
         return value.replace("\\", "\\\\")
-                   .replace("%", "\\%")
-                   .replace("_", "\\_");
+                .replace("%", "\\%")
+                .replace("_", "\\_");
     }
 }

--- a/booklore-api/src/test/java/org/booklore/service/BookRuleEvaluatorServiceIntegrationTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/BookRuleEvaluatorServiceIntegrationTest.java
@@ -1,0 +1,1532 @@
+package org.booklore.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.booklore.model.dto.*;
+import org.booklore.model.entity.*;
+import org.booklore.model.enums.ReadStatus;
+import org.booklore.repository.BookRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = {org.booklore.BookloreApplication.class})
+@Transactional
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.datasource.url=jdbc:h2:mem:ruleeval;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "app.path-config=build/tmp/test-config",
+        "app.bookdrop-folder=build/tmp/test-bookdrop",
+        "spring.main.allow-bean-definition-overriding=true",
+        "spring.task.scheduling.enabled=false",
+        "app.task.scan-library-cron=*/1 * * * * *",
+        "app.task.process-bookdrop-cron=*/1 * * * * *",
+        "app.features.oidc-enabled=false"
+})
+@Import(BookRuleEvaluatorServiceIntegrationTest.TestConfig.class)
+class BookRuleEvaluatorServiceIntegrationTest {
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean("flyway")
+        @Primary
+        public org.flywaydb.core.Flyway flyway() {
+            return org.mockito.Mockito.mock(org.flywaydb.core.Flyway.class);
+        }
+
+        @Bean
+        @Primary
+        public org.booklore.service.task.TaskCronService taskCronService() {
+            return org.mockito.Mockito.mock(org.booklore.service.task.TaskCronService.class);
+        }
+    }
+
+    @Autowired
+    private BookRuleEvaluatorService evaluator;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private LibraryEntity library;
+    private LibraryPathEntity libraryPath;
+    private BookLoreUserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        library = LibraryEntity.builder().name("Test Library").icon("book").watch(false).build();
+        em.persist(library);
+        em.flush();
+
+        libraryPath = LibraryPathEntity.builder().library(library).path("/test/path").build();
+        em.persist(libraryPath);
+        em.flush();
+
+        user = BookLoreUserEntity.builder()
+                .username("testuser")
+                .passwordHash("hash")
+                .isDefaultPassword(true)
+                .name("Test User")
+                .build();
+        em.persist(user);
+        em.flush();
+    }
+
+    private BookEntity createBook(String title) {
+        return createBook(title, null, null, null);
+    }
+
+    private BookEntity createBook(String title, String seriesName, Float seriesNumber, Integer seriesTotal) {
+        BookEntity book = BookEntity.builder()
+                .library(library)
+                .libraryPath(libraryPath)
+                .addedOn(Instant.now())
+                .deleted(false)
+                .build();
+        em.persist(book);
+        em.flush();
+
+        BookMetadataEntity metadata = BookMetadataEntity.builder()
+                .book(book)
+                .bookId(book.getId())
+                .title(title)
+                .seriesName(seriesName)
+                .seriesNumber(seriesNumber)
+                .seriesTotal(seriesTotal)
+                .build();
+        em.persist(metadata);
+        em.flush();
+
+        book.setMetadata(metadata);
+        return book;
+    }
+
+    private UserBookProgressEntity createProgress(BookEntity book, ReadStatus status) {
+        return createProgress(book, status, null, null);
+    }
+
+    private UserBookProgressEntity createProgress(BookEntity book, ReadStatus status, Float koreaderPercent, Instant dateFinished) {
+        UserBookProgressEntity progress = UserBookProgressEntity.builder()
+                .user(user)
+                .book(book)
+                .readStatus(status)
+                .koreaderProgressPercent(koreaderPercent)
+                .dateFinished(dateFinished)
+                .build();
+        em.persist(progress);
+        em.flush();
+        return progress;
+    }
+
+    private List<Long> findMatchingIds(GroupRule group) {
+        Specification<BookEntity> spec = evaluator.toSpecification(group, user.getId());
+        return bookRepository.findAll(spec).stream().map(BookEntity::getId).distinct().toList();
+    }
+
+    private GroupRule singleRule(RuleField field, RuleOperator operator, Object value) {
+        return singleRule(field, operator, value, null, null);
+    }
+
+    private GroupRule singleRule(RuleField field, RuleOperator operator, Object value, Object valueStart, Object valueEnd) {
+        Rule rule = new Rule();
+        rule.setField(field);
+        rule.setOperator(operator);
+        rule.setValue(value);
+        rule.setValueStart(valueStart);
+        rule.setValueEnd(valueEnd);
+        GroupRule group = new GroupRule();
+        group.setJoin(JoinType.AND);
+        group.setRules(List.of(rule));
+        return group;
+    }
+
+    @Nested
+    class ReadingProgressTests {
+        @Test
+        void greaterThan_matchesBookWithHighProgress() {
+            BookEntity book = createBook("High Progress Book");
+            createProgress(book, ReadStatus.READING, 75f, null);
+
+            BookEntity lowBook = createBook("Low Progress Book");
+            createProgress(lowBook, ReadStatus.READING, 20f, null);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.GREATER_THAN, 50));
+            assertThat(ids).contains(book.getId());
+            assertThat(ids).doesNotContain(lowBook.getId());
+        }
+
+        @Test
+        void lessThan_matchesBookWithLowProgress() {
+            BookEntity book = createBook("Low Progress Book");
+            createProgress(book, ReadStatus.READING, 20f, null);
+
+            BookEntity highBook = createBook("High Progress Book");
+            createProgress(highBook, ReadStatus.READING, 80f, null);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.LESS_THAN, 50));
+            assertThat(ids).contains(book.getId());
+            assertThat(ids).doesNotContain(highBook.getId());
+        }
+    }
+
+    @Nested
+    class RelativeDateTests {
+        @Test
+        void withinLast_matchesRecentBook() {
+            BookEntity recent = createBook("Recent Book");
+            recent.setAddedOn(Instant.now().minus(2, ChronoUnit.DAYS));
+            em.merge(recent);
+
+            BookEntity old = createBook("Old Book");
+            old.setAddedOn(Instant.now().minus(30, ChronoUnit.DAYS));
+            em.merge(old);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.WITHIN_LAST, 7, null, "days"));
+            assertThat(ids).contains(recent.getId());
+            assertThat(ids).doesNotContain(old.getId());
+        }
+
+        @Test
+        void olderThan_matchesOldBook() {
+            BookEntity old = createBook("Old Book");
+            old.setAddedOn(Instant.now().minus(60, ChronoUnit.DAYS));
+            em.merge(old);
+
+            BookEntity recent = createBook("Recent Book");
+            recent.setAddedOn(Instant.now().minus(2, ChronoUnit.DAYS));
+            em.merge(recent);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.OLDER_THAN, 30, null, "days"));
+            assertThat(ids).contains(old.getId());
+            assertThat(ids).doesNotContain(recent.getId());
+        }
+
+        @Test
+        void thisPeriod_year_matchesThisYearBook() {
+            BookEntity thisYear = createBook("This Year Book");
+            thisYear.setAddedOn(Instant.now().minus(10, ChronoUnit.DAYS));
+            em.merge(thisYear);
+
+            BookEntity lastYear = createBook("Last Year Book");
+            lastYear.setAddedOn(Instant.now().minus(400, ChronoUnit.DAYS));
+            em.merge(lastYear);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.THIS_PERIOD, "year"));
+            assertThat(ids).contains(thisYear.getId());
+            assertThat(ids).doesNotContain(lastYear.getId());
+        }
+
+        @Test
+        void withinLast_months_matchesRecentBook() {
+            BookEntity recent = createBook("Two Months Ago");
+            recent.setAddedOn(Instant.now().minus(50, ChronoUnit.DAYS));
+            em.merge(recent);
+
+            BookEntity old = createBook("Six Months Ago");
+            old.setAddedOn(Instant.now().minus(200, ChronoUnit.DAYS));
+            em.merge(old);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.WITHIN_LAST, 3, null, "months"));
+            assertThat(ids).contains(recent.getId());
+            assertThat(ids).doesNotContain(old.getId());
+        }
+    }
+
+    @Nested
+    class SeriesStatusTests {
+        @Test
+        void fullyRead_matchesSeriesWhereAllBooksRead() {
+            BookEntity b1 = createBook("FullRead S1", "FullRead Series", 1f, 2);
+            BookEntity b2 = createBook("FullRead S2", "FullRead Series", 2f, 2);
+            createProgress(b1, ReadStatus.READ);
+            createProgress(b2, ReadStatus.READ);
+
+            BookEntity u1 = createBook("Unread S1", "Unread Series", 1f, 2);
+            BookEntity u2 = createBook("Unread S2", "Unread Series", 2f, 2);
+            createProgress(u1, ReadStatus.UNREAD);
+            createProgress(u2, ReadStatus.UNREAD);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.EQUALS, "fully_read"));
+            assertThat(ids).contains(b1.getId(), b2.getId());
+            assertThat(ids).doesNotContain(u1.getId(), u2.getId());
+        }
+
+        @Test
+        void notStarted_matchesSeriesWithNoProgress() {
+            BookEntity u1 = createBook("NotStarted S1", "Fresh Series", 1f, 2);
+            BookEntity u2 = createBook("NotStarted S2", "Fresh Series", 2f, 2);
+            createProgress(u1, ReadStatus.UNREAD);
+            createProgress(u2, ReadStatus.UNREAD);
+
+            BookEntity r1 = createBook("Started S1", "Started Series", 1f, 2);
+            createProgress(r1, ReadStatus.READING);
+            BookEntity r2 = createBook("Started S2", "Started Series", 2f, 2);
+            createProgress(r2, ReadStatus.UNREAD);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.EQUALS, "not_started"));
+            assertThat(ids).contains(u1.getId(), u2.getId());
+            assertThat(ids).doesNotContain(r1.getId(), r2.getId());
+        }
+
+        @Test
+        void reading_matchesSeriesWithActiveReading() {
+            BookEntity b1 = createBook("Active S1", "Active Series", 1f, 3);
+            BookEntity b2 = createBook("Active S2", "Active Series", 2f, 3);
+            createProgress(b1, ReadStatus.READ);
+            createProgress(b2, ReadStatus.READING);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.EQUALS, "reading"));
+            assertThat(ids).contains(b1.getId(), b2.getId());
+        }
+
+        @Test
+        void completed_matchesSeriesOwningLastBook() {
+            BookEntity b1 = createBook("Complete S1", "Complete Series", 1f, 3);
+            BookEntity b3 = createBook("Complete S3", "Complete Series", 3f, 3);
+
+            BookEntity i1 = createBook("Incomplete S1", "Incomplete Series", 1f, 5);
+            BookEntity i2 = createBook("Incomplete S2", "Incomplete Series", 2f, 5);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.EQUALS, "completed"));
+            assertThat(ids).contains(b1.getId(), b3.getId());
+            assertThat(ids).doesNotContain(i1.getId(), i2.getId());
+        }
+    }
+
+    @Nested
+    class SeriesGapsTests {
+        @Test
+        void anyGap_matchesSeriesWithMissingNumbers() {
+            BookEntity g1 = createBook("Gap S1", "Gap Series", 1f, 4);
+            BookEntity g3 = createBook("Gap S3", "Gap Series", 3f, 4);
+
+            BookEntity n1 = createBook("NoGap S1", "NoGap Series", 1f, 2);
+            BookEntity n2 = createBook("NoGap S2", "NoGap Series", 2f, 2);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_GAPS, RuleOperator.EQUALS, "any_gap"));
+            assertThat(ids).contains(g1.getId(), g3.getId());
+            assertThat(ids).doesNotContain(n1.getId(), n2.getId());
+        }
+
+        @Test
+        void missingFirst_matchesSeriesWithoutBookOne() {
+            BookEntity m2 = createBook("MissFirst S2", "MissFirst Series", 2f, 3);
+            BookEntity m3 = createBook("MissFirst S3", "MissFirst Series", 3f, 3);
+
+            BookEntity h1 = createBook("HasFirst S1", "HasFirst Series", 1f, 2);
+            BookEntity h2 = createBook("HasFirst S2", "HasFirst Series", 2f, 2);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_GAPS, RuleOperator.EQUALS, "missing_first"));
+            assertThat(ids).contains(m2.getId(), m3.getId());
+            assertThat(ids).doesNotContain(h1.getId(), h2.getId());
+        }
+
+        @Test
+        void duplicateNumber_matchesSeriesWithDuplicates() {
+            BookEntity d1a = createBook("Dup S1a", "Dup Series", 1f, 3);
+            BookEntity d1b = createBook("Dup S1b", "Dup Series", 1f, 3);
+            BookEntity d2 = createBook("Dup S2", "Dup Series", 2f, 3);
+
+            BookEntity u1 = createBook("Unique S1", "Unique Series", 1f, 2);
+            BookEntity u2 = createBook("Unique S2", "Unique Series", 2f, 2);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_GAPS, RuleOperator.EQUALS, "duplicate_number"));
+            assertThat(ids).contains(d1a.getId(), d1b.getId(), d2.getId());
+            assertThat(ids).doesNotContain(u1.getId(), u2.getId());
+        }
+    }
+
+    @Nested
+    class SeriesPositionTests {
+        @Test
+        void firstInSeries_matchesLowestNumberedBook() {
+            BookEntity b1 = createBook("Pos S1", "Pos Series", 1f, 3);
+            BookEntity b2 = createBook("Pos S2", "Pos Series", 2f, 3);
+            BookEntity b3 = createBook("Pos S3", "Pos Series", 3f, 3);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_POSITION, RuleOperator.EQUALS, "first_in_series"));
+            assertThat(ids).contains(b1.getId());
+            assertThat(ids).doesNotContain(b2.getId(), b3.getId());
+        }
+
+        @Test
+        void lastInSeries_matchesHighestNumberedBook() {
+            BookEntity b1 = createBook("Last S1", "Last Series", 1f, 3);
+            BookEntity b2 = createBook("Last S2", "Last Series", 2f, 3);
+            BookEntity b3 = createBook("Last S3", "Last Series", 3f, 3);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_POSITION, RuleOperator.EQUALS, "last_in_series"));
+            assertThat(ids).contains(b3.getId());
+            assertThat(ids).doesNotContain(b1.getId(), b2.getId());
+        }
+
+        @Test
+        void nextUnread_matchesFirstUnreadAfterReadBook() {
+            BookEntity b1 = createBook("Next S1", "Next Series", 1f, 3);
+            BookEntity b2 = createBook("Next S2", "Next Series", 2f, 3);
+            BookEntity b3 = createBook("Next S3", "Next Series", 3f, 3);
+            createProgress(b1, ReadStatus.READ);
+            createProgress(b2, ReadStatus.UNREAD);
+            createProgress(b3, ReadStatus.UNREAD);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_POSITION, RuleOperator.EQUALS, "next_unread"));
+            assertThat(ids).contains(b2.getId());
+            assertThat(ids).doesNotContain(b1.getId(), b3.getId());
+        }
+    }
+
+    @Nested
+    class NegationTests {
+        @Test
+        void seriesStatus_notEquals_excludesMatching() {
+            BookEntity b1 = createBook("FullRead N1", "FullRead Neg", 1f, 2);
+            BookEntity b2 = createBook("FullRead N2", "FullRead Neg", 2f, 2);
+            createProgress(b1, ReadStatus.READ);
+            createProgress(b2, ReadStatus.READ);
+
+            BookEntity u1 = createBook("NotRead N1", "NotRead Neg", 1f, 2);
+            BookEntity u2 = createBook("NotRead N2", "NotRead Neg", 2f, 2);
+            createProgress(u1, ReadStatus.UNREAD);
+            createProgress(u2, ReadStatus.UNREAD);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.NOT_EQUALS, "fully_read"));
+            assertThat(ids).contains(u1.getId(), u2.getId());
+            assertThat(ids).doesNotContain(b1.getId(), b2.getId());
+        }
+    }
+
+    @Nested
+    class ReadingProgressEdgeCases {
+        @Test
+        void inBetween_matchesBooksInRange() {
+            BookEntity low = createBook("Low Progress");
+            createProgress(low, ReadStatus.READING, 10f, null);
+
+            BookEntity mid = createBook("Mid Progress");
+            createProgress(mid, ReadStatus.READING, 50f, null);
+
+            BookEntity high = createBook("High Progress");
+            createProgress(high, ReadStatus.READING, 90f, null);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.IN_BETWEEN, null, 30, 70));
+            assertThat(ids).contains(mid.getId());
+            assertThat(ids).doesNotContain(low.getId(), high.getId());
+        }
+
+        @Test
+        void equals_matchesExactProgress() {
+            BookEntity book = createBook("Exact Progress");
+            createProgress(book, ReadStatus.READING, 50f, null);
+            em.flush();
+            em.clear();
+
+            List<Long> matchIds = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.EQUALS, 50));
+            assertThat(matchIds).contains(book.getId());
+
+            List<Long> noMatchIds = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.EQUALS, 60));
+            assertThat(noMatchIds).doesNotContain(book.getId());
+        }
+
+        @Test
+        void greaterThanEqualTo_matchesBoundary() {
+            BookEntity book = createBook("Boundary Book");
+            createProgress(book, ReadStatus.READING, 50f, null);
+            em.flush();
+            em.clear();
+
+            List<Long> matchIds = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.GREATER_THAN_EQUAL_TO, 50));
+            assertThat(matchIds).contains(book.getId());
+
+            List<Long> noMatchIds = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.GREATER_THAN_EQUAL_TO, 51));
+            assertThat(noMatchIds).doesNotContain(book.getId());
+        }
+
+        @Test
+        void lessThanEqualTo_matchesBoundary() {
+            BookEntity book = createBook("Boundary Book");
+            createProgress(book, ReadStatus.READING, 50f, null);
+            em.flush();
+            em.clear();
+
+            List<Long> matchIds = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.LESS_THAN_EQUAL_TO, 50));
+            assertThat(matchIds).contains(book.getId());
+
+            List<Long> noMatchIds = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.LESS_THAN_EQUAL_TO, 49));
+            assertThat(noMatchIds).doesNotContain(book.getId());
+        }
+
+        @Test
+        void noProgressRecord_treatedAsZero() {
+            BookEntity book = createBook("No Progress Book");
+            // No progress entity created
+            em.flush();
+            em.clear();
+
+            List<Long> zeroIds = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.EQUALS, 0));
+            assertThat(zeroIds).contains(book.getId());
+
+            List<Long> gtIds = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.GREATER_THAN, 0));
+            assertThat(gtIds).doesNotContain(book.getId());
+        }
+
+        @Test
+        void multipleProgressSources_usesGreatest() {
+            BookEntity book = createBook("Multi Source Book");
+            UserBookProgressEntity progress = createProgress(book, ReadStatus.READING, 30f, null);
+            progress.setKoboProgressPercent(70f);
+            em.merge(progress);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.READING_PROGRESS, RuleOperator.GREATER_THAN, 50));
+            assertThat(ids).contains(book.getId());
+        }
+    }
+
+    @Nested
+    class RelativeDateEdgeCases {
+        @Test
+        void withinLast_weeks_matchesRecentBook() {
+            BookEntity recent = createBook("One Week Ago");
+            recent.setAddedOn(Instant.now().minus(7, ChronoUnit.DAYS));
+            em.merge(recent);
+
+            BookEntity old = createBook("Twenty Days Ago");
+            old.setAddedOn(Instant.now().minus(20, ChronoUnit.DAYS));
+            em.merge(old);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.WITHIN_LAST, 2, null, "weeks"));
+            assertThat(ids).contains(recent.getId());
+            assertThat(ids).doesNotContain(old.getId());
+        }
+
+        @Test
+        void withinLast_years_matchesRecentBook() {
+            BookEntity recent = createBook("Six Months Ago");
+            recent.setAddedOn(Instant.now().minus(180, ChronoUnit.DAYS));
+            em.merge(recent);
+
+            BookEntity old = createBook("Two Years Ago");
+            old.setAddedOn(Instant.now().minus(730, ChronoUnit.DAYS));
+            em.merge(old);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.WITHIN_LAST, 1, null, "years"));
+            assertThat(ids).contains(recent.getId());
+            assertThat(ids).doesNotContain(old.getId());
+        }
+
+        @Test
+        void olderThan_months_matchesOldBook() {
+            BookEntity old = createBook("Four Months Ago");
+            old.setAddedOn(Instant.now().minus(120, ChronoUnit.DAYS));
+            em.merge(old);
+
+            BookEntity recent = createBook("One Month Ago");
+            recent.setAddedOn(Instant.now().minus(25, ChronoUnit.DAYS));
+            em.merge(recent);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.OLDER_THAN, 3, null, "months"));
+            assertThat(ids).contains(old.getId());
+            assertThat(ids).doesNotContain(recent.getId());
+        }
+
+        @Test
+        void olderThan_years_matchesOldBook() {
+            BookEntity old = createBook("Two Years Ago");
+            old.setAddedOn(Instant.now().minus(730, ChronoUnit.DAYS));
+            em.merge(old);
+
+            BookEntity recent = createBook("Six Months Ago");
+            recent.setAddedOn(Instant.now().minus(180, ChronoUnit.DAYS));
+            em.merge(recent);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.OLDER_THAN, 1, null, "years"));
+            assertThat(ids).contains(old.getId());
+            assertThat(ids).doesNotContain(recent.getId());
+        }
+
+        @Test
+        void thisPeriod_month_matchesThisMonthBook() {
+            BookEntity thisMonth = createBook("This Month Book");
+            thisMonth.setAddedOn(Instant.now().minus(1, ChronoUnit.DAYS));
+            em.merge(thisMonth);
+
+            BookEntity notThisMonth = createBook("Not This Month Book");
+            notThisMonth.setAddedOn(Instant.now().minus(60, ChronoUnit.DAYS));
+            em.merge(notThisMonth);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.THIS_PERIOD, "month"));
+            assertThat(ids).contains(thisMonth.getId());
+            assertThat(ids).doesNotContain(notThisMonth.getId());
+        }
+
+        @Test
+        void dateFinished_withinLast_matchesRecentlyFinished() {
+            BookEntity book = createBook("Recently Finished");
+            createProgress(book, ReadStatus.READ, null, Instant.now().minus(2, ChronoUnit.DAYS));
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.DATE_FINISHED, RuleOperator.WITHIN_LAST, 7, null, "days"));
+            assertThat(ids).contains(book.getId());
+        }
+
+        @Test
+        void dateFinished_olderThan_matchesOldFinish() {
+            BookEntity book = createBook("Old Finish");
+            createProgress(book, ReadStatus.READ, null, Instant.now().minus(60, ChronoUnit.DAYS));
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.DATE_FINISHED, RuleOperator.OLDER_THAN, 30, null, "days"));
+            assertThat(ids).contains(book.getId());
+        }
+
+        @Test
+        void publishedDate_withinLast_matchesRecentlyPublished() {
+            BookEntity book = createBook("Recent Publish");
+            BookMetadataEntity metadata = book.getMetadata();
+            metadata.setPublishedDate(LocalDate.now().minusDays(10));
+            em.merge(metadata);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.PUBLISHED_DATE, RuleOperator.WITHIN_LAST, 30, null, "days"));
+            assertThat(ids).contains(book.getId());
+        }
+
+        @Test
+        void nullValue_returnsAllBooks() {
+            BookEntity book = createBook("Any Book");
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.WITHIN_LAST, null, null, "days"));
+            assertThat(ids).contains(book.getId());
+        }
+    }
+
+    @Nested
+    class SeriesStatusEdgeCases {
+        @Test
+        void ongoing_matchesSeriesWithTotalButMissingLast() {
+            // Ongoing: total=3, books #1 and #2 but no #3
+            BookEntity o1 = createBook("Ongoing S1", "Ongoing Series", 1f, 3);
+            BookEntity o2 = createBook("Ongoing S2", "Ongoing Series", 2f, 3);
+
+            // Not ongoing: total=2, books #1 and #2 (complete)
+            BookEntity c1 = createBook("Complete S1", "Complete Series2", 1f, 2);
+            BookEntity c2 = createBook("Complete S2", "Complete Series2", 2f, 2);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.EQUALS, "ongoing"));
+            assertThat(ids).contains(o1.getId(), o2.getId());
+            assertThat(ids).doesNotContain(c1.getId(), c2.getId());
+        }
+
+        @Test
+        void booksWithoutSeries_neverMatchSeriesStatus() {
+            BookEntity noSeries = createBook("No Series Book");
+            em.flush();
+            em.clear();
+
+            List<Long> readingIds = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.EQUALS, "reading"));
+            assertThat(readingIds).doesNotContain(noSeries.getId());
+
+            List<Long> fullyReadIds = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.EQUALS, "fully_read"));
+            assertThat(fullyReadIds).doesNotContain(noSeries.getId());
+        }
+
+        @Test
+        void emptyStringSeriesName_neverMatchSeriesStatus() {
+            BookEntity emptySeriesBook = createBook("Empty Series Book", "", 1f, 2);
+            em.flush();
+            em.clear();
+
+            List<Long> readingIds = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.EQUALS, "reading"));
+            assertThat(readingIds).doesNotContain(emptySeriesBook.getId());
+
+            List<Long> fullyReadIds = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.EQUALS, "fully_read"));
+            assertThat(fullyReadIds).doesNotContain(emptySeriesBook.getId());
+        }
+
+        @Test
+        void reReading_countsAsReading() {
+            BookEntity b1 = createBook("ReRead S1", "ReRead Series", 1f, 2);
+            BookEntity b2 = createBook("ReRead S2", "ReRead Series", 2f, 2);
+            createProgress(b1, ReadStatus.RE_READING);
+            createProgress(b2, ReadStatus.UNREAD);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_STATUS, RuleOperator.EQUALS, "reading"));
+            assertThat(ids).contains(b1.getId(), b2.getId());
+        }
+    }
+
+    @Nested
+    class SeriesGapsEdgeCases {
+        @Test
+        void missingLatest_matchesSeriesMissingLastBook() {
+            // Missing latest: total=3, books #1 and #2 only
+            BookEntity m1 = createBook("MissLatest S1", "MissLatest Series", 1f, 3);
+            BookEntity m2 = createBook("MissLatest S2", "MissLatest Series", 2f, 3);
+
+            // Not missing latest: total=2, books #1 and #2
+            BookEntity c1 = createBook("HasLatest S1", "HasLatest Series", 1f, 2);
+            BookEntity c2 = createBook("HasLatest S2", "HasLatest Series", 2f, 2);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_GAPS, RuleOperator.EQUALS, "missing_latest"));
+            assertThat(ids).contains(m1.getId(), m2.getId());
+            assertThat(ids).doesNotContain(c1.getId(), c2.getId());
+        }
+
+        @Test
+        void noGaps_doesNotMatch() {
+            BookEntity n1 = createBook("NoGap S1", "Consecutive Series", 1f, 3);
+            BookEntity n2 = createBook("NoGap S2", "Consecutive Series", 2f, 3);
+            BookEntity n3 = createBook("NoGap S3", "Consecutive Series", 3f, 3);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_GAPS, RuleOperator.EQUALS, "any_gap"));
+            assertThat(ids).doesNotContain(n1.getId(), n2.getId(), n3.getId());
+        }
+    }
+
+    @Nested
+    class SeriesPositionEdgeCases {
+        @Test
+        void nextUnread_noReadBooks_doesNotMatch() {
+            BookEntity b1 = createBook("AllUnread S1", "AllUnread Series", 1f, 3);
+            BookEntity b2 = createBook("AllUnread S2", "AllUnread Series", 2f, 3);
+            BookEntity b3 = createBook("AllUnread S3", "AllUnread Series", 3f, 3);
+            createProgress(b1, ReadStatus.UNREAD);
+            createProgress(b2, ReadStatus.UNREAD);
+            createProgress(b3, ReadStatus.UNREAD);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_POSITION, RuleOperator.EQUALS, "next_unread"));
+            assertThat(ids).doesNotContain(b1.getId(), b2.getId(), b3.getId());
+        }
+
+        @Test
+        void nextUnread_allBooksRead_doesNotMatch() {
+            BookEntity b1 = createBook("AllRead S1", "AllRead Series", 1f, 3);
+            BookEntity b2 = createBook("AllRead S2", "AllRead Series", 2f, 3);
+            BookEntity b3 = createBook("AllRead S3", "AllRead Series", 3f, 3);
+            createProgress(b1, ReadStatus.READ);
+            createProgress(b2, ReadStatus.READ);
+            createProgress(b3, ReadStatus.READ);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_POSITION, RuleOperator.EQUALS, "next_unread"));
+            assertThat(ids).doesNotContain(b1.getId(), b2.getId(), b3.getId());
+        }
+
+        @Test
+        void firstInSeries_fractionalNumbers() {
+            BookEntity b05 = createBook("Frac S0.5", "Frac Series", 0.5f, 3);
+            BookEntity b1 = createBook("Frac S1", "Frac Series", 1f, 3);
+            BookEntity b2 = createBook("Frac S2", "Frac Series", 2f, 3);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_POSITION, RuleOperator.EQUALS, "first_in_series"));
+            assertThat(ids).contains(b05.getId());
+            assertThat(ids).doesNotContain(b1.getId(), b2.getId());
+        }
+
+        @Test
+        void positionFilters_requireSeriesNumber() {
+            BookEntity noNumber = createBook("No Number", "NoNum Series", null, 3);
+            em.flush();
+            em.clear();
+
+            List<Long> firstIds = findMatchingIds(singleRule(RuleField.SERIES_POSITION, RuleOperator.EQUALS, "first_in_series"));
+            assertThat(firstIds).doesNotContain(noNumber.getId());
+
+            List<Long> lastIds = findMatchingIds(singleRule(RuleField.SERIES_POSITION, RuleOperator.EQUALS, "last_in_series"));
+            assertThat(lastIds).doesNotContain(noNumber.getId());
+
+            List<Long> nextIds = findMatchingIds(singleRule(RuleField.SERIES_POSITION, RuleOperator.EQUALS, "next_unread"));
+            assertThat(nextIds).doesNotContain(noNumber.getId());
+        }
+    }
+
+    @Nested
+    class GroupLogicTests {
+        @Test
+        void andJoin_requiresBothRulesToMatch() {
+            BookEntity matchBoth = createBook("Both Match");
+            matchBoth.getMetadata().setPageCount(200);
+            em.merge(matchBoth.getMetadata());
+            matchBoth.setMetadataMatchScore(70f);
+            em.merge(matchBoth);
+
+            BookEntity matchOne = createBook("One Match");
+            matchOne.getMetadata().setPageCount(200);
+            em.merge(matchOne.getMetadata());
+            matchOne.setMetadataMatchScore(30f);
+            em.merge(matchOne);
+            em.flush();
+            em.clear();
+
+            Rule rule1 = new Rule();
+            rule1.setField(RuleField.PAGE_COUNT);
+            rule1.setOperator(RuleOperator.GREATER_THAN);
+            rule1.setValue(100);
+
+            Rule rule2 = new Rule();
+            rule2.setField(RuleField.METADATA_SCORE);
+            rule2.setOperator(RuleOperator.GREATER_THAN);
+            rule2.setValue(50);
+
+            GroupRule group = new GroupRule();
+            group.setJoin(JoinType.AND);
+            group.setRules(List.of(rule1, rule2));
+
+            List<Long> ids = findMatchingIds(group);
+            assertThat(ids).contains(matchBoth.getId());
+            assertThat(ids).doesNotContain(matchOne.getId());
+        }
+
+        @Test
+        void orJoin_requiresEitherRuleToMatch() {
+            BookEntity matchFirst = createBook("First Match");
+            matchFirst.getMetadata().setPageCount(200);
+            em.merge(matchFirst.getMetadata());
+            matchFirst.setMetadataMatchScore(30f);
+            em.merge(matchFirst);
+
+            BookEntity matchNeither = createBook("Neither Match");
+            matchNeither.getMetadata().setPageCount(50);
+            em.merge(matchNeither.getMetadata());
+            matchNeither.setMetadataMatchScore(30f);
+            em.merge(matchNeither);
+            em.flush();
+            em.clear();
+
+            Rule rule1 = new Rule();
+            rule1.setField(RuleField.PAGE_COUNT);
+            rule1.setOperator(RuleOperator.GREATER_THAN);
+            rule1.setValue(100);
+
+            Rule rule2 = new Rule();
+            rule2.setField(RuleField.METADATA_SCORE);
+            rule2.setOperator(RuleOperator.GREATER_THAN);
+            rule2.setValue(50);
+
+            GroupRule group = new GroupRule();
+            group.setJoin(JoinType.OR);
+            group.setRules(List.of(rule1, rule2));
+
+            List<Long> ids = findMatchingIds(group);
+            assertThat(ids).contains(matchFirst.getId());
+            assertThat(ids).doesNotContain(matchNeither.getId());
+        }
+
+        @Test
+        void nestedGroup_evaluatesCorrectly() {
+            // Book that matches outer rule AND inner OR group
+            BookEntity matchAll = createBook("Match All");
+            matchAll.getMetadata().setPageCount(200);
+            matchAll.getMetadata().setLanguage("en");
+            em.merge(matchAll.getMetadata());
+            matchAll.setMetadataMatchScore(70f);
+            em.merge(matchAll);
+
+            // Book that matches outer rule but NOT inner OR group
+            BookEntity matchOuterOnly = createBook("Match Outer Only");
+            matchOuterOnly.getMetadata().setPageCount(200);
+            matchOuterOnly.getMetadata().setLanguage("xx");
+            em.merge(matchOuterOnly.getMetadata());
+            matchOuterOnly.setMetadataMatchScore(30f);
+            em.merge(matchOuterOnly);
+            em.flush();
+            em.clear();
+
+            // Outer rule: pageCount > 100
+            Rule outerRule = new Rule();
+            outerRule.setField(RuleField.PAGE_COUNT);
+            outerRule.setOperator(RuleOperator.GREATER_THAN);
+            outerRule.setValue(100);
+
+            // Inner OR group: metadataScore > 50 OR language = "en"
+            Rule innerRule1 = new Rule();
+            innerRule1.setField(RuleField.METADATA_SCORE);
+            innerRule1.setOperator(RuleOperator.GREATER_THAN);
+            innerRule1.setValue(50);
+
+            Rule innerRule2 = new Rule();
+            innerRule2.setField(RuleField.LANGUAGE);
+            innerRule2.setOperator(RuleOperator.EQUALS);
+            innerRule2.setValue("en");
+
+            GroupRule innerGroup = new GroupRule();
+            innerGroup.setType("group");
+            innerGroup.setJoin(JoinType.OR);
+            innerGroup.setRules(List.of(innerRule1, innerRule2));
+
+            GroupRule outerGroup = new GroupRule();
+            outerGroup.setJoin(JoinType.AND);
+            outerGroup.setRules(List.of(outerRule, innerGroup));
+
+            List<Long> ids = findMatchingIds(outerGroup);
+            assertThat(ids).contains(matchAll.getId());
+            assertThat(ids).doesNotContain(matchOuterOnly.getId());
+        }
+
+        @Test
+        void emptyGroupRules_matchesAllBooks() {
+            BookEntity book1 = createBook("Book One");
+            BookEntity book2 = createBook("Book Two");
+            em.flush();
+            em.clear();
+
+            GroupRule group = new GroupRule();
+            group.setJoin(JoinType.AND);
+            group.setRules(new ArrayList<>());
+
+            List<Long> ids = findMatchingIds(group);
+            assertThat(ids).contains(book1.getId(), book2.getId());
+        }
+    }
+
+    @Nested
+    class StringOperatorTests {
+        @Test
+        void contains_matchesTitleSubstring() {
+            BookEntity hp = createBook("Harry Potter and the Philosopher's Stone");
+            BookEntity lotr = createBook("The Lord of the Rings");
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.TITLE, RuleOperator.CONTAINS, "potter"));
+            assertThat(ids).contains(hp.getId());
+            assertThat(ids).doesNotContain(lotr.getId());
+        }
+
+        @Test
+        void doesNotContain_excludesTitleSubstring() {
+            BookEntity hp = createBook("Harry Potter and the Philosopher's Stone");
+            BookEntity lotr = createBook("The Lord of the Rings");
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.TITLE, RuleOperator.DOES_NOT_CONTAIN, "potter"));
+            assertThat(ids).contains(lotr.getId());
+            assertThat(ids).doesNotContain(hp.getId());
+        }
+
+        @Test
+        void startsWith_matchesTitlePrefix() {
+            BookEntity hp = createBook("Harry Potter");
+            BookEntity hobbit = createBook("The Hobbit");
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.TITLE, RuleOperator.STARTS_WITH, "harry"));
+            assertThat(ids).contains(hp.getId());
+            assertThat(ids).doesNotContain(hobbit.getId());
+        }
+
+        @Test
+        void endsWith_matchesTitleSuffix() {
+            BookEntity hp = createBook("Harry Potter");
+            BookEntity hobbit = createBook("The Hobbit");
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.TITLE, RuleOperator.ENDS_WITH, "hobbit"));
+            assertThat(ids).contains(hobbit.getId());
+            assertThat(ids).doesNotContain(hp.getId());
+        }
+
+        @Test
+        void contains_onArrayField_matchesAuthorName() {
+            BookEntity book1 = createBook("Mistborn");
+            AuthorEntity author1 = AuthorEntity.builder().name("Brandon Sanderson").build();
+            em.persist(author1);
+            book1.getMetadata().setAuthors(new HashSet<>(Set.of(author1)));
+            em.merge(book1.getMetadata());
+
+            BookEntity book2 = createBook("It");
+            AuthorEntity author2 = AuthorEntity.builder().name("Stephen King").build();
+            em.persist(author2);
+            book2.getMetadata().setAuthors(new HashSet<>(Set.of(author2)));
+            em.merge(book2.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.AUTHORS, RuleOperator.CONTAINS, "sanderson"));
+            assertThat(ids).contains(book1.getId());
+            assertThat(ids).doesNotContain(book2.getId());
+        }
+    }
+
+    @Nested
+    class EmptyOperatorTests {
+        @Test
+        void isEmpty_matchesBookWithNullPublisher() {
+            BookEntity noPublisher = createBook("No Publisher Book");
+            // publisher is null by default
+
+            BookEntity withPublisher = createBook("With Publisher Book");
+            withPublisher.getMetadata().setPublisher("Penguin");
+            em.merge(withPublisher.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.PUBLISHER, RuleOperator.IS_EMPTY, null));
+            assertThat(ids).contains(noPublisher.getId());
+            assertThat(ids).doesNotContain(withPublisher.getId());
+        }
+
+        @Test
+        void isNotEmpty_matchesBookWithPublisher() {
+            BookEntity noPublisher = createBook("No Publisher Book");
+
+            BookEntity withPublisher = createBook("With Publisher Book");
+            withPublisher.getMetadata().setPublisher("Penguin");
+            em.merge(withPublisher.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.PUBLISHER, RuleOperator.IS_NOT_EMPTY, null));
+            assertThat(ids).contains(withPublisher.getId());
+            assertThat(ids).doesNotContain(noPublisher.getId());
+        }
+
+        @Test
+        void isEmpty_onArrayField_matchesBookWithNoAuthors() {
+            BookEntity noAuthors = createBook("No Authors Book");
+            // authors is null/empty by default
+
+            BookEntity withAuthors = createBook("With Authors Book");
+            AuthorEntity author = AuthorEntity.builder().name("Test Author").build();
+            em.persist(author);
+            withAuthors.getMetadata().setAuthors(new HashSet<>(Set.of(author)));
+            em.merge(withAuthors.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.AUTHORS, RuleOperator.IS_EMPTY, null));
+            assertThat(ids).contains(noAuthors.getId());
+            assertThat(ids).doesNotContain(withAuthors.getId());
+        }
+
+        @Test
+        void isNotEmpty_onArrayField_matchesBookWithAuthors() {
+            BookEntity noAuthors = createBook("No Authors Book");
+
+            BookEntity withAuthors = createBook("With Authors Book");
+            AuthorEntity author = AuthorEntity.builder().name("Test Author 2").build();
+            em.persist(author);
+            withAuthors.getMetadata().setAuthors(new HashSet<>(Set.of(author)));
+            em.merge(withAuthors.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.AUTHORS, RuleOperator.IS_NOT_EMPTY, null));
+            assertThat(ids).contains(withAuthors.getId());
+            assertThat(ids).doesNotContain(noAuthors.getId());
+        }
+    }
+
+    @Nested
+    class MultiValueOperatorTests {
+        @Test
+        void includesAny_matchesReadStatusInList() {
+            BookEntity readBook = createBook("Read Book");
+            createProgress(readBook, ReadStatus.READ);
+
+            BookEntity readingBook = createBook("Reading Book");
+            createProgress(readingBook, ReadStatus.READING);
+
+            BookEntity pausedBook = createBook("Paused Book");
+            createProgress(pausedBook, ReadStatus.PAUSED);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.READ_STATUS, RuleOperator.INCLUDES_ANY, List.of("READ", "READING")));
+            assertThat(ids).contains(readBook.getId(), readingBook.getId());
+            assertThat(ids).doesNotContain(pausedBook.getId());
+        }
+
+        @Test
+        void excludesAll_excludesReadStatusInList() {
+            BookEntity readBook = createBook("Read Book");
+            createProgress(readBook, ReadStatus.READ);
+
+            BookEntity readingBook = createBook("Reading Book");
+            createProgress(readingBook, ReadStatus.READING);
+
+            BookEntity pausedBook = createBook("Paused Book");
+            createProgress(pausedBook, ReadStatus.PAUSED);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.READ_STATUS, RuleOperator.EXCLUDES_ALL, List.of("READ", "READING")));
+            assertThat(ids).contains(pausedBook.getId());
+            assertThat(ids).doesNotContain(readBook.getId(), readingBook.getId());
+        }
+
+        @Test
+        void includesAny_onArrayField_matchesAnyAuthor() {
+            BookEntity bookA = createBook("Book A");
+            AuthorEntity authorA = AuthorEntity.builder().name("Author A").build();
+            em.persist(authorA);
+            bookA.getMetadata().setAuthors(new HashSet<>(Set.of(authorA)));
+            em.merge(bookA.getMetadata());
+
+            BookEntity bookB = createBook("Book B");
+            AuthorEntity authorB = AuthorEntity.builder().name("Author B").build();
+            em.persist(authorB);
+            bookB.getMetadata().setAuthors(new HashSet<>(Set.of(authorB)));
+            em.merge(bookB.getMetadata());
+
+            BookEntity bookC = createBook("Book C");
+            AuthorEntity authorC = AuthorEntity.builder().name("Author C").build();
+            em.persist(authorC);
+            bookC.getMetadata().setAuthors(new HashSet<>(Set.of(authorC)));
+            em.merge(bookC.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.AUTHORS, RuleOperator.INCLUDES_ANY, List.of("Author A", "Author B")));
+            assertThat(ids).contains(bookA.getId(), bookB.getId());
+            assertThat(ids).doesNotContain(bookC.getId());
+        }
+
+        @Test
+        void excludesAll_onArrayField_excludesAllAuthors() {
+            BookEntity bookA = createBook("Book A2");
+            AuthorEntity authorA = AuthorEntity.builder().name("Author A2").build();
+            em.persist(authorA);
+            bookA.getMetadata().setAuthors(new HashSet<>(Set.of(authorA)));
+            em.merge(bookA.getMetadata());
+
+            BookEntity bookB = createBook("Book B2");
+            AuthorEntity authorB = AuthorEntity.builder().name("Author B2").build();
+            em.persist(authorB);
+            bookB.getMetadata().setAuthors(new HashSet<>(Set.of(authorB)));
+            em.merge(bookB.getMetadata());
+
+            BookEntity bookC = createBook("Book C2");
+            AuthorEntity authorC = AuthorEntity.builder().name("Author C2").build();
+            em.persist(authorC);
+            bookC.getMetadata().setAuthors(new HashSet<>(Set.of(authorC)));
+            em.merge(bookC.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.AUTHORS, RuleOperator.EXCLUDES_ALL, List.of("Author A2", "Author B2")));
+            assertThat(ids).contains(bookC.getId());
+            assertThat(ids).doesNotContain(bookA.getId(), bookB.getId());
+        }
+
+        @Test
+        void includesAll_onArrayField_matchesBookWithAllAuthors() {
+            BookEntity bookBoth = createBook("Book Both Authors");
+            AuthorEntity authorX = AuthorEntity.builder().name("Author X").build();
+            AuthorEntity authorY = AuthorEntity.builder().name("Author Y").build();
+            em.persist(authorX);
+            em.persist(authorY);
+            bookBoth.getMetadata().setAuthors(new HashSet<>(Set.of(authorX, authorY)));
+            em.merge(bookBoth.getMetadata());
+
+            BookEntity bookOne = createBook("Book One Author");
+            AuthorEntity authorX2 = AuthorEntity.builder().name("Author X2").build();
+            em.persist(authorX2);
+            bookOne.getMetadata().setAuthors(new HashSet<>(Set.of(authorX2)));
+            em.merge(bookOne.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.AUTHORS, RuleOperator.INCLUDES_ALL, List.of("Author X", "Author Y")));
+            assertThat(ids).contains(bookBoth.getId());
+            assertThat(ids).doesNotContain(bookOne.getId());
+        }
+    }
+
+    @Nested
+    class EqualsEdgeCaseTests {
+        @Test
+        void equals_stringField_caseInsensitive() {
+            BookEntity hp = createBook("Harry Potter");
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.TITLE, RuleOperator.EQUALS, "harry potter"));
+            assertThat(ids).contains(hp.getId());
+        }
+
+        @Test
+        void equals_booleanField_matchesTrue() {
+            BookEntity physical = createBook("Physical Book");
+            physical.setIsPhysical(true);
+            em.merge(physical);
+
+            BookEntity digital = createBook("Digital Book");
+            digital.setIsPhysical(false);
+            em.merge(digital);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.IS_PHYSICAL, RuleOperator.EQUALS, "true"));
+            assertThat(ids).contains(physical.getId());
+            assertThat(ids).doesNotContain(digital.getId());
+        }
+
+        @Test
+        void equals_booleanField_matchesFalse() {
+            BookEntity physical = createBook("Physical Book 2");
+            physical.setIsPhysical(true);
+            em.merge(physical);
+
+            BookEntity digital = createBook("Digital Book 2");
+            digital.setIsPhysical(false);
+            em.merge(digital);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.IS_PHYSICAL, RuleOperator.EQUALS, "false"));
+            assertThat(ids).contains(digital.getId());
+            assertThat(ids).doesNotContain(physical.getId());
+        }
+
+        @Test
+        void notEquals_stringField_excludesMatch() {
+            BookEntity hp = createBook("Harry Potter");
+            BookEntity hobbit = createBook("The Hobbit");
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.TITLE, RuleOperator.NOT_EQUALS, "harry potter"));
+            assertThat(ids).contains(hobbit.getId());
+            assertThat(ids).doesNotContain(hp.getId());
+        }
+
+        @Test
+        void equals_readStatus_matchesSpecificStatus() {
+            BookEntity readBook = createBook("Read Book");
+            createProgress(readBook, ReadStatus.READ);
+
+            BookEntity readingBook = createBook("Reading Book");
+            createProgress(readingBook, ReadStatus.READING);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.READ_STATUS, RuleOperator.EQUALS, "READ"));
+            assertThat(ids).contains(readBook.getId());
+            assertThat(ids).doesNotContain(readingBook.getId());
+        }
+
+        @Test
+        void equals_readStatus_unset_matchesNullProgress() {
+            BookEntity noProgress = createBook("No Progress Book");
+            // No UserBookProgressEntity created
+
+            BookEntity readingBook = createBook("Reading Book");
+            createProgress(readingBook, ReadStatus.READING);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.READ_STATUS, RuleOperator.EQUALS, "UNSET"));
+            assertThat(ids).contains(noProgress.getId());
+            assertThat(ids).doesNotContain(readingBook.getId());
+        }
+    }
+
+    @Nested
+    class DateComparisonTests {
+        @Test
+        void greaterThan_matchesPublishedDateAfterThreshold() {
+            BookEntity recentBook = createBook("Recent Book");
+            recentBook.getMetadata().setPublishedDate(LocalDate.of(2024, 6, 15));
+            em.merge(recentBook.getMetadata());
+
+            BookEntity oldBook = createBook("Old Book");
+            oldBook.getMetadata().setPublishedDate(LocalDate.of(2020, 1, 1));
+            em.merge(oldBook.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.PUBLISHED_DATE, RuleOperator.GREATER_THAN, "2023-01-01"));
+            assertThat(ids).contains(recentBook.getId());
+            assertThat(ids).doesNotContain(oldBook.getId());
+        }
+
+        @Test
+        void lessThan_matchesPublishedDateBeforeThreshold() {
+            BookEntity recentBook = createBook("Recent Book");
+            recentBook.getMetadata().setPublishedDate(LocalDate.of(2024, 6, 15));
+            em.merge(recentBook.getMetadata());
+
+            BookEntity oldBook = createBook("Old Book");
+            oldBook.getMetadata().setPublishedDate(LocalDate.of(2020, 1, 1));
+            em.merge(oldBook.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.PUBLISHED_DATE, RuleOperator.LESS_THAN, "2023-01-01"));
+            assertThat(ids).contains(oldBook.getId());
+            assertThat(ids).doesNotContain(recentBook.getId());
+        }
+
+        @Test
+        void inBetween_matchesPublishedDateInRange() {
+            BookEntity inRange = createBook("In Range Book");
+            inRange.getMetadata().setPublishedDate(LocalDate.of(2023, 6, 15));
+            em.merge(inRange.getMetadata());
+
+            BookEntity outOfRange = createBook("Out of Range Book");
+            outOfRange.getMetadata().setPublishedDate(LocalDate.of(2020, 1, 1));
+            em.merge(outOfRange.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.PUBLISHED_DATE, RuleOperator.IN_BETWEEN, null, "2023-01-01", "2024-01-01"));
+            assertThat(ids).contains(inRange.getId());
+            assertThat(ids).doesNotContain(outOfRange.getId());
+        }
+    }
+
+    @Nested
+    class ReadStatusUnsetTests {
+        @Test
+        void includesAny_withUnsetAndOtherStatuses() {
+            BookEntity noProgress = createBook("No Progress Book");
+
+            BookEntity readBook = createBook("Read Book");
+            createProgress(readBook, ReadStatus.READ);
+
+            BookEntity pausedBook = createBook("Paused Book");
+            createProgress(pausedBook, ReadStatus.PAUSED);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.READ_STATUS, RuleOperator.INCLUDES_ANY, List.of("UNSET", "READ")));
+            assertThat(ids).contains(noProgress.getId(), readBook.getId());
+            assertThat(ids).doesNotContain(pausedBook.getId());
+        }
+
+        @Test
+        void includesAny_withOnlyUnset() {
+            BookEntity noProgress = createBook("No Progress Book");
+
+            BookEntity readBook = createBook("Read Book");
+            createProgress(readBook, ReadStatus.READ);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.READ_STATUS, RuleOperator.INCLUDES_ANY, List.of("UNSET")));
+            assertThat(ids).contains(noProgress.getId());
+            assertThat(ids).doesNotContain(readBook.getId());
+        }
+    }
+
+    @Nested
+    class CompositeNegationTests {
+        @Test
+        void seriesGaps_notEquals_excludesMatching() {
+            // Series with gap (books 1, 3 — missing 2)
+            BookEntity g1 = createBook("Gap S1", "GapNeg Series", 1f, 4);
+            BookEntity g3 = createBook("Gap S3", "GapNeg Series", 3f, 4);
+
+            // Series without gap (books 1, 2 — consecutive)
+            BookEntity n1 = createBook("NoGap S1", "NoGapNeg Series", 1f, 2);
+            BookEntity n2 = createBook("NoGap S2", "NoGapNeg Series", 2f, 2);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_GAPS, RuleOperator.NOT_EQUALS, "any_gap"));
+            assertThat(ids).contains(n1.getId(), n2.getId());
+            assertThat(ids).doesNotContain(g1.getId(), g3.getId());
+        }
+
+        @Test
+        void seriesPosition_notEquals_excludesMatching() {
+            BookEntity b1 = createBook("Pos S1", "PosNeg Series", 1f, 3);
+            BookEntity b2 = createBook("Pos S2", "PosNeg Series", 2f, 3);
+            BookEntity b3 = createBook("Pos S3", "PosNeg Series", 3f, 3);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.SERIES_POSITION, RuleOperator.NOT_EQUALS, "first_in_series"));
+            assertThat(ids).contains(b2.getId(), b3.getId());
+            assertThat(ids).doesNotContain(b1.getId());
+        }
+    }
+
+    @Nested
+    class PublishedDateRelativeTests {
+        @Test
+        void olderThan_publishedDate_matchesOldBook() {
+            BookEntity oldBook = createBook("Old Published Book");
+            oldBook.getMetadata().setPublishedDate(LocalDate.now().minusMonths(6));
+            em.merge(oldBook.getMetadata());
+
+            BookEntity recentBook = createBook("Recent Published Book");
+            recentBook.getMetadata().setPublishedDate(LocalDate.now().minusDays(10));
+            em.merge(recentBook.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.PUBLISHED_DATE, RuleOperator.OLDER_THAN, 3, null, "months"));
+            assertThat(ids).contains(oldBook.getId());
+            assertThat(ids).doesNotContain(recentBook.getId());
+        }
+
+        @Test
+        void thisPeriod_publishedDate_matchesThisYearBook() {
+            BookEntity recentBook = createBook("This Year Published");
+            recentBook.getMetadata().setPublishedDate(LocalDate.now().minusDays(10));
+            em.merge(recentBook.getMetadata());
+
+            BookEntity oldBook = createBook("Two Years Ago Published");
+            oldBook.getMetadata().setPublishedDate(LocalDate.now().minusYears(2));
+            em.merge(oldBook.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.PUBLISHED_DATE, RuleOperator.THIS_PERIOD, "year"));
+            assertThat(ids).contains(recentBook.getId());
+            assertThat(ids).doesNotContain(oldBook.getId());
+        }
+
+        @Test
+        void thisPeriod_week_matchesThisWeekBook() {
+            BookEntity yesterday = createBook("Yesterday Book");
+            yesterday.setAddedOn(Instant.now().minus(1, ChronoUnit.DAYS));
+            em.merge(yesterday);
+
+            BookEntity twoWeeksAgo = createBook("Two Weeks Ago Book");
+            twoWeeksAgo.setAddedOn(Instant.now().minus(14, ChronoUnit.DAYS));
+            em.merge(twoWeeksAgo);
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.ADDED_ON, RuleOperator.THIS_PERIOD, "week"));
+            assertThat(ids).contains(yesterday.getId());
+            assertThat(ids).doesNotContain(twoWeeksAgo.getId());
+        }
+    }
+
+
+    @Nested
+    class IntegerFieldTests {
+        @Test
+        void equals_integerField_matchesExact() {
+            BookEntity book300 = createBook("300 Pages");
+            book300.getMetadata().setPageCount(300);
+            em.merge(book300.getMetadata());
+
+            BookEntity book500 = createBook("500 Pages");
+            book500.getMetadata().setPageCount(500);
+            em.merge(book500.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.PAGE_COUNT, RuleOperator.EQUALS, 300));
+            assertThat(ids).contains(book300.getId());
+            assertThat(ids).doesNotContain(book500.getId());
+        }
+
+        @Test
+        void notEquals_integerField_excludesMatch() {
+            BookEntity book300 = createBook("300 Pages");
+            book300.getMetadata().setPageCount(300);
+            em.merge(book300.getMetadata());
+
+            BookEntity book500 = createBook("500 Pages");
+            book500.getMetadata().setPageCount(500);
+            em.merge(book500.getMetadata());
+            em.flush();
+            em.clear();
+
+            List<Long> ids = findMatchingIds(singleRule(RuleField.PAGE_COUNT, RuleOperator.NOT_EQUALS, 300));
+            assertThat(ids).contains(book500.getId());
+            assertThat(ids).doesNotContain(book300.getId());
+        }
+    }
+}

--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser-entity.service.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser-entity.service.ts
@@ -165,8 +165,9 @@ export class BookBrowserEntityService {
         if (!bookState.loaded || bookState.error || !magicShelf?.filterJson) {
           return bookState;
         }
-        const filteredBooks: Book[] | undefined = bookState.books?.filter(book =>
-          this.bookRuleEvaluatorService.evaluateGroup(book, JSON.parse(magicShelf.filterJson!) as GroupRule)
+        const allBooks = bookState.books ?? [];
+        const filteredBooks = allBooks.filter(book =>
+          this.bookRuleEvaluatorService.evaluateGroup(book, JSON.parse(magicShelf.filterJson!) as GroupRule, allBooks)
         );
         const sortedBooks = this.sortService.applySort(filteredBooks ?? [], sortOption);
         return {...bookState, books: sortedBooks};

--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.service.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.service.ts
@@ -204,7 +204,7 @@ export class BookFilterService {
     if (!magicShelf.filterJson) return [];
     try {
       const groupRule = JSON.parse(magicShelf.filterJson) as GroupRule;
-      return books.filter(book => this.bookRuleEvaluatorService.evaluateGroup(book, groupRule));
+      return books.filter(book => this.bookRuleEvaluatorService.evaluateGroup(book, groupRule, books));
     } catch {
       console.warn('Invalid filterJson for MagicShelf');
       return [];

--- a/booklore-ui/src/app/features/dashboard/components/main-dashboard/main-dashboard.component.ts
+++ b/booklore-ui/src/app/features/dashboard/components/main-dashboard/main-dashboard.component.ts
@@ -166,8 +166,9 @@ export class MainDashboardComponent implements OnInit {
 
         return this.bookService.bookState$.pipe(
           map((state: BookState) => {
-            const filteredBooks = (state.books || []).filter((book) =>
-              this.ruleEvaluatorService.evaluateGroup(book, group)
+            const allBooks = state.books || [];
+            const filteredBooks = allBooks.filter((book) =>
+              this.ruleEvaluatorService.evaluateGroup(book, group, allBooks)
             );
 
             return maxItems ? filteredBooks.slice(0, maxItems) : filteredBooks;

--- a/booklore-ui/src/app/features/magic-shelf/component/magic-shelf-component.html
+++ b/booklore-ui/src/app/features/magic-shelf/component/magic-shelf-component.html
@@ -116,15 +116,20 @@
                 <ng-container *ngTemplateOutlet="groupTemplate; context: { group: ruleCtrl }"></ng-container>
               </ng-container>
             } @else {
-              <p-select [options]="fieldOptions" formControlName="field" (onChange)="onFieldChange(ruleCtrl)" [placeholder]="t('placeholders.field')" appendTo="body" class="field-select"/>
+              <p-select [options]="fieldOptions" [group]="true" optionGroupLabel="label" optionGroupChildren="items" [filter]="true" filterBy="label" formControlName="field" (onChange)="onFieldChange(ruleCtrl)" [placeholder]="t('placeholders.field')" appendTo="body" class="field-select"/>
               <p-select [options]="getOperatorOptionsForField(ruleCtrl.get('field')?.value)" appendTo="body" formControlName="operator" [placeholder]="t('placeholders.operator')" class="operator-select" (onChange)="onOperatorChange(ruleCtrl)"/>
 
               @if (!['is_empty', 'is_not_empty'].includes(ruleCtrl.get('operator')?.value)) {
-                @if (ruleCtrl.get('operator')?.value === 'in_between') {
+                @if (['within_last', 'older_than'].includes(ruleCtrl.get('operator')?.value)) {
+                  <p-inputNumber formControlName="value" class="value-input" [min]="1" [placeholder]="t('placeholders.amount')" [showButtons]="true"></p-inputNumber>
+                  <p-select [options]="dateUnitOptions" formControlName="valueEnd" [placeholder]="t('placeholders.selectUnit')" appendTo="body" class="value-input"></p-select>
+                } @else if (ruleCtrl.get('operator')?.value === 'this_period') {
+                  <p-select [options]="datePeriodOptions" formControlName="value" [placeholder]="t('placeholders.selectPeriod')" appendTo="body" class="value-input"></p-select>
+                } @else if (ruleCtrl.get('operator')?.value === 'in_between') {
                   @if (ruleCtrl.get('field')?.value === 'publishedDate') {
                     <p-datepicker [formControl]="ruleCtrl.get('valueStart')" dateFormat="dd-M-yy" [placeholder]="t('placeholders.startYear')" appendTo="body" fluid class="value-input"></p-datepicker>
                     <p-datepicker [formControl]="ruleCtrl.get('valueEnd')" dateFormat="dd-M-yy" [placeholder]="t('placeholders.endYear')" appendTo="body" fluid class="value-input"></p-datepicker>
-                  } @else if (ruleCtrl.get('field')?.value === 'dateFinished') {
+                  } @else if (['dateFinished', 'addedOn', 'lastReadTime'].includes(ruleCtrl.get('field')?.value)) {
                     <p-datepicker [formControl]="ruleCtrl.get('valueStart')" dateFormat="dd-M-yy" [placeholder]="t('placeholders.startDate')" appendTo="body" fluid class="value-input"></p-datepicker>
                     <p-datepicker [formControl]="ruleCtrl.get('valueEnd')" dateFormat="dd-M-yy" [placeholder]="t('placeholders.endDate')" appendTo="body" fluid class="value-input"></p-datepicker>
                   } @else if (numericFieldConfigMap.get(ruleCtrl.get('field')?.value)?.type === 'number') {
@@ -140,12 +145,20 @@
                 } @else {
                   @if (ruleCtrl.get('field')?.value === 'publishedDate') {
                     <p-datepicker formControlName="value" dateFormat="dd-M-yy" appendTo="body" fluid class="value-input"></p-datepicker>
-                  } @else if (ruleCtrl.get('field')?.value === 'dateFinished') {
+                  } @else if (['dateFinished', 'addedOn', 'lastReadTime'].includes(ruleCtrl.get('field')?.value)) {
                     <p-datepicker formControlName="value" dateFormat="dd-M-yy" appendTo="body" fluid class="value-input"></p-datepicker>
+                  } @else if (numericFieldConfigMap.get(ruleCtrl.get('field')?.value)?.type === 'boolean') {
+                    <p-select [options]="booleanOptions" formControlName="value" [placeholder]="t('placeholders.selectValue')" appendTo="body" class="value-input"></p-select>
                   } @else if (numericFieldConfigMap.get(ruleCtrl.get('field')?.value)?.type === 'number') {
                     <p-inputNumber formControlName="value" class="value-input" mode="decimal" [placeholder]="t('placeholders.value')" [showButtons]="true"></p-inputNumber>
                   } @else if (numericFieldConfigMap.get(ruleCtrl.get('field')?.value)?.type === 'decimal') {
                     <p-inputNumber formControlName="value" mode="decimal" [minFractionDigits]="1" [maxFractionDigits]="1" [min]="0" [max]="numericFieldConfigMap.get(ruleCtrl.get('field')?.value)?.max || 10" class="value-input" [placeholder]="t('placeholders.value')"></p-inputNumber>
+                  } @else if (ruleCtrl.get('field')?.value === 'seriesStatus') {
+                    <p-select [options]="seriesStatusOptions" formControlName="value" [placeholder]="t('placeholders.selectSeriesStatus')" appendTo="body" class="value-input"></p-select>
+                  } @else if (ruleCtrl.get('field')?.value === 'seriesGaps') {
+                    <p-select [options]="seriesGapsOptions" formControlName="value" [placeholder]="t('placeholders.selectSeriesGap')" appendTo="body" class="value-input"></p-select>
+                  } @else if (ruleCtrl.get('field')?.value === 'seriesPosition') {
+                    <p-select [options]="seriesPositionOptions" formControlName="value" [placeholder]="t('placeholders.selectSeriesPosition')" appendTo="body" class="value-input"></p-select>
                   } @else if (['includes_any', 'includes_all', 'excludes_all'].includes(ruleCtrl.get('operator')?.value)) {
                     @if (ruleCtrl.get('field')?.value === 'readStatus') {
                       <p-multiSelect [options]="readStatusOptions" formControlName="value" display="chip" class="value-input" appendTo="body" [placeholder]="t('placeholders.selectStatuses')"></p-multiSelect>
@@ -157,6 +170,8 @@
                       <p-multiSelect [options]="shelfOptions" formControlName="value" display="chip" class="value-input" appendTo="body" [placeholder]="t('placeholders.selectShelves')"></p-multiSelect>
                     } @else if (ruleCtrl.get('field')?.value === 'categories') {
                       <p-multiSelect [options]="categoryOptions" formControlName="value" display="chip" class="value-input" appendTo="body" [placeholder]="t('placeholders.selectGenres')"></p-multiSelect>
+                    } @else if (ruleCtrl.get('field')?.value === 'contentRating') {
+                      <p-multiSelect [options]="contentRatingOptions" formControlName="value" display="chip" class="value-input" appendTo="body" [placeholder]="t('placeholders.selectContentRatings')"></p-multiSelect>
                     } @else {
                       <div class="autocomplete-wrapper">
                         <p-autoComplete [formControl]="ruleCtrl.get('value')" [multiple]="true" [typeahead]="false" [dropdown]="false" [forceSelection]="false" [placeholder]="t('placeholders.enterValues')" (onBlur)="onAutoCompleteBlur(ruleCtrl.get('value'), $event)"></p-autoComplete>
@@ -172,6 +187,8 @@
                     <p-select [options]="shelfOptions" formControlName="value" [placeholder]="t('placeholders.selectShelf')" appendTo="body" class="value-input"></p-select>
                   } @else if (ruleCtrl.get('field')?.value === 'categories') {
                     <p-select [options]="categoryOptions" formControlName="value" [placeholder]="t('placeholders.selectGenre')" appendTo="body" class="value-input"></p-select>
+                  } @else if (ruleCtrl.get('field')?.value === 'contentRating') {
+                    <p-select [options]="contentRatingOptions" formControlName="value" [placeholder]="t('placeholders.selectContentRating')" appendTo="body" class="value-input"></p-select>
                   } @else {
                     <input pInputText formControlName="value" class="value-input" [placeholder]="t('placeholders.value')"/>
                   }

--- a/booklore-ui/src/app/features/magic-shelf/component/magic-shelf-component.spec.ts
+++ b/booklore-ui/src/app/features/magic-shelf/component/magic-shelf-component.spec.ts
@@ -1,0 +1,603 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {TestBed} from '@angular/core/testing';
+import {MagicShelfComponent, Rule} from './magic-shelf-component';
+import {TranslocoService} from '@jsverse/transloco';
+import {LibraryService} from '../../book/service/library.service';
+import {ShelfService} from '../../book/service/shelf.service';
+import {BookService} from '../../book/service/book.service';
+import {MagicShelfService} from '../service/magic-shelf.service';
+import {MessageService} from 'primeng/api';
+import {DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+import {UserService} from '../../settings/user-management/user.service';
+import {IconPickerService} from '../../../shared/service/icon-picker.service';
+import {of} from 'rxjs';
+
+describe('MagicShelfComponent (Part 3)', () => {
+  let component: MagicShelfComponent;
+
+  const mockTransloco = {
+    translate: vi.fn((key: string) => key),
+    selectTranslation: vi.fn(() => of({})),
+    langChanges$: of('en'),
+    getActiveLang: vi.fn(() => 'en'),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: TranslocoService, useValue: mockTransloco},
+        {provide: LibraryService, useValue: {getLibrariesFromState: vi.fn(() => [])}},
+        {provide: ShelfService, useValue: {getShelvesFromState: vi.fn(() => [])}},
+        {provide: BookService, useValue: {bookState$: of({loaded: false, books: []})}},
+        {provide: MagicShelfService, useValue: {}},
+        {provide: MessageService, useValue: {add: vi.fn()}},
+        {provide: DynamicDialogRef, useValue: {close: vi.fn()}},
+        {provide: DynamicDialogConfig, useValue: {data: null}},
+        {provide: UserService, useValue: {getCurrentUser: vi.fn(() => ({permissions: {admin: false}}))}},
+        {provide: IconPickerService, useValue: {open: vi.fn(() => of(null))}},
+      ]
+    });
+
+    const fixture = TestBed.createComponent(MagicShelfComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('getOperatorOptionsForField', () => {
+    it('should return is/isNot operators for seriesStatus', () => {
+      const operators = component.getOperatorOptionsForField('seriesStatus');
+      expect(operators).toHaveLength(2);
+      expect(operators.map(o => o.value)).toEqual(['equals', 'not_equals']);
+      expect(operators[0].label).toContain('is');
+    });
+
+    it('should return is/isNot operators for seriesPosition', () => {
+      const operators = component.getOperatorOptionsForField('seriesPosition');
+      expect(operators).toHaveLength(2);
+      expect(operators.map(o => o.value)).toEqual(['equals', 'not_equals']);
+    });
+
+    it('should return has/hasNot operators for seriesGaps', () => {
+      const operators = component.getOperatorOptionsForField('seriesGaps');
+      expect(operators).toHaveLength(2);
+      expect(operators.map(o => o.value)).toEqual(['equals', 'not_equals']);
+      expect(operators[0].label).toContain('has');
+    });
+
+    it('should include relative date operators for date fields', () => {
+      const operators = component.getOperatorOptionsForField('dateFinished');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('within_last');
+      expect(values).toContain('older_than');
+      expect(values).toContain('this_period');
+    });
+
+    it('should include relative date operators for addedOn', () => {
+      const operators = component.getOperatorOptionsForField('addedOn');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('within_last');
+      expect(values).toContain('older_than');
+      expect(values).toContain('this_period');
+    });
+
+    it('should include relative date operators for publishedDate', () => {
+      const operators = component.getOperatorOptionsForField('publishedDate');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('within_last');
+      expect(values).toContain('older_than');
+      expect(values).toContain('this_period');
+    });
+
+    it('should NOT include relative date operators for number fields', () => {
+      const operators = component.getOperatorOptionsForField('pageCount');
+      const values = operators.map(o => o.value);
+      expect(values).not.toContain('within_last');
+      expect(values).not.toContain('older_than');
+      expect(values).not.toContain('this_period');
+    });
+
+    it('should include comparison operators for readingProgress', () => {
+      const operators = component.getOperatorOptionsForField('readingProgress');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('greater_than');
+      expect(values).toContain('less_than');
+      expect(values).toContain('in_between');
+    });
+
+    it('should NOT include relative date operators for readingProgress', () => {
+      const operators = component.getOperatorOptionsForField('readingProgress');
+      const values = operators.map(o => o.value);
+      expect(values).not.toContain('within_last');
+    });
+
+    it('should return only base operators for boolean fields', () => {
+      const operators = component.getOperatorOptionsForField('abridged');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('equals');
+      expect(values).toContain('not_equals');
+      expect(values).toContain('is_empty');
+      expect(values).toContain('is_not_empty');
+      expect(values).not.toContain('contains');
+      expect(values).not.toContain('greater_than');
+    });
+  });
+
+  describe('buildRuleFromData', () => {
+    it('should parse within_last value as number, not date', () => {
+      const rule: Rule = {field: 'dateFinished', operator: 'within_last', value: 30, valueEnd: 'days'};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toBe(30);
+      expect(formGroup.get('valueEnd')?.value).toBe('days');
+    });
+
+    it('should preserve this_period value as string', () => {
+      const rule: Rule = {field: 'addedOn', operator: 'this_period', value: 'month'};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toBe('month');
+      expect(formGroup.get('valueEnd')?.value).toBeNull();
+    });
+
+    it('should parse older_than value as number', () => {
+      const rule: Rule = {field: 'lastReadTime', operator: 'older_than', value: 6, valueEnd: 'months'};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toBe(6);
+      expect(formGroup.get('valueEnd')?.value).toBe('months');
+    });
+
+    it('should still parse regular date values as Date objects', () => {
+      const rule: Rule = {field: 'dateFinished', operator: 'equals', value: '2024-06-15'};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toBeInstanceOf(Date);
+    });
+
+    it('should parse composite field values as strings', () => {
+      const rule: Rule = {field: 'seriesStatus', operator: 'equals', value: 'reading'};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toBe('reading');
+    });
+
+    it('should parse readingProgress values as numbers', () => {
+      const rule: Rule = {field: 'readingProgress', operator: 'greater_than', value: 50};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toBe(50);
+    });
+  });
+
+  describe('onOperatorChange', () => {
+    it('should set valueEnd to days for within_last operator', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('operator')?.setValue('within_last');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('valueEnd')?.value).toBe('days');
+      expect(ruleCtrl.get('value')?.value).toBeNull();
+    });
+
+    it('should set valueEnd to days for older_than operator', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('operator')?.setValue('older_than');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('valueEnd')?.value).toBe('days');
+      expect(ruleCtrl.get('value')?.value).toBeNull();
+    });
+
+    it('should set valueEnd to null for this_period operator', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('operator')?.setValue('this_period');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('valueEnd')?.value).toBeNull();
+      expect(ruleCtrl.get('value')?.value).toBeNull();
+    });
+
+    it('should set value to empty array for includes_any operator', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('operator')?.setValue('includes_any');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toEqual([]);
+    });
+
+    it('should clear all values for is_empty operator', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('value')?.setValue('something');
+      ruleCtrl.get('operator')?.setValue('is_empty');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBeNull();
+      expect(ruleCtrl.get('valueStart')?.value).toBeNull();
+      expect(ruleCtrl.get('valueEnd')?.value).toBeNull();
+    });
+  });
+
+  describe('option getters', () => {
+    it('should return 5 series status options', () => {
+      const options = component.seriesStatusOptions;
+      expect(options).toHaveLength(5);
+      expect(options.map(o => o.value)).toEqual(['reading', 'completed', 'ongoing', 'not_started', 'fully_read']);
+    });
+
+    it('should return 4 series gaps options', () => {
+      const options = component.seriesGapsOptions;
+      expect(options).toHaveLength(4);
+      expect(options.map(o => o.value)).toEqual(['any_gap', 'missing_first', 'missing_latest', 'duplicate_number']);
+    });
+
+    it('should return 3 series position options', () => {
+      const options = component.seriesPositionOptions;
+      expect(options).toHaveLength(3);
+      expect(options.map(o => o.value)).toEqual(['next_unread', 'first_in_series', 'last_in_series']);
+    });
+
+    it('should return 4 date unit options', () => {
+      const options = component.dateUnitOptions;
+      expect(options).toHaveLength(4);
+      expect(options.map(o => o.value)).toEqual(['days', 'weeks', 'months', 'years']);
+    });
+
+    it('should return 3 date period options', () => {
+      const options = component.datePeriodOptions;
+      expect(options).toHaveLength(3);
+      expect(options.map(o => o.value)).toEqual(['week', 'month', 'year']);
+    });
+  });
+
+  describe('fieldOptions grouping', () => {
+    it('should include readingProgress in organization group', () => {
+      const groups = component.fieldOptions;
+      const orgGroup = groups.find(g => g.label.includes('organization'));
+      const fieldValues = orgGroup?.items.map(i => i.value) ?? [];
+      expect(fieldValues).toContain('readingProgress');
+    });
+
+    it('should include seriesStatus, seriesGaps, seriesPosition in series group', () => {
+      const groups = component.fieldOptions;
+      const seriesGroup = groups.find(g => g.label.includes('series'));
+      const fieldValues = seriesGroup?.items.map(i => i.value) ?? [];
+      expect(fieldValues).toContain('seriesStatus');
+      expect(fieldValues).toContain('seriesGaps');
+      expect(fieldValues).toContain('seriesPosition');
+    });
+  });
+
+  describe('getOperatorOptionsForField edge cases', () => {
+    it('should return baseOperators + multiValueOperators for null field', () => {
+      const operators = component.getOperatorOptionsForField(null);
+      const values = operators.map(o => o.value);
+      expect(operators).toHaveLength(7);
+      expect(values).toContain('equals');
+      expect(values).toContain('not_equals');
+      expect(values).toContain('is_empty');
+      expect(values).toContain('is_not_empty');
+      expect(values).toContain('includes_any');
+      expect(values).toContain('excludes_all');
+      expect(values).toContain('includes_all');
+    });
+
+    it('should return baseOperators + multiValueOperators for undefined field', () => {
+      const operators = component.getOperatorOptionsForField(undefined);
+      const values = operators.map(o => o.value);
+      expect(operators).toHaveLength(7);
+      expect(values).toContain('equals');
+      expect(values).toContain('not_equals');
+      expect(values).toContain('is_empty');
+      expect(values).toContain('is_not_empty');
+      expect(values).toContain('includes_any');
+      expect(values).toContain('excludes_all');
+      expect(values).toContain('includes_all');
+    });
+
+    it('should include text operators for title field', () => {
+      const operators = component.getOperatorOptionsForField('title');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('contains');
+      expect(values).toContain('does_not_contain');
+      expect(values).toContain('starts_with');
+      expect(values).toContain('ends_with');
+      expect(values).toContain('includes_any');
+      expect(values).toContain('excludes_all');
+      expect(values).toContain('includes_all');
+    });
+
+    it('should NOT include text operators for library field', () => {
+      const operators = component.getOperatorOptionsForField('library');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('includes_any');
+      expect(values).not.toContain('contains');
+      expect(values).not.toContain('does_not_contain');
+      expect(values).not.toContain('starts_with');
+      expect(values).not.toContain('ends_with');
+    });
+
+    it('should NOT include text operators for readStatus field', () => {
+      const operators = component.getOperatorOptionsForField('readStatus');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('includes_any');
+      expect(values).not.toContain('contains');
+      expect(values).not.toContain('does_not_contain');
+      expect(values).not.toContain('starts_with');
+      expect(values).not.toContain('ends_with');
+    });
+
+    it('should include comparison operators for metadataScore', () => {
+      const operators = component.getOperatorOptionsForField('metadataScore');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('greater_than');
+      expect(values).toContain('greater_than_equal_to');
+      expect(values).toContain('less_than');
+      expect(values).toContain('less_than_equal_to');
+      expect(values).toContain('in_between');
+    });
+
+    it('should include relative date operators for lastReadTime', () => {
+      const operators = component.getOperatorOptionsForField('lastReadTime');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('within_last');
+      expect(values).toContain('older_than');
+      expect(values).toContain('this_period');
+    });
+
+    it('should NOT include comparison operators for string fields', () => {
+      const operators = component.getOperatorOptionsForField('title');
+      const values = operators.map(o => o.value);
+      expect(values).not.toContain('greater_than');
+      expect(values).not.toContain('greater_than_equal_to');
+      expect(values).not.toContain('less_than');
+      expect(values).not.toContain('less_than_equal_to');
+      expect(values).not.toContain('in_between');
+    });
+
+    it('should include both text and multi-value operators for authors', () => {
+      const operators = component.getOperatorOptionsForField('authors');
+      const values = operators.map(o => o.value);
+      expect(values).toContain('contains');
+      expect(values).toContain('does_not_contain');
+      expect(values).toContain('starts_with');
+      expect(values).toContain('ends_with');
+      expect(values).toContain('includes_any');
+      expect(values).toContain('excludes_all');
+      expect(values).toContain('includes_all');
+    });
+  });
+
+  describe('buildRuleFromData edge cases', () => {
+    it('should handle in_between for date fields', () => {
+      const rule: Rule = {field: 'publishedDate', operator: 'in_between' as any, value: null, valueStart: '2024-01-01', valueEnd: '2024-12-31'};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('valueStart')?.value).toBeInstanceOf(Date);
+      expect(formGroup.get('valueEnd')?.value).toBeInstanceOf(Date);
+    });
+
+    it('should handle in_between for number fields', () => {
+      const rule: Rule = {field: 'pageCount', operator: 'in_between' as any, value: null, valueStart: 100, valueEnd: 500};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('valueStart')?.value).toBe(100);
+      expect(formGroup.get('valueEnd')?.value).toBe(500);
+    });
+
+    it('should preserve array values for includes_any', () => {
+      const rule: Rule = {field: 'readStatus', operator: 'includes_any' as any, value: ['READ', 'READING']};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toEqual(['READ', 'READING']);
+    });
+
+    it('should handle is_empty operator with no value', () => {
+      const rule: Rule = {field: 'title', operator: 'is_empty' as any, value: null};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toBeNull();
+    });
+
+    it('should handle boolean field values', () => {
+      const rule: Rule = {field: 'abridged', operator: 'equals', value: 'true'};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toBe('true');
+    });
+
+    it('should handle string values for text fields', () => {
+      const rule: Rule = {field: 'title', operator: 'contains' as any, value: 'Harry Potter'};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toBe('Harry Potter');
+    });
+
+    it('should handle within_last with string number value', () => {
+      const rule: Rule = {field: 'dateFinished', operator: 'within_last', value: '30', valueEnd: 'days'};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('value')?.value).toBe(30);
+    });
+
+    it('should handle this_period with null valueEnd', () => {
+      const rule: Rule = {field: 'addedOn', operator: 'this_period', value: 'week', valueEnd: 'something'};
+      const formGroup = component.buildRuleFromData(rule);
+      expect(formGroup.get('valueEnd')?.value).toBeNull();
+    });
+  });
+
+  describe('onOperatorChange edge cases', () => {
+    it('should set value to empty array for excludes_all operator', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('operator')?.setValue('excludes_all');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toEqual([]);
+    });
+
+    it('should set value to empty array for includes_all operator', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('operator')?.setValue('includes_all');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toEqual([]);
+    });
+
+    it('should clear all values for is_not_empty operator', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('value')?.setValue('something');
+      ruleCtrl.get('valueStart')?.setValue('start');
+      ruleCtrl.get('valueEnd')?.setValue('end');
+      ruleCtrl.get('operator')?.setValue('is_not_empty');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBeNull();
+      expect(ruleCtrl.get('valueStart')?.value).toBeNull();
+      expect(ruleCtrl.get('valueEnd')?.value).toBeNull();
+    });
+
+    it('should set value to empty string for regular operators', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('operator')?.setValue('equals');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe('');
+      expect(ruleCtrl.get('valueStart')?.value).toBeNull();
+      expect(ruleCtrl.get('valueEnd')?.value).toBeNull();
+    });
+
+    it('should set value to empty string for in_between operator', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('operator')?.setValue('in_between');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe('');
+    });
+
+    it('should not affect form when called with already-set within_last', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('operator')?.setValue('within_last');
+      component.onOperatorChange(ruleCtrl);
+      ruleCtrl.get('value')?.setValue('15');
+      ruleCtrl.get('operator')?.setValue('within_last');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBeNull();
+    });
+  });
+
+  describe('onFieldChange', () => {
+    it('should reset operator and all values', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('field')?.setValue('title');
+      ruleCtrl.get('operator')?.setValue('contains');
+      ruleCtrl.get('value')?.setValue('some value');
+      ruleCtrl.get('valueStart')?.setValue('start');
+      ruleCtrl.get('valueEnd')?.setValue('end');
+      component.onFieldChange(ruleCtrl);
+      expect(ruleCtrl.get('operator')?.value).toBe('');
+      expect(ruleCtrl.get('value')?.value).toBeNull();
+      expect(ruleCtrl.get('valueStart')?.value).toBeNull();
+      expect(ruleCtrl.get('valueEnd')?.value).toBeNull();
+    });
+  });
+
+  describe('createRule and createGroup', () => {
+    it('should create rule with empty defaults', () => {
+      const rule = component.createRule();
+      expect(rule.get('field')?.value).toBe('');
+      expect(rule.get('operator')?.value).toBe('');
+      expect(rule.get('value')?.value).toBeNull();
+      expect(rule.get('valueStart')?.value).toBeNull();
+      expect(rule.get('valueEnd')?.value).toBeNull();
+    });
+
+    it('should create group with and join and empty rules', () => {
+      const group = component.createGroup();
+      expect(group.get('type')?.value).toBe('group');
+      expect(group.get('join')?.value).toBe('and');
+      expect((group.get('rules') as any).length).toBe(0);
+    });
+  });
+
+  describe('fieldOptions completeness', () => {
+    it('should have 8 groups total', () => {
+      expect(component.fieldOptions.length).toBe(8);
+    });
+
+    it('should map categories field to genre translation key', () => {
+      const groups = component.fieldOptions;
+      const bookInfoGroup = groups.find(g => g.label.includes('bookInfo'));
+      const categoriesItem = bookInfoGroup?.items.find(i => i.value === 'categories');
+      expect(categoriesItem).toBeDefined();
+      expect(categoriesItem!.label).toContain('genre');
+    });
+
+    it('should include all audiobook fields in audiobook group', () => {
+      const groups = component.fieldOptions;
+      const audiobookGroup = groups.find(g => g.label.includes('audiobook'));
+      const fieldValues = audiobookGroup?.items.map(i => i.value) ?? [];
+      expect(fieldValues).toContain('narrator');
+      expect(fieldValues).toContain('abridged');
+      expect(fieldValues).toContain('audiobookDuration');
+    });
+
+    it('should include all date fields in dates group', () => {
+      const groups = component.fieldOptions;
+      const datesGroup = groups.find(g => g.label.includes('dates'));
+      const fieldValues = datesGroup?.items.map(i => i.value) ?? [];
+      expect(fieldValues).toContain('publishedDate');
+      expect(fieldValues).toContain('dateFinished');
+      expect(fieldValues).toContain('lastReadTime');
+      expect(fieldValues).toContain('addedOn');
+    });
+  });
+
+  describe('numericFieldConfigMap', () => {
+    it('should contain readingProgress with max 100', () => {
+      const config = component.numericFieldConfigMap.get('readingProgress');
+      expect(config).toBeDefined();
+      expect(config!.type).toBe('decimal');
+      expect(config!.max).toBe(100);
+    });
+
+    it('should contain personalRating with max 10', () => {
+      const config = component.numericFieldConfigMap.get('personalRating');
+      expect(config).toBeDefined();
+      expect(config!.type).toBe('decimal');
+      expect(config!.max).toBe(10);
+    });
+
+    it('should contain pageCount with type number and no max', () => {
+      const config = component.numericFieldConfigMap.get('pageCount');
+      expect(config).toBeDefined();
+      expect(config!.type).toBe('number');
+      expect(config!.max).toBeUndefined();
+    });
+
+    it('should not contain title', () => {
+      const config = component.numericFieldConfigMap.get('title' as any);
+      expect(config).toBeUndefined();
+    });
+
+    it('should contain abridged with type boolean', () => {
+      const config = component.numericFieldConfigMap.get('abridged');
+      expect(config).toBeDefined();
+      expect(config!.type).toBe('boolean');
+    });
+  });
+
+  describe('buildGroupFromData', () => {
+    it('should build group with mixed rules and nested groups', () => {
+      const groupData = {
+        name: '',
+        type: 'group' as const,
+        join: 'or' as const,
+        rules: [
+          {field: 'title', operator: 'contains', value: 'test'} as Rule,
+          {
+            type: 'group' as const,
+            join: 'and' as const,
+            rules: [
+              {field: 'pageCount', operator: 'greater_than', value: 100} as Rule
+            ],
+            name: ''
+          }
+        ]
+      };
+      const result = component.buildGroupFromData(groupData);
+      expect(result.get('join')?.value).toBe('or');
+      const rulesArray = result.get('rules') as any;
+      expect(rulesArray.length).toBe(2);
+      const nestedGroup = rulesArray.at(1);
+      expect(nestedGroup.get('rules')).toBeDefined();
+      expect(nestedGroup.get('rules').length).toBe(1);
+    });
+
+    it('should preserve join type', () => {
+      const groupData = {
+        name: '',
+        type: 'group' as const,
+        join: 'or' as const,
+        rules: []
+      };
+      const result = component.buildGroupFromData(groupData);
+      expect(result.get('join')?.value).toBe('or');
+    });
+  });
+});

--- a/booklore-ui/src/app/features/magic-shelf/service/book-rule-evaluator.service.spec.ts
+++ b/booklore-ui/src/app/features/magic-shelf/service/book-rule-evaluator.service.spec.ts
@@ -33,7 +33,7 @@ describe('BookRuleEvaluatorService', () => {
 
   describe('fileType filtering', () => {
     it('should filter EPUB books correctly when rule uses "epub"', () => {
-      const book = createBook({ bookType: 'EPUB' });
+      const book = createBook({bookType: 'EPUB'});
       const group: GroupRule = {
         name: 'test',
         type: 'group',
@@ -52,7 +52,7 @@ describe('BookRuleEvaluatorService', () => {
     });
 
     it('should filter PDF books correctly when rule uses "pdf"', () => {
-      const book = createBook({ bookType: 'PDF' });
+      const book = createBook({bookType: 'PDF'});
       const group: GroupRule = {
         name: 'test',
         type: 'group',
@@ -71,9 +71,8 @@ describe('BookRuleEvaluatorService', () => {
     });
 
     it('should handle CBX books correctly for cbr, cbz, and cb7 rules', () => {
-      const book = createBook({ bookType: 'CBX' });
+      const book = createBook({bookType: 'CBX'});
 
-      // Test CBR
       const cbrGroup: GroupRule = {
         name: 'test',
         type: 'group',
@@ -88,7 +87,6 @@ describe('BookRuleEvaluatorService', () => {
       };
       expect(service.evaluateGroup(book, cbrGroup)).toBe(true);
 
-      // Test CBZ
       const cbzGroup: GroupRule = {
         name: 'test',
         type: 'group',
@@ -103,7 +101,6 @@ describe('BookRuleEvaluatorService', () => {
       };
       expect(service.evaluateGroup(book, cbzGroup)).toBe(true);
 
-      // Test CB7
       const cb7Group: GroupRule = {
         name: 'test',
         type: 'group',
@@ -120,7 +117,7 @@ describe('BookRuleEvaluatorService', () => {
     });
 
     it('should handle not_equals operator correctly', () => {
-      const epubBook = createBook({ bookType: 'EPUB' });
+      const epubBook = createBook({bookType: 'EPUB'});
       const group: GroupRule = {
         name: 'test',
         type: 'group',
@@ -137,15 +134,14 @@ describe('BookRuleEvaluatorService', () => {
       const result = service.evaluateGroup(epubBook, group);
       expect(result).toBe(true);
 
-      // Test the opposite case
-      const pdfBook = createBook({ bookType: 'PDF' });
+      const pdfBook = createBook({bookType: 'PDF'});
       const result2 = service.evaluateGroup(pdfBook, group);
       expect(result2).toBe(false);
     });
 
     it('should filter EPUB books correctly when rule uses "not_equals" with "epub"', () => {
-      const epubBook = createBook({ bookType: 'EPUB' });
-      const pdfBook = createBook({ bookType: 'PDF' });
+      const epubBook = createBook({bookType: 'EPUB'});
+      const pdfBook = createBook({bookType: 'PDF'});
 
       const group: GroupRule = {
         name: 'test',
@@ -160,10 +156,8 @@ describe('BookRuleEvaluatorService', () => {
         ]
       };
 
-      // EPUB book should not match when rule is "not_equals epub"
       expect(service.evaluateGroup(epubBook, group)).toBe(false);
 
-      // PDF book should match when rule is "not_equals epub"
       expect(service.evaluateGroup(pdfBook, group)).toBe(true);
     });
   });
@@ -179,8 +173,8 @@ describe('BookRuleEvaluatorService', () => {
         type: 'group',
         join: 'and',
         rules: [
-          { field: 'fileType', operator: 'equals', value: 'epub' },
-          { field: 'language', operator: 'equals', value: 'en' }
+          {field: 'fileType', operator: 'equals', value: 'epub'},
+          {field: 'language', operator: 'equals', value: 'en'}
         ]
       };
 
@@ -189,15 +183,15 @@ describe('BookRuleEvaluatorService', () => {
     });
 
     it('should evaluate group rules with OR logic', () => {
-      const book = createBook({ bookType: 'PDF' });
+      const book = createBook({bookType: 'PDF'});
 
       const group: GroupRule = {
         name: 'test',
         type: 'group',
         join: 'or',
         rules: [
-          { field: 'fileType', operator: 'equals', value: 'epub' },
-          { field: 'fileType', operator: 'equals', value: 'pdf' }
+          {field: 'fileType', operator: 'equals', value: 'epub'},
+          {field: 'fileType', operator: 'equals', value: 'pdf'}
         ]
       };
 
@@ -205,4 +199,1262 @@ describe('BookRuleEvaluatorService', () => {
       expect(result).toBe(true);
     });
   });
+
+  const rule = (field: string, operator: string, value: unknown, valueEnd?: unknown): GroupRule => ({
+    name: 'test', type: 'group', join: 'and',
+    rules: [{field, operator, value, valueEnd} as never]
+  });
+
+  const seriesBook = (num: number, status: ReadStatus, extra: Partial<Book> = {}): Book => createBook({
+    id: num * 100,
+    readStatus: status,
+    metadata: {
+      bookId: num * 100,
+      title: `Book ${num}`,
+      seriesName: 'Dune',
+      seriesNumber: num,
+      authors: [],
+      categories: [],
+      ...extra.metadata
+    },
+    ...extra
+  });
+
+  describe('within_last operator', () => {
+    it('should match addedOn within last 30 days', () => {
+      const book = createBook({addedOn: new Date().toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'within_last', 30, 'days'))).toBe(true);
+    });
+
+    it('should not match addedOn older than 30 days for within_last 30 days', () => {
+      const old = new Date();
+      old.setDate(old.getDate() - 60);
+      const book = createBook({addedOn: old.toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'within_last', 30, 'days'))).toBe(false);
+    });
+
+    it('should work with weeks unit', () => {
+      const book = createBook({addedOn: new Date().toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'within_last', 2, 'weeks'))).toBe(true);
+    });
+
+    it('should work with months unit', () => {
+      const book = createBook({addedOn: new Date().toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'within_last', 3, 'months'))).toBe(true);
+    });
+
+    it('should work with years unit', () => {
+      const book = createBook({addedOn: new Date().toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'within_last', 1, 'years'))).toBe(true);
+    });
+
+    it('should work with dateFinished', () => {
+      const book = createBook({dateFinished: new Date().toISOString()});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'within_last', 7, 'days'))).toBe(true);
+    });
+
+    it('should work with lastReadTime', () => {
+      const book = createBook({lastReadTime: new Date().toISOString()});
+      expect(service.evaluateGroup(book, rule('lastReadTime', 'within_last', 7, 'days'))).toBe(true);
+    });
+
+    it('should work with publishedDate', () => {
+      const book = createBook({metadata: {bookId: 1, publishedDate: new Date().toISOString().split('T')[0]}});
+      expect(service.evaluateGroup(book, rule('publishedDate', 'within_last', 30, 'days'))).toBe(true);
+    });
+
+    it('should return false for null date', () => {
+      const book = createBook({addedOn: undefined});
+      expect(service.evaluateGroup(book, rule('addedOn', 'within_last', 30, 'days'))).toBe(false);
+    });
+
+    it('should return false for non-date field', () => {
+      const book = createBook({metadata: {bookId: 1, title: 'Test', pageCount: 300}});
+      expect(service.evaluateGroup(book, rule('pageCount', 'within_last', 30, 'days'))).toBe(false);
+    });
+  });
+
+  describe('older_than operator', () => {
+    it('should match addedOn older than 30 days', () => {
+      const old = new Date();
+      old.setDate(old.getDate() - 60);
+      const book = createBook({addedOn: old.toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'older_than', 30, 'days'))).toBe(true);
+    });
+
+    it('should not match recent addedOn for older_than 30 days', () => {
+      const book = createBook({addedOn: new Date().toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'older_than', 30, 'days'))).toBe(false);
+    });
+
+    it('should work with months unit', () => {
+      const old = new Date();
+      old.setFullYear(old.getFullYear() - 1);
+      const book = createBook({addedOn: old.toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'older_than', 6, 'months'))).toBe(true);
+    });
+
+    it('should work with lastReadTime', () => {
+      const old = new Date();
+      old.setMonth(old.getMonth() - 4);
+      const book = createBook({lastReadTime: old.toISOString()});
+      expect(service.evaluateGroup(book, rule('lastReadTime', 'older_than', 3, 'months'))).toBe(true);
+    });
+
+    it('should return false for null date', () => {
+      const book = createBook({lastReadTime: undefined});
+      expect(service.evaluateGroup(book, rule('lastReadTime', 'older_than', 3, 'months'))).toBe(false);
+    });
+  });
+
+  describe('this_period operator', () => {
+    it('should match dateFinished this year', () => {
+      const book = createBook({dateFinished: new Date().toISOString()});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'this_period', 'year'))).toBe(true);
+    });
+
+    it('should not match dateFinished from last year for this_period year', () => {
+      const old = new Date();
+      old.setFullYear(old.getFullYear() - 2);
+      const book = createBook({dateFinished: old.toISOString()});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'this_period', 'year'))).toBe(false);
+    });
+
+    it('should match addedOn this month', () => {
+      const book = createBook({addedOn: new Date().toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'this_period', 'month'))).toBe(true);
+    });
+
+    it('should match addedOn this week', () => {
+      const book = createBook({addedOn: new Date().toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'this_period', 'week'))).toBe(true);
+    });
+
+    it('should work with publishedDate', () => {
+      const book = createBook({metadata: {bookId: 1, publishedDate: new Date().toISOString().split('T')[0]}});
+      expect(service.evaluateGroup(book, rule('publishedDate', 'this_period', 'year'))).toBe(true);
+    });
+
+    it('should return false for null date', () => {
+      const book = createBook({dateFinished: undefined});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'this_period', 'year'))).toBe(false);
+    });
+  });
+
+  describe('seriesStatus', () => {
+    it('should match "reading" when a series book is READING', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.READING);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'reading'), allBooks)).toBe(true);
+    });
+
+    it('should match "reading" when a series book is RE_READING', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.RE_READING);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'reading'), allBooks)).toBe(true);
+    });
+
+    it('should not match "reading" when no book is READING or RE_READING', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'reading'), allBooks)).toBe(false);
+    });
+
+    it('should match "not_started" when no book has been read', () => {
+      const b1 = seriesBook(1, ReadStatus.UNREAD);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'not_started'), allBooks)).toBe(true);
+    });
+
+    it('should not match "not_started" when a book is READING', () => {
+      const b1 = seriesBook(1, ReadStatus.UNREAD);
+      const b2 = seriesBook(2, ReadStatus.READING);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'not_started'), allBooks)).toBe(false);
+    });
+
+    it('should match "fully_read" when all books are READ', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.READ);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'fully_read'), allBooks)).toBe(true);
+    });
+
+    it('should not match "fully_read" when some books are not READ', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'fully_read'), allBooks)).toBe(false);
+    });
+
+    it('should match "completed" when own last book in series', () => {
+      const b1 = seriesBook(1, ReadStatus.READ, {metadata: {bookId: 100, seriesName: 'Dune', seriesNumber: 1, seriesTotal: 3}});
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b2, b3];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'completed'), allBooks)).toBe(true);
+    });
+
+    it('should not match "completed" when missing last book', () => {
+      const b1 = seriesBook(1, ReadStatus.READ, {metadata: {bookId: 100, seriesName: 'Dune', seriesNumber: 1, seriesTotal: 5}});
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'completed'), allBooks)).toBe(false);
+    });
+
+    it('should match "ongoing" when missing last book', () => {
+      const b1 = seriesBook(1, ReadStatus.READ, {metadata: {bookId: 100, seriesName: 'Dune', seriesNumber: 1, seriesTotal: 5}});
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'ongoing'), allBooks)).toBe(true);
+    });
+
+    it('should not match "ongoing" when own last book', () => {
+      const b1 = seriesBook(1, ReadStatus.READ, {metadata: {bookId: 100, seriesName: 'Dune', seriesNumber: 1, seriesTotal: 3}});
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b3];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'ongoing'), allBooks)).toBe(false);
+    });
+
+    it('should negate with not_equals', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.READING);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'not_equals', 'reading'), allBooks)).toBe(false);
+    });
+
+    it('should return false for book without series', () => {
+      const book = createBook();
+      expect(service.evaluateGroup(book, rule('seriesStatus', 'equals', 'reading'), [book])).toBe(false);
+    });
+  });
+
+  describe('seriesGaps', () => {
+    it('should match "any_gap" when series has a missing number', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b3];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'equals', 'any_gap'), allBooks)).toBe(true);
+    });
+
+    it('should not match "any_gap" when series is contiguous', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b2, b3];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'equals', 'any_gap'), allBooks)).toBe(false);
+    });
+
+    it('should match "missing_first" when book 1 is absent', () => {
+      const b2 = seriesBook(2, ReadStatus.READ);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b2, b3];
+      expect(service.evaluateGroup(b2, rule('seriesGaps', 'equals', 'missing_first'), allBooks)).toBe(true);
+    });
+
+    it('should not match "missing_first" when book 1 exists', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'equals', 'missing_first'), allBooks)).toBe(false);
+    });
+
+    it('should match "missing_latest" when final book is absent', () => {
+      const b1 = seriesBook(1, ReadStatus.READ, {metadata: {bookId: 100, seriesName: 'Dune', seriesNumber: 1, seriesTotal: 5}});
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'equals', 'missing_latest'), allBooks)).toBe(true);
+    });
+
+    it('should not match "missing_latest" when final book is present', () => {
+      const b1 = seriesBook(1, ReadStatus.READ, {metadata: {bookId: 100, seriesName: 'Dune', seriesNumber: 1, seriesTotal: 3}});
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b3];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'equals', 'missing_latest'), allBooks)).toBe(false);
+    });
+
+    it('should not match "missing_latest" when no seriesTotal is set', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'equals', 'missing_latest'), allBooks)).toBe(false);
+    });
+
+    it('should match "duplicate_number" when two books share a number', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b1dup = seriesBook(1, ReadStatus.UNREAD);
+      b1dup.id = 999;
+      const allBooks = [b1, b1dup];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'equals', 'duplicate_number'), allBooks)).toBe(true);
+    });
+
+    it('should not match "duplicate_number" when all numbers are unique', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'equals', 'duplicate_number'), allBooks)).toBe(false);
+    });
+
+    it('should return false for book without series', () => {
+      const book = createBook();
+      expect(service.evaluateGroup(book, rule('seriesGaps', 'equals', 'any_gap'), [book])).toBe(false);
+    });
+  });
+
+  describe('seriesPosition', () => {
+    it('should match "first_in_series" for lowest numbered book', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b2, b3];
+      expect(service.evaluateGroup(b1, rule('seriesPosition', 'equals', 'first_in_series'), allBooks)).toBe(true);
+      expect(service.evaluateGroup(b2, rule('seriesPosition', 'equals', 'first_in_series'), allBooks)).toBe(false);
+    });
+
+    it('should match "last_in_series" for highest numbered book', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b2, b3];
+      expect(service.evaluateGroup(b3, rule('seriesPosition', 'equals', 'last_in_series'), allBooks)).toBe(true);
+      expect(service.evaluateGroup(b2, rule('seriesPosition', 'equals', 'last_in_series'), allBooks)).toBe(false);
+    });
+
+    it('should match "next_unread" for the first unread after a read book', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b2, b3];
+      expect(service.evaluateGroup(b2, rule('seriesPosition', 'equals', 'next_unread'), allBooks)).toBe(true);
+    });
+
+    it('should not match "next_unread" for a later unread book', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b2, b3];
+      expect(service.evaluateGroup(b3, rule('seriesPosition', 'equals', 'next_unread'), allBooks)).toBe(false);
+    });
+
+    it('should not match "next_unread" for a READ book', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesPosition', 'equals', 'next_unread'), allBooks)).toBe(false);
+    });
+
+    it('should not match "next_unread" when no prior book is read', () => {
+      const b1 = seriesBook(1, ReadStatus.UNREAD);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesPosition', 'equals', 'next_unread'), allBooks)).toBe(false);
+    });
+
+    it('should negate with not_equals', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesPosition', 'not_equals', 'first_in_series'), allBooks)).toBe(false);
+    });
+
+    it('should return false for book without seriesNumber', () => {
+      const book = createBook({metadata: {bookId: 1, seriesName: 'Dune'}});
+      expect(service.evaluateGroup(book, rule('seriesPosition', 'equals', 'first_in_series'), [book])).toBe(false);
+    });
+
+    it('should return false for book without series', () => {
+      const book = createBook();
+      expect(service.evaluateGroup(book, rule('seriesPosition', 'equals', 'first_in_series'), [book])).toBe(false);
+    });
+  });
+
+  describe('readingProgress', () => {
+    it('should return max of all progress sources', () => {
+      const book = createBook({
+        epubProgress: {cfi: '', percentage: 45},
+        pdfProgress: {page: 10, percentage: 20},
+        koreaderProgress: {percentage: 80}
+      });
+      expect(service.evaluateGroup(book, rule('readingProgress', 'greater_than', 70))).toBe(true);
+      expect(service.evaluateGroup(book, rule('readingProgress', 'greater_than', 85))).toBe(false);
+    });
+
+    it('should return 0 when no progress exists', () => {
+      const book = createBook();
+      expect(service.evaluateGroup(book, rule('readingProgress', 'equals', 0))).toBe(true);
+    });
+
+    it('should work with less_than', () => {
+      const book = createBook({epubProgress: {cfi: '', percentage: 5}});
+      expect(service.evaluateGroup(book, rule('readingProgress', 'less_than', 10))).toBe(true);
+    });
+
+    it('should work with in_between', () => {
+      const book = createBook({pdfProgress: {page: 50, percentage: 50}});
+      const g: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [{field: 'readingProgress', operator: 'in_between', value: null, valueStart: 40, valueEnd: 60}]
+      };
+      expect(service.evaluateGroup(book, g)).toBe(true);
+    });
+
+    it('should pick kobo progress when it is the highest', () => {
+      const book = createBook({koboProgress: {percentage: 95}});
+      expect(service.evaluateGroup(book, rule('readingProgress', 'greater_than', 90))).toBe(true);
+    });
+
+    it('should pick cbx progress when it is the highest', () => {
+      const book = createBook({cbxProgress: {page: 5, percentage: 60}});
+      expect(service.evaluateGroup(book, rule('readingProgress', 'greater_than_equal_to', 60))).toBe(true);
+    });
+
+    it('should pick audiobook progress when it is the highest', () => {
+      const book = createBook({audiobookProgress: {positionMs: 1000, percentage: 75}});
+      expect(service.evaluateGroup(book, rule('readingProgress', 'greater_than', 70))).toBe(true);
+    });
+  });
+
+  describe('new fields', () => {
+    it('should filter by addedOn with equals', () => {
+      const date = '2025-06-15T10:00:00Z';
+      const book = createBook({addedOn: date});
+      expect(service.evaluateGroup(book, rule('addedOn', 'equals', date))).toBe(true);
+    });
+
+    it('should filter by description with contains', () => {
+      const book = createBook({metadata: {bookId: 1, description: 'A tale of dragons and fire'}});
+      expect(service.evaluateGroup(book, rule('description', 'contains', 'dragon'))).toBe(true);
+    });
+
+    it('should filter by narrator with contains', () => {
+      const book = createBook({metadata: {bookId: 1, narrator: 'Stephen Fry'}});
+      expect(service.evaluateGroup(book, rule('narrator', 'contains', 'fry'))).toBe(true);
+    });
+
+    it('should filter by ageRating with greater_than', () => {
+      const book = createBook({metadata: {bookId: 1, ageRating: 16}});
+      expect(service.evaluateGroup(book, rule('ageRating', 'greater_than', 13))).toBe(true);
+    });
+
+    it('should filter by contentRating with equals', () => {
+      const book = createBook({metadata: {bookId: 1, contentRating: 'MATURE'}});
+      expect(service.evaluateGroup(book, rule('contentRating', 'equals', 'MATURE'))).toBe(true);
+    });
+
+    it('should filter by audibleRating with greater_than_equal_to', () => {
+      const book = createBook({metadata: {bookId: 1, audibleRating: 4.5}});
+      expect(service.evaluateGroup(book, rule('audibleRating', 'greater_than_equal_to', 4))).toBe(true);
+    });
+
+    it('should filter by audibleReviewCount', () => {
+      const book = createBook({metadata: {bookId: 1, audibleReviewCount: 500}});
+      expect(service.evaluateGroup(book, rule('audibleReviewCount', 'greater_than', 100))).toBe(true);
+    });
+
+    it('should filter by abridged with equals true', () => {
+      const book = createBook({metadata: {bookId: 1, abridged: true}});
+      expect(service.evaluateGroup(book, rule('abridged', 'equals', true))).toBe(true);
+    });
+
+    it('should filter by abridged with equals false', () => {
+      const book = createBook({metadata: {bookId: 1, abridged: false}});
+      expect(service.evaluateGroup(book, rule('abridged', 'equals', false))).toBe(true);
+    });
+
+    it('should filter by audiobookDuration', () => {
+      const book = createBook({
+        metadata: {bookId: 1, audiobookMetadata: {durationSeconds: 36000}}
+      });
+      expect(service.evaluateGroup(book, rule('audiobookDuration', 'greater_than', 30000))).toBe(true);
+    });
+
+    it('should return null for audiobookDuration when no metadata', () => {
+      const book = createBook();
+      expect(service.evaluateGroup(book, rule('audiobookDuration', 'is_empty', null))).toBe(true);
+    });
+
+    it('should filter by isPhysical', () => {
+      const book = createBook({isPhysical: true});
+      expect(service.evaluateGroup(book, rule('isPhysical', 'equals', true))).toBe(true);
+    });
+
+    it('should filter by lubimyczytacRating', () => {
+      const book = createBook({metadata: {bookId: 1, lubimyczytacRating: 4.2}});
+      expect(service.evaluateGroup(book, rule('lubimyczytacRating', 'greater_than', 4))).toBe(true);
+    });
+
+    it('should filter by categories with includes_any', () => {
+      const book = createBook({metadata: {bookId: 1, categories: ['Science Fiction', 'Fantasy']}});
+      expect(service.evaluateGroup(book, rule('categories', 'includes_any', ['fantasy']))).toBe(true);
+    });
+
+    it('should handle categories with includes_all', () => {
+      const book = createBook({metadata: {bookId: 1, categories: ['Science Fiction', 'Fantasy']}});
+      expect(service.evaluateGroup(book, rule('categories', 'includes_all', ['science fiction', 'fantasy']))).toBe(true);
+    });
+
+    it('should handle categories with excludes_all', () => {
+      const book = createBook({metadata: {bookId: 1, categories: ['Science Fiction']}});
+      expect(service.evaluateGroup(book, rule('categories', 'excludes_all', ['horror', 'romance']))).toBe(true);
+    });
+
+    it('should filter by description is_empty', () => {
+      const book = createBook({metadata: {bookId: 1}});
+      expect(service.evaluateGroup(book, rule('description', 'is_empty', null))).toBe(true);
+    });
+
+    it('should filter by narrator is_not_empty', () => {
+      const book = createBook({metadata: {bookId: 1, narrator: 'John Smith'}});
+      expect(service.evaluateGroup(book, rule('narrator', 'is_not_empty', null))).toBe(true);
+    });
+  });
+
+  describe('combined Part 3 rules', () => {
+    it('should evaluate "Gathering Dust": UNREAD AND addedOn older_than 1 year', () => {
+      const old = new Date();
+      old.setFullYear(old.getFullYear() - 2);
+      const book = createBook({readStatus: ReadStatus.UNREAD, addedOn: old.toISOString()});
+      const group: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [
+          {field: 'readStatus', operator: 'equals', value: 'UNREAD'},
+          {field: 'addedOn', operator: 'older_than', value: 1, valueEnd: 'years'}
+        ]
+      };
+      expect(service.evaluateGroup(book, group)).toBe(true);
+    });
+
+    it('should evaluate "Barely Started": readingProgress < 10 AND READING/RE_READING', () => {
+      const book = createBook({
+        readStatus: ReadStatus.READING,
+        epubProgress: {cfi: '', percentage: 5}
+      });
+      const group: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [
+          {field: 'readingProgress', operator: 'less_than', value: 10},
+          {field: 'readStatus', operator: 'includes_any', value: ['READING', 'RE_READING']}
+        ]
+      };
+      expect(service.evaluateGroup(book, group)).toBe(true);
+    });
+
+    it('should evaluate "Completed Series Not Started": completed AND not_started', () => {
+      const b1 = seriesBook(1, ReadStatus.UNREAD, {metadata: {bookId: 100, seriesName: 'Dune', seriesNumber: 1, seriesTotal: 3}});
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b2, b3];
+      const group: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [
+          {field: 'seriesStatus', operator: 'equals', value: 'completed'},
+          {field: 'seriesStatus', operator: 'equals', value: 'not_started'}
+        ]
+      };
+      expect(service.evaluateGroup(b1, group, allBooks)).toBe(true);
+    });
+
+    it('should evaluate "Ongoing Series Im Behind On": ongoing AND NOT reading', () => {
+      const b1 = seriesBook(1, ReadStatus.READ, {metadata: {bookId: 100, seriesName: 'Dune', seriesNumber: 1, seriesTotal: 5}});
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b1, b2];
+      const group: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [
+          {field: 'seriesStatus', operator: 'equals', value: 'ongoing'},
+          {field: 'seriesStatus', operator: 'not_equals', value: 'reading'}
+        ]
+      };
+      expect(service.evaluateGroup(b1, group, allBooks)).toBe(true);
+    });
+  });
+
+  describe('evaluateGroup edge cases', () => {
+    it('should handle nested groups', () => {
+      const book = createBook({readStatus: ReadStatus.READING, metadata: {bookId: 1, title: 'Epic', language: 'en', categories: ['Fantasy']}});
+      const group: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [
+          {field: 'language', operator: 'equals', value: 'en'},
+          {
+            type: 'group', join: 'or', rules: [
+              {field: 'readStatus', operator: 'equals', value: 'READ'},
+              {field: 'readStatus', operator: 'equals', value: 'READING'}
+            ]
+          } as never
+        ]
+      };
+      expect(service.evaluateGroup(book, group)).toBe(true);
+    });
+
+    it('should pass allBooks through to nested groups', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.READING);
+      const allBooks = [b1, b2];
+      const group: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [
+          {
+            type: 'group', join: 'and', rules: [
+              {field: 'seriesStatus', operator: 'equals', value: 'reading'}
+            ]
+          } as never
+        ]
+      };
+      expect(service.evaluateGroup(b1, group, allBooks)).toBe(true);
+    });
+
+    it('should return true for AND with empty rules', () => {
+      const book = createBook();
+      const group: GroupRule = {name: 'test', type: 'group', join: 'and', rules: []};
+      expect(service.evaluateGroup(book, group)).toBe(true);
+    });
+
+    it('should return false for OR with empty rules', () => {
+      const book = createBook();
+      const group: GroupRule = {name: 'test', type: 'group', join: 'or', rules: []};
+      expect(service.evaluateGroup(book, group)).toBe(false);
+    });
+
+    it('should fail AND when one rule fails', () => {
+      const book = createBook({readStatus: ReadStatus.READING});
+      const group: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [
+          {field: 'readStatus', operator: 'equals', value: 'READING'},
+          {field: 'readStatus', operator: 'equals', value: 'READ'}
+        ]
+      };
+      expect(service.evaluateGroup(book, group)).toBe(false);
+    });
+
+    it('should pass OR when one rule passes', () => {
+      const book = createBook({readStatus: ReadStatus.READING});
+      const group: GroupRule = {
+        name: 'test', type: 'group', join: 'or',
+        rules: [
+          {field: 'readStatus', operator: 'equals', value: 'READ'},
+          {field: 'readStatus', operator: 'equals', value: 'READING'}
+        ]
+      };
+      expect(service.evaluateGroup(book, group)).toBe(true);
+    });
+  });
+
+  describe('equals and not_equals edge cases', () => {
+    it('should match equals on array field (authors)', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Brandon Sanderson', 'Robert Jordan']}});
+      expect(service.evaluateGroup(book, rule('authors', 'equals', 'brandon sanderson'))).toBe(true);
+    });
+
+    it('should not match equals on array when value absent', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Brandon Sanderson']}});
+      expect(service.evaluateGroup(book, rule('authors', 'equals', 'patrick rothfuss'))).toBe(false);
+    });
+
+    it('should match not_equals on array field (all must differ)', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Brandon Sanderson']}});
+      expect(service.evaluateGroup(book, rule('authors', 'not_equals', 'patrick rothfuss'))).toBe(true);
+    });
+
+    it('should not match not_equals on array when value present', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Brandon Sanderson']}});
+      expect(service.evaluateGroup(book, rule('authors', 'not_equals', 'brandon sanderson'))).toBe(false);
+    });
+
+    it('should compare dates with equals', () => {
+      const date = '2024-06-15T00:00:00Z';
+      const book = createBook({dateFinished: date});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'equals', date))).toBe(true);
+    });
+
+    it('should compare dates with not_equals', () => {
+      const book = createBook({dateFinished: '2024-06-15T00:00:00Z'});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'not_equals', '2024-01-01T00:00:00Z'))).toBe(true);
+    });
+
+    it('should compare strings case-insensitively', () => {
+      const book = createBook({metadata: {bookId: 1, title: 'The Great Gatsby'}});
+      expect(service.evaluateGroup(book, rule('title', 'equals', 'THE GREAT GATSBY'))).toBe(true);
+    });
+
+    it('should compare numbers with equals', () => {
+      const book = createBook({metadata: {bookId: 1, pageCount: 350}});
+      expect(service.evaluateGroup(book, rule('pageCount', 'equals', 350))).toBe(true);
+    });
+
+    it('should handle library id (numeric id field) with equals', () => {
+      const book = createBook({libraryId: 42});
+      expect(service.evaluateGroup(book, rule('library', 'equals', 42))).toBe(true);
+    });
+
+    it('should handle shelf id (numeric id field) with includes_any', () => {
+      const book = createBook({shelves: [{id: 5, name: 'Fav', icon: ''}]});
+      expect(service.evaluateGroup(book, rule('shelf', 'includes_any', [5]))).toBe(true);
+    });
+
+    it('should handle shelf with excludes_all', () => {
+      const book = createBook({shelves: [{id: 5, name: 'Fav', icon: ''}]});
+      expect(service.evaluateGroup(book, rule('shelf', 'excludes_all', [99]))).toBe(true);
+      expect(service.evaluateGroup(book, rule('shelf', 'excludes_all', [5]))).toBe(false);
+    });
+
+    it('should handle readStatus UNSET when book has no readStatus', () => {
+      const book = createBook({readStatus: undefined});
+      expect(service.evaluateGroup(book, rule('readStatus', 'equals', 'UNSET'))).toBe(true);
+    });
+  });
+
+  describe('text operators', () => {
+    it('should match contains on array field (authors)', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Brandon Sanderson']}});
+      expect(service.evaluateGroup(book, rule('authors', 'contains', 'sanderson'))).toBe(true);
+    });
+
+    it('should not match contains on array when no element matches', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Brandon Sanderson']}});
+      expect(service.evaluateGroup(book, rule('authors', 'contains', 'rothfuss'))).toBe(false);
+    });
+
+    it('should match does_not_contain on string', () => {
+      const book = createBook({metadata: {bookId: 1, title: 'The Great Gatsby'}});
+      expect(service.evaluateGroup(book, rule('title', 'does_not_contain', 'hobbit'))).toBe(true);
+    });
+
+    it('should not match does_not_contain when string matches', () => {
+      const book = createBook({metadata: {bookId: 1, title: 'The Great Gatsby'}});
+      expect(service.evaluateGroup(book, rule('title', 'does_not_contain', 'gatsby'))).toBe(false);
+    });
+
+    it('should match does_not_contain on array field', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Brandon Sanderson']}});
+      expect(service.evaluateGroup(book, rule('authors', 'does_not_contain', 'rothfuss'))).toBe(true);
+    });
+
+    it('should not match does_not_contain on array when any element matches', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Brandon Sanderson', 'Robert Jordan']}});
+      expect(service.evaluateGroup(book, rule('authors', 'does_not_contain', 'jordan'))).toBe(false);
+    });
+
+    it('should match starts_with on string', () => {
+      const book = createBook({metadata: {bookId: 1, title: 'The Great Gatsby'}});
+      expect(service.evaluateGroup(book, rule('title', 'starts_with', 'the great'))).toBe(true);
+    });
+
+    it('should not match starts_with when prefix differs', () => {
+      const book = createBook({metadata: {bookId: 1, title: 'The Great Gatsby'}});
+      expect(service.evaluateGroup(book, rule('title', 'starts_with', 'gatsby'))).toBe(false);
+    });
+
+    it('should match starts_with on array (authors)', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Brandon Sanderson']}});
+      expect(service.evaluateGroup(book, rule('authors', 'starts_with', 'brandon'))).toBe(true);
+    });
+
+    it('should match ends_with on string', () => {
+      const book = createBook({metadata: {bookId: 1, title: 'The Great Gatsby'}});
+      expect(service.evaluateGroup(book, rule('title', 'ends_with', 'gatsby'))).toBe(true);
+    });
+
+    it('should not match ends_with when suffix differs', () => {
+      const book = createBook({metadata: {bookId: 1, title: 'The Great Gatsby'}});
+      expect(service.evaluateGroup(book, rule('title', 'ends_with', 'great'))).toBe(false);
+    });
+
+    it('should match ends_with on array (authors)', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Brandon Sanderson']}});
+      expect(service.evaluateGroup(book, rule('authors', 'ends_with', 'sanderson'))).toBe(true);
+    });
+
+    it('should return false for contains on non-string value', () => {
+      const book = createBook({metadata: {bookId: 1, pageCount: 350}});
+      expect(service.evaluateGroup(book, rule('pageCount', 'contains', '35'))).toBe(false);
+    });
+
+    it('should return true for does_not_contain on non-string value', () => {
+      const book = createBook({metadata: {bookId: 1, pageCount: 350}});
+      expect(service.evaluateGroup(book, rule('pageCount', 'does_not_contain', '35'))).toBe(true);
+    });
+
+    it('should return false for starts_with on non-string value', () => {
+      const book = createBook({metadata: {bookId: 1, pageCount: 350}});
+      expect(service.evaluateGroup(book, rule('pageCount', 'starts_with', '3'))).toBe(false);
+    });
+
+    it('should return false for ends_with on non-string value', () => {
+      const book = createBook({metadata: {bookId: 1, pageCount: 350}});
+      expect(service.evaluateGroup(book, rule('pageCount', 'ends_with', '0'))).toBe(false);
+    });
+  });
+
+  describe('date comparison operators', () => {
+    it('should match greater_than on dates', () => {
+      const book = createBook({dateFinished: '2024-06-15T00:00:00Z'});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'greater_than', '2024-01-01T00:00:00Z'))).toBe(true);
+    });
+
+    it('should not match greater_than when date is earlier', () => {
+      const book = createBook({dateFinished: '2024-01-01T00:00:00Z'});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'greater_than', '2024-06-15T00:00:00Z'))).toBe(false);
+    });
+
+    it('should match greater_than_equal_to on exact date', () => {
+      const date = '2024-06-15T00:00:00Z';
+      const book = createBook({dateFinished: date});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'greater_than_equal_to', date))).toBe(true);
+    });
+
+    it('should match less_than on dates', () => {
+      const book = createBook({dateFinished: '2024-01-01T00:00:00Z'});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'less_than', '2024-06-15T00:00:00Z'))).toBe(true);
+    });
+
+    it('should match less_than_equal_to on exact date', () => {
+      const date = '2024-06-15T00:00:00Z';
+      const book = createBook({dateFinished: date});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'less_than_equal_to', date))).toBe(true);
+    });
+
+    it('should match in_between on dates', () => {
+      const book = createBook({dateFinished: '2024-06-15T00:00:00Z'});
+      const g: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [{field: 'dateFinished', operator: 'in_between', value: null, valueStart: '2024-01-01T00:00:00Z', valueEnd: '2024-12-31T00:00:00Z'}]
+      };
+      expect(service.evaluateGroup(book, g)).toBe(true);
+    });
+
+    it('should not match in_between when date outside range', () => {
+      const book = createBook({dateFinished: '2023-06-15T00:00:00Z'});
+      const g: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [{field: 'dateFinished', operator: 'in_between', value: null, valueStart: '2024-01-01T00:00:00Z', valueEnd: '2024-12-31T00:00:00Z'}]
+      };
+      expect(service.evaluateGroup(book, g)).toBe(false);
+    });
+
+    it('should return false for in_between when value is null', () => {
+      const book = createBook({dateFinished: undefined});
+      const g: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [{field: 'dateFinished', operator: 'in_between', value: null, valueStart: '2024-01-01T00:00:00Z', valueEnd: '2024-12-31T00:00:00Z'}]
+      };
+      expect(service.evaluateGroup(book, g)).toBe(false);
+    });
+  });
+
+  describe('numeric comparison edge cases', () => {
+    it('should match less_than_equal_to on number', () => {
+      const book = createBook({metadata: {bookId: 1, pageCount: 200}});
+      expect(service.evaluateGroup(book, rule('pageCount', 'less_than_equal_to', 200))).toBe(true);
+      expect(service.evaluateGroup(book, rule('pageCount', 'less_than_equal_to', 199))).toBe(false);
+    });
+
+    it('should match in_between on number', () => {
+      const book = createBook({metadata: {bookId: 1, pageCount: 300}});
+      const g: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [{field: 'pageCount', operator: 'in_between', value: null, valueStart: 100, valueEnd: 500}]
+      };
+      expect(service.evaluateGroup(book, g)).toBe(true);
+    });
+
+    it('should match fileSize with greater_than', () => {
+      const book = createBook({fileSizeKb: 5000});
+      expect(service.evaluateGroup(book, rule('fileSize', 'greater_than', 1000))).toBe(true);
+    });
+
+    it('should match metadataScore with less_than', () => {
+      const book = createBook({metadataMatchScore: 45});
+      expect(service.evaluateGroup(book, rule('metadataScore', 'less_than', 50))).toBe(true);
+    });
+
+    it('should match personalRating with equals', () => {
+      const book = createBook({personalRating: 8});
+      expect(service.evaluateGroup(book, rule('personalRating', 'equals', 8))).toBe(true);
+    });
+
+    it('should match seriesNumber with greater_than', () => {
+      const book = createBook({metadata: {bookId: 1, seriesName: 'Dune', seriesNumber: 5}});
+      expect(service.evaluateGroup(book, rule('seriesNumber', 'greater_than', 3))).toBe(true);
+    });
+
+    it('should match seriesTotal with equals', () => {
+      const book = createBook({metadata: {bookId: 1, seriesName: 'Dune', seriesTotal: 10}});
+      expect(service.evaluateGroup(book, rule('seriesTotal', 'equals', 10))).toBe(true);
+    });
+  });
+
+  describe('is_empty and is_not_empty edge cases', () => {
+    it('should match is_empty on empty string', () => {
+      const book = createBook({metadata: {bookId: 1, title: '  '}});
+      expect(service.evaluateGroup(book, rule('title', 'is_empty', null))).toBe(true);
+    });
+
+    it('should not match is_empty on non-empty string', () => {
+      const book = createBook({metadata: {bookId: 1, title: 'Test'}});
+      expect(service.evaluateGroup(book, rule('title', 'is_empty', null))).toBe(false);
+    });
+
+    it('should match is_empty on empty array', () => {
+      const book = createBook({metadata: {bookId: 1, authors: []}});
+      expect(service.evaluateGroup(book, rule('authors', 'is_empty', null))).toBe(true);
+    });
+
+    it('should not match is_empty on non-empty array', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Author']}});
+      expect(service.evaluateGroup(book, rule('authors', 'is_empty', null))).toBe(false);
+    });
+
+    it('should match is_empty on null value', () => {
+      const book = createBook({metadata: {bookId: 1, publisher: undefined}});
+      expect(service.evaluateGroup(book, rule('publisher', 'is_empty', null))).toBe(true);
+    });
+
+    it('should return false for is_empty on a number', () => {
+      const book = createBook({metadata: {bookId: 1, pageCount: 0}});
+      expect(service.evaluateGroup(book, rule('pageCount', 'is_empty', null))).toBe(false);
+    });
+
+    it('should match is_not_empty on non-empty array', () => {
+      const book = createBook({metadata: {bookId: 1, tags: ['sci-fi']}});
+      expect(service.evaluateGroup(book, rule('tags', 'is_not_empty', null))).toBe(true);
+    });
+
+    it('should not match is_not_empty on null', () => {
+      const book = createBook({metadata: {bookId: 1, isbn13: undefined}});
+      expect(service.evaluateGroup(book, rule('isbn13', 'is_not_empty', null))).toBe(false);
+    });
+
+    it('should return true for is_not_empty on a number', () => {
+      const book = createBook({metadata: {bookId: 1, pageCount: 100}});
+      expect(service.evaluateGroup(book, rule('pageCount', 'is_not_empty', null))).toBe(true);
+    });
+  });
+
+  describe('multi-value operator edge cases', () => {
+    it('should not match includes_any when no values match', () => {
+      const book = createBook({metadata: {bookId: 1, categories: ['Fiction']}});
+      expect(service.evaluateGroup(book, rule('categories', 'includes_any', ['horror', 'romance']))).toBe(false);
+    });
+
+    it('should match includes_all when all present', () => {
+      const book = createBook({metadata: {bookId: 1, moods: ['dark', 'atmospheric', 'tense']}});
+      expect(service.evaluateGroup(book, rule('moods', 'includes_all', ['dark', 'tense']))).toBe(true);
+    });
+
+    it('should not match includes_all when one is missing', () => {
+      const book = createBook({metadata: {bookId: 1, moods: ['dark', 'atmospheric']}});
+      expect(service.evaluateGroup(book, rule('moods', 'includes_all', ['dark', 'tense']))).toBe(false);
+    });
+
+    it('should not match excludes_all when one value matches', () => {
+      const book = createBook({metadata: {bookId: 1, tags: ['sci-fi', 'space']}});
+      expect(service.evaluateGroup(book, rule('tags', 'excludes_all', ['space', 'western']))).toBe(false);
+    });
+
+    it('should match excludes_all when no values match', () => {
+      const book = createBook({metadata: {bookId: 1, tags: ['sci-fi', 'space']}});
+      expect(service.evaluateGroup(book, rule('tags', 'excludes_all', ['western', 'noir']))).toBe(true);
+    });
+
+    it('should handle includes_any on readStatus', () => {
+      const book = createBook({readStatus: ReadStatus.PAUSED});
+      expect(service.evaluateGroup(book, rule('readStatus', 'includes_any', ['PAUSED', 'ABANDONED']))).toBe(true);
+    });
+
+    it('should handle includes_any on language', () => {
+      const book = createBook({metadata: {bookId: 1, language: 'en'}});
+      expect(service.evaluateGroup(book, rule('language', 'includes_any', ['en', 'fr']))).toBe(true);
+    });
+
+    it('should handle includes_any with fileType mapping', () => {
+      const book = createBook({bookType: 'CBX'});
+      expect(service.evaluateGroup(book, rule('fileType', 'includes_any', ['cbr', 'pdf']))).toBe(true);
+    });
+
+    it('should handle null rule value as empty list', () => {
+      const book = createBook({metadata: {bookId: 1, authors: ['Author']}});
+      expect(service.evaluateGroup(book, rule('authors', 'includes_any', null))).toBe(false);
+    });
+  });
+
+  describe('fileType mapping edge cases', () => {
+    it('should map azw to azw3', () => {
+      const book = createBook({bookType: 'AZW3'});
+      expect(service.evaluateGroup(book, rule('fileType', 'equals', 'azw'))).toBe(true);
+    });
+
+    it('should handle MOBI bookType', () => {
+      const book = createBook({bookType: 'MOBI'});
+      expect(service.evaluateGroup(book, rule('fileType', 'equals', 'mobi'))).toBe(true);
+    });
+
+    it('should handle not_equals with fileType cbr mapping', () => {
+      const book = createBook({bookType: 'PDF'});
+      expect(service.evaluateGroup(book, rule('fileType', 'not_equals', 'cbr'))).toBe(true);
+    });
+  });
+
+  describe('extractBookValue coverage', () => {
+    it('should extract subtitle', () => {
+      const book = createBook({metadata: {bookId: 1, subtitle: 'A Novel'}});
+      expect(service.evaluateGroup(book, rule('subtitle', 'equals', 'a novel'))).toBe(true);
+    });
+
+    it('should extract isbn13', () => {
+      const book = createBook({metadata: {bookId: 1, isbn13: '9780123456789'}});
+      expect(service.evaluateGroup(book, rule('isbn13', 'equals', '9780123456789'))).toBe(true);
+    });
+
+    it('should extract isbn10', () => {
+      const book = createBook({metadata: {bookId: 1, isbn10: '0123456789'}});
+      expect(service.evaluateGroup(book, rule('isbn10', 'equals', '0123456789'))).toBe(true);
+    });
+
+    it('should extract seriesName', () => {
+      const book = createBook({metadata: {bookId: 1, seriesName: 'Wheel of Time'}});
+      expect(service.evaluateGroup(book, rule('seriesName', 'contains', 'wheel'))).toBe(true);
+    });
+
+    it('should extract amazonRating', () => {
+      const book = createBook({metadata: {bookId: 1, amazonRating: 4.3}});
+      expect(service.evaluateGroup(book, rule('amazonRating', 'greater_than', 4))).toBe(true);
+    });
+
+    it('should extract goodreadsRating', () => {
+      const book = createBook({metadata: {bookId: 1, goodreadsRating: 4.1}});
+      expect(service.evaluateGroup(book, rule('goodreadsRating', 'greater_than', 4))).toBe(true);
+    });
+
+    it('should extract hardcoverRating', () => {
+      const book = createBook({metadata: {bookId: 1, hardcoverRating: 3.8}});
+      expect(service.evaluateGroup(book, rule('hardcoverRating', 'less_than', 4))).toBe(true);
+    });
+
+    it('should extract ranobedbRating', () => {
+      const book = createBook({metadata: {bookId: 1, ranobedbRating: 4.5}});
+      expect(service.evaluateGroup(book, rule('ranobedbRating', 'equals', 4.5))).toBe(true);
+    });
+
+    it('should extract amazonReviewCount', () => {
+      const book = createBook({metadata: {bookId: 1, amazonReviewCount: 1200}});
+      expect(service.evaluateGroup(book, rule('amazonReviewCount', 'greater_than', 1000))).toBe(true);
+    });
+
+    it('should extract goodreadsReviewCount', () => {
+      const book = createBook({metadata: {bookId: 1, goodreadsReviewCount: 5000}});
+      expect(service.evaluateGroup(book, rule('goodreadsReviewCount', 'greater_than', 1000))).toBe(true);
+    });
+
+    it('should extract hardcoverReviewCount', () => {
+      const book = createBook({metadata: {bookId: 1, hardcoverReviewCount: 300}});
+      expect(service.evaluateGroup(book, rule('hardcoverReviewCount', 'less_than', 500))).toBe(true);
+    });
+
+    it('should return null for publishedDate when missing', () => {
+      const book = createBook({metadata: {bookId: 1}});
+      expect(service.evaluateGroup(book, rule('publishedDate', 'is_empty', null))).toBe(true);
+    });
+
+    it('should return null for dateFinished when missing', () => {
+      const book = createBook({dateFinished: undefined});
+      expect(service.evaluateGroup(book, rule('dateFinished', 'is_empty', null))).toBe(true);
+    });
+
+    it('should return null for lastReadTime when missing', () => {
+      const book = createBook({lastReadTime: undefined});
+      expect(service.evaluateGroup(book, rule('lastReadTime', 'is_empty', null))).toBe(true);
+    });
+
+    it('should handle default field via dynamic property', () => {
+      const book = createBook();
+      (book as Record<string, unknown>)['customField'] = 'hello';
+      expect(service.evaluateGroup(book, rule('customField' as never, 'equals', 'hello'))).toBe(true);
+    });
+  });
+
+  describe('seriesStatus edge cases', () => {
+    it('should not match "not_started" when a book is PARTIALLY_READ', () => {
+      const b1 = seriesBook(1, ReadStatus.UNREAD);
+      const b2 = seriesBook(2, ReadStatus.PARTIALLY_READ);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'not_started'), allBooks)).toBe(false);
+    });
+
+    it('should not match "completed" when no seriesTotal exists', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.READ);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'completed'), allBooks)).toBe(false);
+    });
+
+    it('should not match "ongoing" when no seriesTotal exists', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.READ);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'ongoing'), allBooks)).toBe(false);
+    });
+
+    it('should return false for unknown status value', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const allBooks = [b1];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'bogus'), allBooks)).toBe(false);
+    });
+
+    it('should handle completed with fractional seriesNumber matching floor(total)', () => {
+      const b1 = seriesBook(1, ReadStatus.READ, {metadata: {bookId: 100, seriesName: 'Dune', seriesNumber: 1, seriesTotal: 3}});
+      const b3 = createBook({
+        id: 300, readStatus: ReadStatus.UNREAD,
+        metadata: {bookId: 300, seriesName: 'Dune', seriesNumber: 3.5}
+      });
+      const allBooks = [b1, b3];
+      expect(service.evaluateGroup(b1, rule('seriesStatus', 'equals', 'completed'), allBooks)).toBe(true);
+    });
+
+    it('should only match series books from same series name', () => {
+      const dune1 = seriesBook(1, ReadStatus.READING);
+      const other = createBook({
+        id: 200, readStatus: ReadStatus.UNREAD,
+        metadata: {bookId: 200, seriesName: 'Foundation', seriesNumber: 1}
+      });
+      const allBooks = [dune1, other];
+      expect(service.evaluateGroup(other, rule('seriesStatus', 'equals', 'not_started'), allBooks)).toBe(true);
+      expect(service.evaluateGroup(dune1, rule('seriesStatus', 'equals', 'reading'), allBooks)).toBe(true);
+    });
+  });
+
+  describe('seriesGaps edge cases', () => {
+    it('should handle fractional series numbers with floor for any_gap', () => {
+      const b1 = createBook({
+        id: 100, readStatus: ReadStatus.READ,
+        metadata: {bookId: 100, seriesName: 'Dune', seriesNumber: 1.5}
+      });
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b3];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'equals', 'any_gap'), allBooks)).toBe(true);
+    });
+
+    it('should return false for unknown gap value', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const allBooks = [b1];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'equals', 'bogus'), allBooks)).toBe(false);
+    });
+
+    it('should return false when series has no numbered books', () => {
+      const book = createBook({metadata: {bookId: 1, seriesName: 'Dune'}});
+      expect(service.evaluateGroup(book, rule('seriesGaps', 'equals', 'any_gap'), [book])).toBe(false);
+    });
+
+    it('should negate gaps with not_equals', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const allBooks = [b1, b2, b3];
+      expect(service.evaluateGroup(b1, rule('seriesGaps', 'not_equals', 'any_gap'), allBooks)).toBe(true);
+    });
+  });
+
+  describe('seriesPosition edge cases', () => {
+    it('should handle next_unread when all books are read', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.READ);
+      const allBooks = [b1, b2];
+      expect(service.evaluateGroup(b1, rule('seriesPosition', 'equals', 'next_unread'), allBooks)).toBe(false);
+      expect(service.evaluateGroup(b2, rule('seriesPosition', 'equals', 'next_unread'), allBooks)).toBe(false);
+    });
+
+    it('should handle next_unread with multiple read then first unread', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.READ);
+      const b3 = seriesBook(3, ReadStatus.UNREAD);
+      const b4 = seriesBook(4, ReadStatus.UNREAD);
+      const allBooks = [b1, b2, b3, b4];
+      expect(service.evaluateGroup(b3, rule('seriesPosition', 'equals', 'next_unread'), allBooks)).toBe(true);
+      expect(service.evaluateGroup(b4, rule('seriesPosition', 'equals', 'next_unread'), allBooks)).toBe(false);
+    });
+
+    it('should return false for unknown position value', () => {
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const allBooks = [b1];
+      expect(service.evaluateGroup(b1, rule('seriesPosition', 'equals', 'bogus'), allBooks)).toBe(false);
+    });
+
+    it('should handle single-book series for first and last', () => {
+      const b1 = seriesBook(1, ReadStatus.UNREAD);
+      const allBooks = [b1];
+      expect(service.evaluateGroup(b1, rule('seriesPosition', 'equals', 'first_in_series'), allBooks)).toBe(true);
+      expect(service.evaluateGroup(b1, rule('seriesPosition', 'equals', 'last_in_series'), allBooks)).toBe(true);
+    });
+
+    it('should handle fractional series numbers for first/last', () => {
+      const b05 = createBook({
+        id: 50, readStatus: ReadStatus.UNREAD,
+        metadata: {bookId: 50, seriesName: 'Dune', seriesNumber: 0.5}
+      });
+      const b1 = seriesBook(1, ReadStatus.READ);
+      const b2 = seriesBook(2, ReadStatus.UNREAD);
+      const allBooks = [b05, b1, b2];
+      expect(service.evaluateGroup(b05, rule('seriesPosition', 'equals', 'first_in_series'), allBooks)).toBe(true);
+      expect(service.evaluateGroup(b2, rule('seriesPosition', 'equals', 'last_in_series'), allBooks)).toBe(true);
+    });
+  });
+
+  describe('relative date default/edge cases', () => {
+    it('should default to days when valueEnd is missing for within_last', () => {
+      const book = createBook({addedOn: new Date().toISOString()});
+      const g: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [{field: 'addedOn', operator: 'within_last', value: 30}]
+      };
+      expect(service.evaluateGroup(book, g)).toBe(true);
+    });
+
+    it('should default to days when valueEnd is missing for older_than', () => {
+      const old = new Date();
+      old.setDate(old.getDate() - 60);
+      const book = createBook({addedOn: old.toISOString()});
+      const g: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [{field: 'addedOn', operator: 'older_than', value: 30}]
+      };
+      expect(service.evaluateGroup(book, g)).toBe(true);
+    });
+
+    it('should default to year when value is missing for this_period', () => {
+      const book = createBook({addedOn: new Date().toISOString()});
+      const g: GroupRule = {
+        name: 'test', type: 'group', join: 'and',
+        rules: [{field: 'addedOn', operator: 'this_period', value: null}]
+      };
+      expect(service.evaluateGroup(book, g)).toBe(true);
+    });
+
+    it('should handle older_than with weeks unit', () => {
+      const old = new Date();
+      old.setDate(old.getDate() - 30);
+      const book = createBook({addedOn: old.toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'older_than', 2, 'weeks'))).toBe(true);
+    });
+
+    it('should handle older_than with years unit', () => {
+      const old = new Date();
+      old.setFullYear(old.getFullYear() - 3);
+      const book = createBook({addedOn: old.toISOString()});
+      expect(service.evaluateGroup(book, rule('addedOn', 'older_than', 2, 'years'))).toBe(true);
+    });
+  });
+
+  describe('unknown operator', () => {
+    it('should return false for an unrecognized operator', () => {
+      const book = createBook();
+      expect(service.evaluateGroup(book, rule('title', 'regex_match' as never, '.*'))).toBe(false);
+    });
+  });
 });
+
+

--- a/booklore-ui/src/app/features/magic-shelf/service/magic-shelf-utils.spec.ts
+++ b/booklore-ui/src/app/features/magic-shelf/service/magic-shelf-utils.spec.ts
@@ -1,0 +1,380 @@
+import {describe, expect, it} from 'vitest';
+import {RELATIVE_DATE_OPERATORS, MULTI_VALUE_OPERATORS, EMPTY_CHECK_OPERATORS, parseValue, serializeDateRules, removeNulls} from './magic-shelf-utils';
+
+describe('magic-shelf-utils', () => {
+
+  describe('RELATIVE_DATE_OPERATORS', () => {
+    it('should contain within_last, older_than, this_period', () => {
+      expect(RELATIVE_DATE_OPERATORS).toEqual(['within_last', 'older_than', 'this_period']);
+    });
+
+    it('should not overlap with MULTI_VALUE_OPERATORS', () => {
+      RELATIVE_DATE_OPERATORS.forEach(op => {
+        expect(MULTI_VALUE_OPERATORS).not.toContain(op);
+      });
+    });
+
+    it('should not overlap with EMPTY_CHECK_OPERATORS', () => {
+      RELATIVE_DATE_OPERATORS.forEach(op => {
+        expect(EMPTY_CHECK_OPERATORS).not.toContain(op);
+      });
+    });
+  });
+
+  describe('serializeDateRules', () => {
+    it('should serialize Date values for regular date operators', () => {
+      const rule = {
+        field: 'dateFinished',
+        operator: 'equals',
+        value: new Date('2024-06-15T00:00:00Z'),
+        valueStart: null,
+        valueEnd: null
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBe('2024-06-15');
+    });
+
+    it('should serialize Date values for in_between operator on date fields', () => {
+      const rule = {
+        field: 'addedOn',
+        operator: 'in_between',
+        value: null,
+        valueStart: new Date('2024-01-01T00:00:00Z'),
+        valueEnd: new Date('2024-12-31T00:00:00Z')
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['valueStart']).toBe('2024-01-01');
+      expect(result['valueEnd']).toBe('2024-12-31');
+    });
+
+    it('should NOT serialize values for within_last operator on date fields', () => {
+      const rule = {
+        field: 'dateFinished',
+        operator: 'within_last',
+        value: 30,
+        valueStart: null,
+        valueEnd: 'days'
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBe(30);
+      expect(result['valueEnd']).toBe('days');
+    });
+
+    it('should NOT serialize values for older_than operator on date fields', () => {
+      const rule = {
+        field: 'lastReadTime',
+        operator: 'older_than',
+        value: 6,
+        valueStart: null,
+        valueEnd: 'months'
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBe(6);
+      expect(result['valueEnd']).toBe('months');
+    });
+
+    it('should NOT serialize values for this_period operator on date fields', () => {
+      const rule = {
+        field: 'addedOn',
+        operator: 'this_period',
+        value: 'year',
+        valueStart: null,
+        valueEnd: null
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBe('year');
+    });
+
+    it('should NOT serialize values for publishedDate with within_last', () => {
+      const rule = {
+        field: 'publishedDate',
+        operator: 'within_last',
+        value: 2,
+        valueStart: null,
+        valueEnd: 'years'
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBe(2);
+      expect(result['valueEnd']).toBe('years');
+    });
+
+    it('should recurse through group rules', () => {
+      const group = {
+        type: 'group',
+        join: 'and',
+        rules: [
+          {
+            field: 'dateFinished',
+            operator: 'within_last',
+            value: 7,
+            valueStart: null,
+            valueEnd: 'days'
+          },
+          {
+            field: 'addedOn',
+            operator: 'equals',
+            value: new Date('2024-03-15T00:00:00Z'),
+            valueStart: null,
+            valueEnd: null
+          }
+        ]
+      };
+
+      const result = serializeDateRules(group) as { rules: Record<string, unknown>[] };
+      expect(result.rules[0]['value']).toBe(7);
+      expect(result.rules[0]['valueEnd']).toBe('days');
+      expect(result.rules[1]['value']).toBe('2024-03-15');
+    });
+
+    it('should not affect non-date fields', () => {
+      const rule = {
+        field: 'title',
+        operator: 'contains',
+        value: 'Harry Potter',
+        valueStart: null,
+        valueEnd: null
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBe('Harry Potter');
+    });
+  });
+
+  describe('parseValue', () => {
+    it('should parse number values correctly', () => {
+      expect(parseValue(42, 'number')).toBe(42);
+      expect(parseValue('42', 'number')).toBe(42);
+      expect(parseValue(3.5, 'decimal')).toBe(3.5);
+    });
+
+    it('should return null for NaN number values', () => {
+      expect(parseValue('not a number', 'number')).toBeNull();
+    });
+
+    it('should parse date values correctly', () => {
+      const result = parseValue('2024-06-15', 'date');
+      expect(result).toBeInstanceOf(Date);
+      expect((result as Date).getFullYear()).toBe(2024);
+    });
+
+    it('should return null for invalid date values', () => {
+      expect(parseValue('not a date', 'date')).toBeNull();
+    });
+
+    it('should return null for null input', () => {
+      expect(parseValue(null, 'number')).toBeNull();
+      expect(parseValue(null, 'date')).toBeNull();
+      expect(parseValue(null, undefined)).toBeNull();
+    });
+
+    it('should return value as-is for undefined type', () => {
+      expect(parseValue('hello', undefined)).toBe('hello');
+      expect(parseValue('true', 'boolean' as any)).toBe('true');
+    });
+
+    it('should return arrays as-is for undefined type', () => {
+      const arr = ['a', 'b'];
+      expect(parseValue(arr, undefined)).toBe(arr);
+    });
+  });
+
+  describe('removeNulls', () => {
+    it('should remove null values from flat object', () => {
+      expect(removeNulls({a: 1, b: null, c: 'hello'})).toEqual({a: 1, c: 'hello'});
+    });
+
+    it('should remove undefined values from flat object', () => {
+      expect(removeNulls({a: 1, b: undefined})).toEqual({a: 1});
+    });
+
+    it('should keep falsy non-null values', () => {
+      expect(removeNulls({a: 0, b: '', c: false})).toEqual({a: 0, b: '', c: false});
+    });
+
+    it('should recurse into nested objects', () => {
+      expect(removeNulls({a: {b: null, c: 1}, d: 2})).toEqual({a: {c: 1}, d: 2});
+    });
+
+    it('should recurse into arrays', () => {
+      expect(removeNulls([{a: null, b: 1}, {c: null}])).toEqual([{b: 1}, {}]);
+    });
+
+    it('should handle empty objects', () => {
+      expect(removeNulls({})).toEqual({});
+    });
+
+    it('should handle empty arrays', () => {
+      expect(removeNulls([])).toEqual([]);
+    });
+
+    it('should pass through primitive values', () => {
+      expect(removeNulls('hello')).toBe('hello');
+      expect(removeNulls(42)).toBe(42);
+    });
+
+    it('should handle deeply nested structures', () => {
+      expect(removeNulls({a: {b: {c: null, d: {e: null, f: 1}}}})).toEqual({a: {b: {d: {f: 1}}}});
+    });
+  });
+
+  describe('serializeDateRules edge cases', () => {
+    it('should handle lastReadTime date field serialization', () => {
+      const rule = {
+        field: 'lastReadTime',
+        operator: 'equals',
+        value: new Date('2024-08-20T00:00:00Z'),
+        valueStart: null,
+        valueEnd: null
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBe('2024-08-20');
+    });
+
+    it('should preserve string values on date fields', () => {
+      const rule = {
+        field: 'dateFinished',
+        operator: 'equals',
+        value: '2024-06-15',
+        valueStart: null,
+        valueEnd: null
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBe('2024-06-15');
+    });
+
+    it('should handle null value on date field', () => {
+      const rule = {
+        field: 'dateFinished',
+        operator: 'is_empty',
+        value: null,
+        valueStart: null,
+        valueEnd: null
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBeNull();
+    });
+
+    it('should handle undefined value on date field', () => {
+      const rule = {
+        field: 'addedOn',
+        operator: 'is_empty',
+        value: undefined,
+        valueStart: null,
+        valueEnd: null
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBeUndefined();
+    });
+
+    it('should handle deeply nested groups', () => {
+      const nested = {
+        type: 'group',
+        join: 'and',
+        rules: [
+          {
+            type: 'group',
+            join: 'or',
+            rules: [
+              {
+                field: 'addedOn',
+                operator: 'equals',
+                value: new Date('2024-11-01T00:00:00Z'),
+                valueStart: null,
+                valueEnd: null
+              }
+            ]
+          }
+        ]
+      };
+
+      const result = serializeDateRules(nested) as { rules: { rules: Record<string, unknown>[] }[] };
+      expect(result.rules[0].rules[0]['value']).toBe('2024-11-01');
+    });
+
+    it('should handle rule with no field property', () => {
+      const rule = {
+        operator: 'equals',
+        value: 'test'
+      };
+
+      const result = serializeDateRules(rule) as Record<string, unknown>;
+      expect(result['value']).toBe('test');
+    });
+
+    it('should handle empty rules array in group', () => {
+      const group = {
+        type: 'group',
+        rules: []
+      };
+
+      const result = serializeDateRules(group) as { rules: unknown[] };
+      expect(result.rules).toEqual([]);
+    });
+  });
+
+  describe('parseValue edge cases', () => {
+    it('should parse 0 as valid number', () => {
+      expect(parseValue(0, 'number')).toBe(0);
+    });
+
+    it('should parse empty string as 0 for number', () => {
+      expect(parseValue('', 'number')).toBe(0);
+    });
+
+    it('should handle undefined input', () => {
+      expect(parseValue(undefined, 'number')).toBeNull();
+    });
+
+    it('should handle Date object input for date type', () => {
+      const result = parseValue(new Date('2024-01-01'), 'date');
+      expect(result).toBeInstanceOf(Date);
+    });
+
+    it('should handle numeric timestamp for date type', () => {
+      const result = parseValue(1718409600000, 'date');
+      expect(result).toBeInstanceOf(Date);
+    });
+
+    it('should parse negative numbers', () => {
+      expect(parseValue(-5, 'number')).toBe(-5);
+    });
+
+    it('should parse decimal string as number', () => {
+      expect(parseValue('3.14', 'decimal')).toBe(3.14);
+    });
+
+    it('should return string type value as-is', () => {
+      expect(parseValue('hello', 'string')).toBe('hello');
+    });
+  });
+
+  describe('MULTI_VALUE_OPERATORS', () => {
+    it('should contain exactly includes_any, includes_all, excludes_all', () => {
+      expect(MULTI_VALUE_OPERATORS).toEqual(['includes_any', 'includes_all', 'excludes_all']);
+    });
+
+    it('should have length 3', () => {
+      expect(MULTI_VALUE_OPERATORS.length).toBe(3);
+    });
+  });
+
+  describe('EMPTY_CHECK_OPERATORS', () => {
+    it('should contain exactly is_empty, is_not_empty', () => {
+      expect(EMPTY_CHECK_OPERATORS).toEqual(['is_empty', 'is_not_empty']);
+    });
+
+    it('should have length 2', () => {
+      expect(EMPTY_CHECK_OPERATORS.length).toBe(2);
+    });
+  });
+});

--- a/booklore-ui/src/app/features/magic-shelf/service/magic-shelf-utils.ts
+++ b/booklore-ui/src/app/features/magic-shelf/service/magic-shelf-utils.ts
@@ -11,7 +11,13 @@ export const EMPTY_CHECK_OPERATORS: RuleOperator[] = [
   'is_not_empty'
 ];
 
-export function parseValue(val: unknown, type: 'string' | 'number' | 'decimal' | 'date' | undefined): unknown {
+export const RELATIVE_DATE_OPERATORS: RuleOperator[] = [
+  'within_last',
+  'older_than',
+  'this_period'
+];
+
+export function parseValue(val: unknown, type: 'string' | 'number' | 'decimal' | 'date' | 'boolean' | undefined): unknown {
   if (val == null) return null;
   if (type === 'number' || type === 'decimal') {
     const num = Number(val);
@@ -48,8 +54,9 @@ export function serializeDateRules(ruleOrGroup: unknown): unknown {
     };
   }
 
-  const rule = ruleOrGroup as { field?: string; value?: unknown; valueStart?: unknown; valueEnd?: unknown; [key: string]: unknown };
-  const isDateField = rule.field === 'publishedDate' || rule.field === 'dateFinished';
+  const rule = ruleOrGroup as { field?: string; operator?: string; value?: unknown; valueStart?: unknown; valueEnd?: unknown; [key: string]: unknown };
+  const isRelativeDateOp = RELATIVE_DATE_OPERATORS.includes(rule.operator as RuleOperator);
+  const isDateField = !isRelativeDateOp && (rule.field === 'publishedDate' || rule.field === 'dateFinished' || rule.field === 'addedOn' || rule.field === 'lastReadTime');
   const serialize = (val: unknown) => (val instanceof Date ? val.toISOString().split('T')[0] : val);
 
   return {

--- a/booklore-ui/src/app/features/magic-shelf/service/magic-shelf.service.ts
+++ b/booklore-ui/src/app/features/magic-shelf/service/magic-shelf.service.ts
@@ -162,11 +162,12 @@ export class MagicShelfService {
         }
 
         return this.bookService.bookState$.pipe(
-          map((state) =>
-            (state.books ?? []).filter((book) =>
-              this.ruleEvaluatorService.evaluateGroup(book, group)
-            ).length
-          )
+          map((state) => {
+            const allBooks = state.books ?? [];
+            return allBooks.filter((book) =>
+              this.ruleEvaluatorService.evaluateGroup(book, group, allBooks)
+            ).length;
+          })
         );
       })
     );

--- a/booklore-ui/src/i18n/en/magic-shelf.json
+++ b/booklore-ui/src/i18n/en/magic-shelf.json
@@ -42,7 +42,16 @@
     "selectFileType": "Select File Type",
     "selectLibrary": "Select Library",
     "selectShelf": "Select Shelf",
-    "selectGenre": "Select Genre"
+    "selectGenre": "Select Genre",
+    "selectValue": "Select Value",
+    "selectContentRating": "Select Content Rating",
+    "selectContentRatings": "Select Content Ratings",
+    "amount": "Amount",
+    "selectUnit": "Select Unit",
+    "selectPeriod": "Select Period",
+    "selectSeriesStatus": "Select Status",
+    "selectSeriesGap": "Select Gap Type",
+    "selectSeriesPosition": "Select Position"
   },
   "conditions": {
     "and": "AND",
@@ -80,7 +89,32 @@
     "hardcoverRating": "Hardcover Rating",
     "hardcoverReviewCount": "Hardcover Review Count",
     "ranobedbRating": "Ranobedb Rating",
-    "genre": "Genre"
+    "genre": "Genre",
+    "addedOn": "Date Added",
+    "lubimyczytacRating": "Lubimyczytac Rating",
+    "description": "Description",
+    "narrator": "Narrator",
+    "ageRating": "Age Rating",
+    "contentRating": "Content Rating",
+    "audibleRating": "Audible Rating",
+    "audibleReviewCount": "Audible Review Count",
+    "abridged": "Abridged",
+    "audiobookDuration": "Audiobook Duration (s)",
+    "isPhysical": "Physical Book",
+    "seriesStatus": "Series Status",
+    "seriesGaps": "Series Gaps",
+    "seriesPosition": "Series Position",
+    "readingProgress": "Reading Progress (%)"
+  },
+  "fieldGroups": {
+    "organization": "Organization",
+    "bookInfo": "Book Info",
+    "series": "Series",
+    "dates": "Dates",
+    "ratingsReviews": "Ratings & Reviews",
+    "tagsMoods": "Tags & Moods",
+    "audiobook": "Audiobook",
+    "fileIdentifiers": "File & Identifiers"
   },
   "operators": {
     "equals": "Equals",
@@ -98,7 +132,25 @@
     "greaterOrEqual": "\u2265 Greater or Equal",
     "lessThan": "< Less Than",
     "lessOrEqual": "\u2264 Less or Equal",
-    "between": "Between"
+    "between": "Between",
+    "withinLast": "Within Last",
+    "olderThan": "Older Than",
+    "thisPeriod": "This Period",
+    "is": "Is",
+    "isNot": "Is Not",
+    "has": "Has",
+    "hasNot": "Has Not"
+  },
+  "booleanValues": {
+    "yes": "Yes",
+    "no": "No"
+  },
+  "contentRatings": {
+    "everyone": "Everyone",
+    "teen": "Teen",
+    "mature": "Mature",
+    "adult": "Adult",
+    "explicit": "Explicit"
   },
   "readStatuses": {
     "unread": "Unread",
@@ -110,6 +162,35 @@
     "wontRead": "Wont Read",
     "abandoned": "Abandoned",
     "unset": "Unset"
+  },
+  "seriesStatuses": {
+    "reading": "Currently Reading",
+    "completed": "Completed",
+    "ongoing": "Ongoing",
+    "notStarted": "Not Started",
+    "fullyRead": "Fully Read"
+  },
+  "seriesGaps": {
+    "anyGap": "Any Gap",
+    "missingFirst": "Missing First",
+    "missingLatest": "Missing Latest",
+    "duplicateNumber": "Duplicate Number"
+  },
+  "seriesPositions": {
+    "nextUnread": "Next Unread",
+    "firstInSeries": "First in Series",
+    "lastInSeries": "Last in Series"
+  },
+  "dateUnits": {
+    "days": "Days",
+    "weeks": "Weeks",
+    "months": "Months",
+    "years": "Years"
+  },
+  "datePeriods": {
+    "week": "This Week",
+    "month": "This Month",
+    "year": "This Year"
   },
   "toast": {
     "validationErrorSummary": "Validation Error",

--- a/booklore-ui/src/i18n/es/magic-shelf.json
+++ b/booklore-ui/src/i18n/es/magic-shelf.json
@@ -42,7 +42,16 @@
     "selectFileType": "Seleccionar Tipo de Archivo",
     "selectLibrary": "Seleccionar Biblioteca",
     "selectShelf": "Seleccionar Estante",
-    "selectGenre": "Seleccionar G\u00e9nero"
+    "selectGenre": "Seleccionar G\u00e9nero",
+    "selectValue": "Seleccionar Valor",
+    "selectContentRating": "Seleccionar Clasificaci\u00f3n de Contenido",
+    "selectContentRatings": "Seleccionar Clasificaciones de Contenido",
+    "amount": "Cantidad",
+    "selectUnit": "Seleccionar Unidad",
+    "selectPeriod": "Seleccionar Per\u00edodo",
+    "selectSeriesStatus": "Seleccionar Estado",
+    "selectSeriesGap": "Seleccionar Tipo de Hueco",
+    "selectSeriesPosition": "Seleccionar Posici\u00f3n"
   },
   "conditions": {
     "and": "Y",
@@ -80,7 +89,32 @@
     "hardcoverRating": "Calificaci\u00f3n de Hardcover",
     "hardcoverReviewCount": "Cantidad de Rese\u00f1as de Hardcover",
     "ranobedbRating": "Calificaci\u00f3n de Ranobedb",
-    "genre": "G\u00e9nero"
+    "genre": "G\u00e9nero",
+    "addedOn": "Fecha de Agregado",
+    "lubimyczytacRating": "Calificaci\u00f3n de Lubimyczytac",
+    "description": "Descripci\u00f3n",
+    "narrator": "Narrador",
+    "ageRating": "Clasificaci\u00f3n por Edad",
+    "contentRating": "Clasificaci\u00f3n de Contenido",
+    "audibleRating": "Calificaci\u00f3n de Audible",
+    "audibleReviewCount": "Cantidad de Rese\u00f1as de Audible",
+    "abridged": "Abreviado",
+    "audiobookDuration": "Duraci\u00f3n del Audiolibro (s)",
+    "isPhysical": "Libro F\u00edsico",
+    "seriesStatus": "Estado de la Serie",
+    "seriesGaps": "Huecos en la Serie",
+    "seriesPosition": "Posici\u00f3n en la Serie",
+    "readingProgress": "Progreso de Lectura (%)"
+  },
+  "fieldGroups": {
+    "organization": "Organizaci\u00f3n",
+    "bookInfo": "Info del Libro",
+    "series": "Serie",
+    "dates": "Fechas",
+    "ratingsReviews": "Calificaciones y Rese\u00f1as",
+    "tagsMoods": "Etiquetas y Estados de \u00c1nimo",
+    "audiobook": "Audiolibro",
+    "fileIdentifiers": "Archivo e Identificadores"
   },
   "operators": {
     "equals": "Igual",
@@ -98,7 +132,25 @@
     "greaterOrEqual": "\u2265 Mayor o Igual",
     "lessThan": "< Menor Que",
     "lessOrEqual": "\u2264 Menor o Igual",
-    "between": "Entre"
+    "between": "Entre",
+    "withinLast": "En los \u00daltimos",
+    "olderThan": "Anterior a",
+    "thisPeriod": "Este Per\u00edodo",
+    "is": "Es",
+    "isNot": "No Es",
+    "has": "Tiene",
+    "hasNot": "No Tiene"
+  },
+  "booleanValues": {
+    "yes": "S\u00ed",
+    "no": "No"
+  },
+  "contentRatings": {
+    "everyone": "Todos",
+    "teen": "Adolescentes",
+    "mature": "Maduro",
+    "adult": "Adulto",
+    "explicit": "Expl\u00edcito"
   },
   "readStatuses": {
     "unread": "No Le\u00eddo",
@@ -110,6 +162,35 @@
     "wontRead": "No Leer\u00e9",
     "abandoned": "Abandonado",
     "unset": "Sin Establecer"
+  },
+  "seriesStatuses": {
+    "reading": "Leyendo Actualmente",
+    "completed": "Completada",
+    "ongoing": "En Curso",
+    "notStarted": "No Iniciada",
+    "fullyRead": "Totalmente Le\u00edda"
+  },
+  "seriesGaps": {
+    "anyGap": "Cualquier Hueco",
+    "missingFirst": "Falta el Primero",
+    "missingLatest": "Falta el \u00daltimo",
+    "duplicateNumber": "N\u00famero Duplicado"
+  },
+  "seriesPositions": {
+    "nextUnread": "Siguiente Sin Leer",
+    "firstInSeries": "Primero de la Serie",
+    "lastInSeries": "\u00daltimo de la Serie"
+  },
+  "dateUnits": {
+    "days": "D\u00edas",
+    "weeks": "Semanas",
+    "months": "Meses",
+    "years": "A\u00f1os"
+  },
+  "datePeriods": {
+    "week": "Esta Semana",
+    "month": "Este Mes",
+    "year": "Este A\u00f1o"
   },
   "toast": {
     "validationErrorSummary": "Error de Validaci\u00f3n",


### PR DESCRIPTION
Adds a searchable grouped field dropdown to the Magic Shelf rule builder, plus a bunch of new composite fields for series analysis (series status, gaps, position). You can now build rules like "series is behind" or "has missing first book" which look across all books in a series. Also adds relative date operators like "within last 30 days". Both backend JPA queries and frontend client-side evaluation are implemented, with a ton of tests.