### PR TITLE
fix: align frontend Page interfaces with VIA_DTO serialization format

### DIFF
--- a/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.ts
+++ b/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.ts
@@ -202,7 +202,7 @@ export class BookdropFileReviewComponent implements OnInit {
               return fresh;
             }
           });
-          this.totalRecords = response.totalElements;
+          this.totalRecords = response.page.totalElements;
           this.currentPage = page;
           this.loading = false;
           this.syncCurrentPageSelection();

--- a/booklore-ui/src/app/features/bookdrop/service/bookdrop.service.ts
+++ b/booklore-ui/src/app/features/bookdrop/service/bookdrop.service.ts
@@ -51,9 +51,12 @@ export interface BookdropFinalizeResult {
 
 export interface Page<T> {
   content: T[];
-  totalElements: number;
-  totalPages: number;
-  number: number;
+  page: {
+    totalElements: number;
+    totalPages: number;
+    number: number;
+    size: number;
+  };
 }
 
 export interface PatternExtractRequest {

--- a/booklore-ui/src/app/features/notebook/components/notebook/notebook.component.ts
+++ b/booklore-ui/src/app/features/notebook/components/notebook/notebook.component.ts
@@ -27,7 +27,8 @@ interface BookOption {
 }
 
 const EMPTY_PAGE: NotebookPage = {
-  content: [], totalElements: 0, totalPages: 0, number: 0, size: 0, first: true, last: true, empty: true
+  content: [],
+  page: { totalElements: 0, totalPages: 0, number: 0, size: 0 },
 };
 
 @Component({
@@ -92,7 +93,7 @@ export class NotebookComponent implements OnInit, OnDestroy {
       }),
       takeUntil(this.destroy$)
     ).subscribe(result => {
-      this.totalEntries = result.totalElements;
+      this.totalEntries = result.page.totalElements;
       this.groupEntries(result.content);
       this.loading = false;
     });

--- a/booklore-ui/src/app/features/notebook/model/notebook.model.ts
+++ b/booklore-ui/src/app/features/notebook/model/notebook.model.ts
@@ -14,13 +14,12 @@ export interface NotebookEntry {
 
 export interface NotebookPage {
   content: NotebookEntry[];
-  totalElements: number;
-  totalPages: number;
-  number: number;
-  size: number;
-  first: boolean;
-  last: boolean;
-  empty: boolean;
+  page: {
+    totalElements: number;
+    totalPages: number;
+    number: number;
+    size: number;
+  };
 }
 
 export interface NotebookBookOption {

--- a/booklore-ui/src/app/shared/service/reading-session-api.service.ts
+++ b/booklore-ui/src/app/shared/service/reading-session-api.service.ts
@@ -22,31 +22,12 @@ export interface ReadingSessionResponse {
 
 export interface PageableResponse<T> {
   content: T[];
-  pageable: {
-    pageNumber: number;
-    pageSize: number;
-    sort: {
-      empty: boolean;
-      sorted: boolean;
-      unsorted: boolean;
-    };
-    offset: number;
-    paged: boolean;
-    unpaged: boolean;
+  page: {
+    totalElements: number;
+    totalPages: number;
+    number: number;
+    size: number;
   };
-  totalElements: number;
-  last: boolean;
-  totalPages: number;
-  numberOfElements: number;
-  first: boolean;
-  size: number;
-  number: number;
-  sort: {
-    empty: boolean;
-    sorted: boolean;
-    unsorted: boolean;
-  };
-  empty: boolean;
 }
 
 export interface CreateReadingSessionDto {


### PR DESCRIPTION
Fixes a bug where the frontend Page interfaces didn't match the backend's VIA_DTO serialization format. The pagination metadata is nested under a page key now, but the frontend was still looking for totalElements at the top level, which came back as undefined and broke things. Updated the interfaces in bookdrop, notebook, and reading sessions.