### PR TITLE
chore: add performance label to release drafter categories

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,6 +27,9 @@ categories:
     labels:
       - 'bug'
       - 'fix'
+  - title: '⚡ Performance'
+    labels:
+      - 'performance'
   - title: '🛠️ Refactoring & Maintenance'
     labels:
       - 'refactor'


### PR DESCRIPTION
The performance label wasn't mapped to any release drafter category, so performance PRs were showing up as uncategorized in the release notes. Just adds the mapping to the config.