### PR TITLE
fix: use audiobook thumbnail for audiobook entries in notebook

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/dto/NotebookEntry.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/NotebookEntry.java
@@ -21,6 +21,7 @@ public class NotebookEntry {
     private String color;
     private String style;
     private String chapterTitle;
+    private String primaryBookType;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/booklore-api/src/main/java/org/booklore/repository/NotebookEntryRepository.java
+++ b/booklore-api/src/main/java/org/booklore/repository/NotebookEntryRepository.java
@@ -45,6 +45,7 @@ public interface NotebookEntryRepository extends Repository<AnnotationEntity, Lo
         String getColor();
         String getStyle();
         String getChapterTitle();
+        String getPrimaryBookType();
         LocalDateTime getCreatedAt();
         LocalDateTime getUpdatedAt();
     }
@@ -56,6 +57,7 @@ public interface NotebookEntryRepository extends Repository<AnnotationEntity, Lo
 
     @Query(value = "SELECT t.id, t.type, t.book_id AS bookId, t.book_title AS bookTitle, " +
                    "t.text, t.note, t.color, t.style, t.chapter_title AS chapterTitle, " +
+                   "(SELECT bf.book_type FROM book_file bf WHERE bf.book_id = t.book_id ORDER BY bf.id LIMIT 1) AS primaryBookType, " +
                    "t.created_at AS createdAt, t.updated_at AS updatedAt " +
                    "FROM (" + ENTRIES_UNION + ") t" + ENTRIES_FILTER,
            countQuery = "SELECT COUNT(*) FROM (" + ENTRIES_UNION + ") t" + ENTRIES_FILTER,

--- a/booklore-api/src/main/java/org/booklore/service/book/NotebookService.java
+++ b/booklore-api/src/main/java/org/booklore/service/book/NotebookService.java
@@ -81,6 +81,7 @@ public class NotebookService {
                 .color(p.getColor())
                 .style(p.getStyle())
                 .chapterTitle(p.getChapterTitle())
+                .primaryBookType(p.getPrimaryBookType())
                 .createdAt(p.getCreatedAt())
                 .updatedAt(p.getUpdatedAt())
                 .build();

--- a/booklore-ui/src/app/features/notebook/components/notebook/notebook.component.ts
+++ b/booklore-ui/src/app/features/notebook/components/notebook/notebook.component.ts
@@ -179,10 +179,13 @@ export class NotebookComponent implements OnInit, OnDestroy {
     const groupMap = new Map<number, BookGroup>();
     for (const entry of entries) {
       if (!groupMap.has(entry.bookId)) {
+        const isAudiobook = entry.primaryBookType === 'AUDIOBOOK';
         groupMap.set(entry.bookId, {
           bookId: entry.bookId,
           bookTitle: entry.bookTitle,
-          thumbnailUrl: this.urlHelper.getThumbnailUrl1(entry.bookId),
+          thumbnailUrl: isAudiobook
+            ? this.urlHelper.getAudiobookThumbnailUrl(entry.bookId)
+            : this.urlHelper.getDirectThumbnailUrl(entry.bookId),
           entries: [],
         });
       }

--- a/booklore-ui/src/app/features/notebook/model/notebook.model.ts
+++ b/booklore-ui/src/app/features/notebook/model/notebook.model.ts
@@ -8,6 +8,7 @@ export interface NotebookEntry {
   color?: string;
   style?: string;
   chapterTitle?: string;
+  primaryBookType?: string;
   createdAt: string;
   updatedAt?: string;
 }

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.ts
@@ -372,7 +372,7 @@ export class ReadingSessionTimelineComponent implements OnInit {
   }
 
   public getCoverUrl(bookId: number): string {
-    return this.urlHelperService.getThumbnailUrl1(bookId);
+    return this.urlHelperService.getDirectThumbnailUrl(bookId);
   }
 
   public getTooltipContent(session: TimelineSession): string {

--- a/booklore-ui/src/app/shared/service/url-helper.service.ts
+++ b/booklore-ui/src/app/shared/service/url-helper.service.ts
@@ -42,7 +42,7 @@ export class UrlHelperService {
     return this.appendToken(url);
   }
 
-  getThumbnailUrl1(bookId: number, coverUpdatedOn?: string): string {
+  getDirectThumbnailUrl(bookId: number, coverUpdatedOn?: string): string {
     let url = `${this.mediaBaseUrl}/book/${bookId}/thumbnail`;
     if (coverUpdatedOn) {
       url += `?${coverUpdatedOn}`;


### PR DESCRIPTION
Audiobook entries in the notebook were showing broken thumbnails because it was always using the ebook thumbnail endpoint. Added the book type to the notebook query so it picks the right thumbnail URL for audiobooks vs ebooks.