### PR TITLE
fix: hide show-more button when description fits without truncation

### DIFF
--- a/booklore-ui/src/app/features/book/components/series-page/series-page.component.html
+++ b/booklore-ui/src/app/features/book/components/series-page/series-page.component.html
@@ -77,13 +77,12 @@
 
               <!-- DESCRIPTION -->
               <div class="description-box">
-                <div [ngClass]="{ 'line-clamp-5': !isExpanded, 'line-clamp-none': isExpanded }"
+                <div #descriptionContent [ngClass]="{ 'line-clamp-5': !isExpanded, 'line-clamp-none': isExpanded }"
                   class="description-container">
                   <div class="readonly-editor"
                   [innerHTML]="(firstDescription$ | async) || t('noDescription')"></div>
                 </div>
-                @let desc = firstDescription$ | async;
-                @if ((desc?.length ?? 0) > 500) {
+                @if (isExpanded || isOverflowing) {
                   <p-button [label]="isExpanded ? t('showLess') : t('showMore')"
                     [icon]="isExpanded ? 'pi pi-chevron-up' : 'pi pi-chevron-down'" iconPos="right" size="small" text
                     (click)="toggleExpand()">

--- a/booklore-ui/src/app/features/book/components/series-page/series-page.component.ts
+++ b/booklore-ui/src/app/features/book/components/series-page/series-page.component.ts
@@ -27,7 +27,7 @@ import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {Tooltip} from "primeng/tooltip";
 import {Divider} from "primeng/divider";
 import {animate, style, transition, trigger} from "@angular/animations";
-import {Component, inject, OnDestroy} from '@angular/core';
+import {AfterViewChecked, Component, ElementRef, inject, OnDestroy, ViewChild} from '@angular/core';
 import {BookCardOverlayPreferenceService} from '../book-browser/book-card-overlay-preference.service';
 
 @Component({
@@ -68,7 +68,7 @@ import {BookCardOverlayPreferenceService} from '../book-browser/book-card-overla
     ])
   ]
 })
-export class SeriesPageComponent implements OnDestroy {
+export class SeriesPageComponent implements OnDestroy, AfterViewChecked {
 
   private route = inject(ActivatedRoute);
   private bookService = inject(BookService);
@@ -88,8 +88,10 @@ export class SeriesPageComponent implements OnDestroy {
   protected appSettingsService = inject(AppSettingsService);
   private readonly t = inject(TranslocoService);
 
+  @ViewChild('descriptionContent') descriptionContentRef?: ElementRef<HTMLElement>;
   tab: string = "view";
   isExpanded = false;
+  isOverflowing = false;
 
   // Selection state
   selectedBooks = new Set<number>();
@@ -265,6 +267,13 @@ export class SeriesPageComponent implements OnDestroy {
       );
     } else {
       this.navigateToFilteredBooks(filterKey, filterValue);
+    }
+  }
+
+  ngAfterViewChecked(): void {
+    if (!this.isExpanded && this.descriptionContentRef) {
+      const el = this.descriptionContentRef.nativeElement;
+      this.isOverflowing = el.scrollHeight > el.clientHeight;
     }
   }
 

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
@@ -670,10 +670,10 @@
         <span>{{ t('synopsisTitle') }}</span>
       </div>
       <div class="description-body">
-        <div [ngClass]="{ 'line-clamp-7': !isExpanded }" class="description-content">
+        <div #descriptionContent [ngClass]="{ 'line-clamp-7': !isExpanded }" class="description-content">
           <div class="description-html" [innerHTML]="book.metadata!.description"></div>
         </div>
-        @if (book.metadata!.description && book.metadata!.description.length > 500) {
+        @if (isExpanded || isOverflowing) {
           <button class="expand-toggle" (click)="toggleExpand()">
             {{ isExpanded ? t('showLess') : t('showMore') }}
             <i class="pi" [ngClass]="isExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -1,4 +1,4 @@
-import {Component, DestroyRef, inject, Input, OnChanges, OnInit, SimpleChanges} from '@angular/core';
+import {AfterViewChecked, Component, DestroyRef, ElementRef, inject, Input, OnChanges, OnInit, SimpleChanges, ViewChild} from '@angular/core';
 import {Button} from 'primeng/button';
 import {AsyncPipe, DecimalPipe, NgClass} from '@angular/common';
 import {combineLatest, Observable} from 'rxjs';
@@ -44,7 +44,7 @@ import {TranslocoDirective, TranslocoPipe, TranslocoService} from '@jsverse/tran
   styleUrl: './metadata-viewer.component.scss',
   imports: [Button, AsyncPipe, Rating, FormsModule, SplitButton, NgClass, Tooltip, DecimalPipe, ProgressBar, Menu, DatePicker, ProgressSpinner, TieredMenu, Image, TagComponent, MetadataTabsComponent, TranslocoDirective, TranslocoPipe]
 })
-export class MetadataViewerComponent implements OnInit, OnChanges {
+export class MetadataViewerComponent implements OnInit, OnChanges, AfterViewChecked {
   @Input() book$!: Observable<Book | null>;
   @Input() recommendedBooks: BookRecommendation[] = [];
   private originalRecommendedBooks: BookRecommendation[] = [];
@@ -70,7 +70,9 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
   otherItems$!: Observable<MenuItem[]>;
   downloadMenuItems$!: Observable<MenuItem[]>;
   bookInSeries: Book[] = [];
+  @ViewChild('descriptionContent') descriptionContentRef?: ElementRef<HTMLElement>;
   isExpanded = false;
+  isOverflowing = false;
   isComicSectionExpanded = true;
   isAudiobookSectionExpanded = true;
   showFilePath = false;
@@ -458,6 +460,13 @@ export class MetadataViewerComponent implements OnInit, OnChanges {
     this.recommendedBooks = this.originalRecommendedBooks.filter(
       rec => !bookInSeriesIds.has(rec.book.id)
     );
+  }
+
+  ngAfterViewChecked(): void {
+    if (!this.isExpanded && this.descriptionContentRef) {
+      const el = this.descriptionContentRef.nativeElement;
+      this.isOverflowing = el.scrollHeight > el.clientHeight;
+    }
   }
 
   toggleExpand(): void {


### PR DESCRIPTION
The show more button on book descriptions was appearing even when the text fit perfectly without truncation. It was using a character count heuristic instead of checking actual DOM overflow. Switched to scrollHeight vs clientHeight detection so it only shows up when the content is genuinely clipped.