### PR TITLE
feat: add series browser page

### DIFF
--- a/booklore-ui/src/app/app.routes.ts
+++ b/booklore-ui/src/app/app.routes.ts
@@ -39,6 +39,7 @@ export const routes: Routes = [
       {path: 'library/:libraryId/books', component: BookBrowserComponent, canActivate: [AuthGuard]},
       {path: 'shelf/:shelfId/books', component: BookBrowserComponent, canActivate: [AuthGuard]},
       {path: 'unshelved-books', component: BookBrowserComponent, canActivate: [AuthGuard]},
+      {path: 'series', loadComponent: () => import('./features/series-browser/components/series-browser/series-browser.component').then(m => m.SeriesBrowserComponent), canActivate: [AuthGuard]},
       {path: 'series/:seriesName', loadComponent: () => import('./features/book/components/series-page/series-page.component').then(m => m.SeriesPageComponent), canActivate: [AuthGuard]},
       {path: 'magic-shelf/:magicShelfId/books', component: BookBrowserComponent, canActivate: [AuthGuard]},
       {path: 'book/:bookId', loadComponent: () => import('./features/metadata/component/book-metadata-center/book-metadata-center.component').then(m => m.BookMetadataCenterComponent), canActivate: [AuthGuard]},

--- a/booklore-ui/src/app/features/series-browser/components/series-browser/series-browser.component.html
+++ b/booklore-ui/src/app/features/series-browser/components/series-browser/series-browser.component.html
@@ -1,0 +1,102 @@
+<ng-container *transloco="let t; prefix: 'seriesBrowser'">
+  @if ((bookState$ | async)?.loaded === false) {
+    <div class="loading-state">
+      <p-progressSpinner
+        [style]="{'width': '60px', 'height': '60px'}"
+        strokeWidth="3"
+        fill="transparent"
+        animationDuration="1.5s">
+      </p-progressSpinner>
+    </div>
+  }
+
+  @if ((bookState$ | async)?.loaded === true) {
+    <div class="browse-header">
+      <h2 class="browse-title">{{ t('browseAllSeries') }}</h2>
+
+      <div class="browse-controls">
+        <div class="search-wrapper">
+          <i class="pi pi-search search-icon"></i>
+          <input
+            pInputText
+            type="text"
+            [placeholder]="t('searchPlaceholder')"
+            [ngModel]="searchTerm$ | async"
+            (ngModelChange)="onSearchChange($event)"
+            class="search-input"/>
+        </div>
+
+        <div class="filter-sort-wrapper">
+          <p-select
+            [options]="filterOptions"
+            [ngModel]="statusFilter$ | async"
+            (ngModelChange)="onStatusFilterChange($event)"
+            optionLabel="label"
+            optionValue="value"
+            class="filter-dropdown">
+          </p-select>
+
+          <p-select
+            [options]="sortOptions"
+            [ngModel]="sortBy$ | async"
+            (ngModelChange)="onSortChange($event)"
+            optionLabel="label"
+            optionValue="value"
+            class="sort-dropdown">
+          </p-select>
+
+          @if (!isMobile) {
+            <button class="display-settings-btn" (click)="displaySettingsPopover.toggle($event)">
+              <i class="pi pi-sliders-h"></i>
+            </button>
+            <p-popover #displaySettingsPopover>
+              <div class="display-settings-content">
+                <label class="display-settings-label">{{ t('cardSize') }}</label>
+                <p-slider
+                  [(ngModel)]="seriesScaleService.scaleFactor"
+                  [min]="0.7"
+                  [max]="1.3"
+                  [step]="0.01"
+                  [style]="{ width: '100%' }"
+                  (onChange)="updateScale()">
+                </p-slider>
+                <div class="scale-value-display">
+                  {{ seriesScaleService.scaleFactor.toFixed(2) }}x
+                </div>
+              </div>
+            </p-popover>
+          }
+        </div>
+      </div>
+    </div>
+
+    @if (filteredSeries$ | async; as seriesList) {
+      @if (seriesList.length === 0) {
+        <div class="empty-state">
+          <i class="pi pi-list empty-icon"></i>
+          <p>{{ t('noSeriesFound') }}</p>
+        </div>
+      } @else {
+        <virtual-scroller
+          #scroll
+          [items]="seriesList"
+          class="virtual-scroller">
+          <div class="series-grid"
+            #container
+            [ngStyle]="{'grid-template-columns': 'repeat(auto-fill, minmax(' + gridColumnMinWidth + ', 1fr))'}">
+            @for (series of scroll.viewPortItems; track series.seriesName) {
+              <div class="virtual-scroller-item"
+                [ngStyle]="{width: cardWidth + 'px', height: cardHeight + 'px'}"
+                [style.--card-scale]="seriesScaleService.scaleFactor">
+                <app-series-card
+                  [series]="series"
+                  (cardClick)="navigateToSeries($event)">
+                </app-series-card>
+              </div>
+            }
+          </div>
+        </virtual-scroller>
+      }
+    }
+  }
+</ng-container>

--- a/booklore-ui/src/app/features/series-browser/components/series-browser/series-browser.component.scss
+++ b/booklore-ui/src/app/features/series-browser/components/series-browser/series-browser.component.scss
@@ -1,0 +1,197 @@
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: calc(100dvh - 6.7rem);
+}
+
+// Browse Header
+.browse-header {
+  padding: 0.75rem 1rem 0;
+}
+
+.browse-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  margin-bottom: 0.75rem;
+  background: linear-gradient(135deg, #ffffff, #e2e8f0, #3b82f6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  letter-spacing: -0.02em;
+}
+
+.browse-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+  align-items: center;
+}
+
+.search-wrapper {
+  position: relative;
+  flex: 1;
+  min-width: 200px;
+  max-width: 400px;
+
+  .search-icon {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #94a3b8;
+    font-size: 0.9rem;
+    z-index: 1;
+  }
+
+  .search-input {
+    width: 100%;
+    padding-left: 2.25rem;
+    font-size: 0.9rem;
+  }
+}
+
+.filter-sort-wrapper {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.filter-dropdown,
+.sort-dropdown {
+  min-width: 160px;
+}
+
+// Display settings
+.display-settings-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--p-surface-500), transparent 50%);
+  background: color-mix(in srgb, var(--p-surface-700), transparent 30%);
+  color: #94a3b8;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    color: #e2e8f0;
+    border-color: var(--p-primary-400);
+  }
+}
+
+.display-settings-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 180px;
+}
+
+.display-settings-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.scale-value-display {
+  text-align: center;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+// Virtual scroller and grid
+.virtual-scroller {
+  width: 100%;
+  height: calc(100dvh - 12.5rem);
+  padding: 1rem;
+  box-sizing: border-box;
+  overflow-y: auto;
+
+  scrollbar-width: thin;
+  scrollbar-color: var(--primary-color) rgba(20, 20, 30, 0.5);
+
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba(20, 20, 30, 0.5);
+    border-radius: 10px;
+  }
+
+  @media (max-width: 768px) {
+    height: calc(100dvh - 13rem);
+    padding: 0.5rem;
+
+    &::-webkit-scrollbar {
+      width: 8px;
+    }
+  }
+}
+
+.series-grid {
+  display: grid;
+  gap: 1.25rem;
+  align-items: start;
+  justify-items: center;
+  width: 100%;
+  padding-top: 1rem;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.virtual-scroller-item {
+  position: relative;
+  overflow: visible;
+  transition: width 0.2s ease, height 0.2s ease;
+}
+
+// Empty state
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  text-align: center;
+
+  .empty-icon {
+    font-size: 3rem;
+    color: #64748b;
+    margin-bottom: 1rem;
+  }
+
+  p {
+    color: #94a3b8;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+}
+
+@media (max-width: 767px) {
+  .browse-header {
+    padding: 0.5rem 0.5rem 0;
+  }
+
+  .browse-controls {
+    flex-direction: column;
+  }
+
+  .search-wrapper {
+    max-width: 100%;
+  }
+
+  .filter-sort-wrapper {
+    width: 100%;
+  }
+
+  .filter-dropdown,
+  .sort-dropdown {
+    flex: 1;
+    min-width: 0;
+  }
+}

--- a/booklore-ui/src/app/features/series-browser/components/series-browser/series-browser.component.ts
+++ b/booklore-ui/src/app/features/series-browser/components/series-browser/series-browser.component.ts
@@ -1,0 +1,220 @@
+import {Component, HostListener, inject, OnInit} from '@angular/core';
+import {AsyncPipe, NgStyle} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {combineLatest, Observable, BehaviorSubject} from 'rxjs';
+import {map} from 'rxjs/operators';
+import {ProgressSpinner} from 'primeng/progressspinner';
+import {InputText} from 'primeng/inputtext';
+import {Select} from 'primeng/select';
+import {Slider} from 'primeng/slider';
+import {Popover} from 'primeng/popover';
+import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
+import {VirtualScrollerModule} from '@iharbeck/ngx-virtual-scroller';
+import {SeriesDataService} from '../../service/series-data.service';
+import {SeriesSummary} from '../../model/series.model';
+import {SeriesCardComponent} from '../series-card/series-card.component';
+import {BookService} from '../../../book/service/book.service';
+import {ReadStatus} from '../../../book/model/book.model';
+import {PageTitleService} from '../../../../shared/service/page-title.service';
+import {SeriesScalePreferenceService} from '../../service/series-scale-preference.service';
+import {Router} from '@angular/router';
+
+interface FilterOption {
+  label: string;
+  value: string;
+}
+
+interface SortOption {
+  label: string;
+  value: string;
+}
+
+@Component({
+  selector: 'app-series-browser',
+  standalone: true,
+  templateUrl: './series-browser.component.html',
+  styleUrls: ['./series-browser.component.scss'],
+  imports: [
+    AsyncPipe,
+    NgStyle,
+    FormsModule,
+    ProgressSpinner,
+    InputText,
+    Select,
+    Slider,
+    Popover,
+    TranslocoDirective,
+    SeriesCardComponent,
+    VirtualScrollerModule
+  ]
+})
+export class SeriesBrowserComponent implements OnInit {
+
+  private static readonly BASE_WIDTH = 230;
+  private static readonly BASE_HEIGHT = 285;
+  private static readonly MOBILE_BASE_WIDTH = 180;
+  private static readonly MOBILE_BASE_HEIGHT = 250;
+
+  private seriesDataService = inject(SeriesDataService);
+  private bookService = inject(BookService);
+  private pageTitle = inject(PageTitleService);
+  private t = inject(TranslocoService);
+  private router = inject(Router);
+  protected seriesScaleService = inject(SeriesScalePreferenceService);
+
+  bookState$ = this.bookService.bookState$;
+
+  screenWidth = window.innerWidth;
+
+  @HostListener('window:resize')
+  onResize(): void {
+    this.screenWidth = window.innerWidth;
+  }
+
+  get isMobile(): boolean {
+    return this.screenWidth <= 767;
+  }
+
+  get cardWidth(): number {
+    const base = this.isMobile
+      ? SeriesBrowserComponent.MOBILE_BASE_WIDTH
+      : SeriesBrowserComponent.BASE_WIDTH;
+    return Math.round(base * this.seriesScaleService.scaleFactor);
+  }
+
+  get cardHeight(): number {
+    const base = this.isMobile
+      ? SeriesBrowserComponent.MOBILE_BASE_HEIGHT
+      : SeriesBrowserComponent.BASE_HEIGHT;
+    return Math.round(base * this.seriesScaleService.scaleFactor);
+  }
+
+  get gridColumnMinWidth(): string {
+    return `${this.cardWidth}px`;
+  }
+
+  // Search and filter state
+  searchTerm$ = new BehaviorSubject<string>('');
+  statusFilter$ = new BehaviorSubject<string>('all');
+  sortBy$ = new BehaviorSubject<string>('name-asc');
+
+  filterOptions: FilterOption[] = [];
+  sortOptions: SortOption[] = [];
+
+  // Filtered grid
+  filteredSeries$!: Observable<SeriesSummary[]>;
+
+  ngOnInit(): void {
+    this.pageTitle.setPageTitle(this.t.translate('seriesBrowser.pageTitle'));
+
+    this.filterOptions = [
+      {label: this.t.translate('seriesBrowser.filters.all'), value: 'all'},
+      {label: this.t.translate('seriesBrowser.filters.notStarted'), value: 'not-started'},
+      {label: this.t.translate('seriesBrowser.filters.inProgress'), value: 'in-progress'},
+      {label: this.t.translate('seriesBrowser.filters.completed'), value: 'completed'},
+      {label: this.t.translate('seriesBrowser.filters.abandoned'), value: 'abandoned'}
+    ];
+
+    this.sortOptions = [
+      {label: this.t.translate('seriesBrowser.sort.nameAsc'), value: 'name-asc'},
+      {label: this.t.translate('seriesBrowser.sort.nameDesc'), value: 'name-desc'},
+      {label: this.t.translate('seriesBrowser.sort.bookCount'), value: 'book-count'},
+      {label: this.t.translate('seriesBrowser.sort.progress'), value: 'progress'},
+      {label: this.t.translate('seriesBrowser.sort.recentlyRead'), value: 'recently-read'},
+      {label: this.t.translate('seriesBrowser.sort.recentlyAdded'), value: 'recently-added'}
+    ];
+
+    this.filteredSeries$ = combineLatest([
+      this.seriesDataService.allSeries$,
+      this.searchTerm$,
+      this.statusFilter$,
+      this.sortBy$
+    ]).pipe(
+      map(([allSeries, search, statusFilter, sortBy]) => {
+        let result = allSeries;
+
+        if (search.trim()) {
+          const term = search.trim().toLowerCase();
+          result = result.filter(s =>
+            s.seriesName.toLowerCase().includes(term) ||
+            s.authors.some(a => a.toLowerCase().includes(term))
+          );
+        }
+
+        result = this.applyStatusFilter(result, statusFilter);
+        result = this.applySort(result, sortBy);
+
+        return result;
+      })
+    );
+  }
+
+  onSearchChange(value: string): void {
+    this.searchTerm$.next(value);
+  }
+
+  onStatusFilterChange(value: string): void {
+    this.statusFilter$.next(value);
+  }
+
+  onSortChange(value: string): void {
+    this.sortBy$.next(value);
+  }
+
+  updateScale(): void {
+    this.seriesScaleService.setScale(this.seriesScaleService.scaleFactor);
+  }
+
+  navigateToSeries(series: SeriesSummary): void {
+    this.router.navigate(['/series', series.seriesName]);
+  }
+
+  private applyStatusFilter(series: SeriesSummary[], filterValue: string): SeriesSummary[] {
+    switch (filterValue) {
+      case 'not-started':
+        return series.filter(s => s.seriesStatus === ReadStatus.UNREAD);
+      case 'in-progress':
+        return series.filter(s =>
+          s.seriesStatus === ReadStatus.READING ||
+          s.seriesStatus === ReadStatus.PARTIALLY_READ
+        );
+      case 'completed':
+        return series.filter(s => s.seriesStatus === ReadStatus.READ);
+      case 'abandoned':
+        return series.filter(s =>
+          s.seriesStatus === ReadStatus.ABANDONED ||
+          s.seriesStatus === ReadStatus.WONT_READ
+        );
+      default:
+        return series;
+    }
+  }
+
+  private applySort(series: SeriesSummary[], sortBy: string): SeriesSummary[] {
+    const sorted = [...series];
+    switch (sortBy) {
+      case 'name-asc':
+        return sorted.sort((a, b) => a.seriesName.localeCompare(b.seriesName));
+      case 'name-desc':
+        return sorted.sort((a, b) => b.seriesName.localeCompare(a.seriesName));
+      case 'book-count':
+        return sorted.sort((a, b) => b.bookCount - a.bookCount);
+      case 'progress':
+        return sorted.sort((a, b) => b.progress - a.progress);
+      case 'recently-read':
+        return sorted.sort((a, b) => {
+          const aTime = a.lastReadTime ? new Date(a.lastReadTime).getTime() : 0;
+          const bTime = b.lastReadTime ? new Date(b.lastReadTime).getTime() : 0;
+          return bTime - aTime;
+        });
+      case 'recently-added':
+        return sorted.sort((a, b) => {
+          const aTime = a.addedOn ? new Date(a.addedOn).getTime() : 0;
+          const bTime = b.addedOn ? new Date(b.addedOn).getTime() : 0;
+          return bTime - aTime;
+        });
+      default:
+        return sorted;
+    }
+  }
+}

--- a/booklore-ui/src/app/features/series-browser/components/series-card/series-card.component.html
+++ b/booklore-ui/src/app/features/series-browser/components/series-card/series-card.component.html
@@ -1,0 +1,48 @@
+<div class="series-card" (click)="onCardClick($event)">
+  <div class="stacked-covers" [ngClass]="'covers-' + series.coverBooks.length">
+    @for (book of series.coverBooks; track book.id; let i = $index) {
+      <img
+        [src]="getCoverUrl(i)"
+        class="cover-img"
+        [ngClass]="'cover-' + i"
+        [alt]="series.seriesName"
+        loading="lazy"
+        decoding="async"/>
+    }
+  </div>
+
+  <div class="card-body">
+    <h4 class="series-name" [pTooltip]="series.seriesName" tooltipPosition="bottom">
+      {{ series.seriesName }}
+    </h4>
+
+    <p class="series-authors" [pTooltip]="series.authors.join(', ')" tooltipPosition="bottom">
+      {{ authorsDisplay }}
+    </p>
+
+    <div class="progress-section">
+      <p-progressBar
+        [value]="progressPercent"
+        [showValue]="false"
+        class="series-progress-bar"
+        [ngClass]="progressPercent === 100 ? 'progress-complete' : 'progress-incomplete'">
+      </p-progressBar>
+      <span class="progress-label">{{ series.readCount }}/{{ series.bookCount }}</span>
+    </div>
+
+    @if (series.nextUnread) {
+      <div class="card-actions">
+        <p-button
+          size="small"
+          icon="pi pi-book"
+          [label]="'seriesBrowser.readNext' | transloco"
+          [pTooltip]="series.nextUnread.metadata?.title || ''"
+          tooltipPosition="bottom"
+          severity="info"
+          [text]="true"
+          (click)="readNext($event)">
+        </p-button>
+      </div>
+    }
+  </div>
+</div>

--- a/booklore-ui/src/app/features/series-browser/components/series-card/series-card.component.scss
+++ b/booklore-ui/src/app/features/series-browser/components/series-card/series-card.component.scss
@@ -1,0 +1,209 @@
+.series-card {
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--p-surface-500), transparent 60%);
+  background: color-mix(in srgb, var(--p-surface-900), transparent 30%);
+  backdrop-filter: blur(10px);
+  overflow: hidden;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 100%;
+  height: 100%;
+
+  &:hover {
+    transform: translateY(-4px) scale(1.02);
+    border-color: color-mix(in srgb, var(--p-primary-400), transparent 50%);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3),
+    0 0 0 1px color-mix(in srgb, var(--p-primary-500), transparent 70%);
+    z-index: 10;
+  }
+}
+
+.stacked-covers {
+  position: relative;
+  width: 100%;
+  height: 62%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  padding: 10px 10px 4px;
+}
+
+.cover-img {
+  position: absolute;
+  width: calc(105px * var(--card-scale, 1));
+  height: calc(152px * var(--card-scale, 1));
+  object-fit: cover;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  transition: transform 0.3s ease, width 0.2s ease, height 0.2s ease;
+}
+
+// Cover positions by index (for 3+ covers)
+.cover-0 {
+  z-index: 7;
+  transform: translateX(0);
+}
+
+.cover-1 {
+  z-index: 6;
+  transform: translateX(calc(-20px * var(--card-scale, 1))) rotate(-4deg);
+  opacity: 0.9;
+}
+
+.cover-2 {
+  z-index: 5;
+  transform: translateX(calc(20px * var(--card-scale, 1))) rotate(4deg);
+  opacity: 0.9;
+}
+
+.cover-3 {
+  z-index: 4;
+  transform: translateX(calc(-42px * var(--card-scale, 1))) rotate(-8deg);
+  opacity: 0.8;
+}
+
+.cover-4 {
+  z-index: 3;
+  transform: translateX(calc(42px * var(--card-scale, 1))) rotate(8deg);
+  opacity: 0.8;
+}
+
+.cover-5 {
+  z-index: 2;
+  transform: translateX(calc(-62px * var(--card-scale, 1))) rotate(-11deg);
+  opacity: 0.7;
+}
+
+.cover-6 {
+  z-index: 1;
+  transform: translateX(calc(62px * var(--card-scale, 1))) rotate(11deg);
+  opacity: 0.7;
+}
+
+// Single cover: centered and larger
+.covers-1 .cover-0 {
+  transform: translateX(0);
+  width: calc(115px * var(--card-scale, 1));
+  height: calc(165px * var(--card-scale, 1));
+}
+
+// Two covers: tighter spread
+.covers-2 .cover-0 {
+  transform: translateX(calc(14px * var(--card-scale, 1)));
+}
+
+.covers-2 .cover-1 {
+  transform: translateX(calc(-14px * var(--card-scale, 1))) rotate(-5deg);
+  opacity: 0.85;
+}
+
+// Hover: spread 2-cover fan
+.series-card:hover .covers-2 .cover-1 {
+  transform: translateX(calc(-20px * var(--card-scale, 1))) rotate(-7deg);
+}
+
+// Hover: spread 3+ cover fan
+.series-card:hover .stacked-covers:not(.covers-1):not(.covers-2) {
+  .cover-1 {
+    transform: translateX(calc(-24px * var(--card-scale, 1))) rotate(-5deg);
+  }
+
+  .cover-2 {
+    transform: translateX(calc(24px * var(--card-scale, 1))) rotate(5deg);
+  }
+
+  .cover-3 {
+    transform: translateX(calc(-48px * var(--card-scale, 1))) rotate(-10deg);
+  }
+
+  .cover-4 {
+    transform: translateX(calc(48px * var(--card-scale, 1))) rotate(10deg);
+  }
+
+  .cover-5 {
+    transform: translateX(calc(-68px * var(--card-scale, 1))) rotate(-13deg);
+  }
+
+  .cover-6 {
+    transform: translateX(calc(68px * var(--card-scale, 1))) rotate(13deg);
+  }
+}
+
+.card-body {
+  padding: 6px 12px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+  min-height: 0;
+}
+
+.series-name {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #e2e8f0;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.3;
+}
+
+.series-authors {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.3;
+}
+
+.progress-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.card-actions {
+  display: flex;
+  align-items: center;
+  margin-top: auto;
+  gap: 4px;
+
+  ::ng-deep .p-button {
+    font-size: 0.75rem;
+    padding: 0.2rem 0.4rem;
+  }
+}
+
+.series-progress-bar {
+  flex: 1;
+  height: 6px;
+
+  ::ng-deep .p-progressbar {
+    height: 6px;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  &.progress-complete ::ng-deep .p-progressbar-value {
+    background: linear-gradient(90deg, #22c55e, #16a34a);
+  }
+
+  &.progress-incomplete ::ng-deep .p-progressbar-value {
+    background: linear-gradient(90deg, var(--p-primary-400), var(--p-primary-600));
+  }
+}
+
+.progress-label {
+  font-size: 0.8rem;
+  color: #cbd5e1;
+  white-space: nowrap;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}

--- a/booklore-ui/src/app/features/series-browser/components/series-card/series-card.component.ts
+++ b/booklore-ui/src/app/features/series-browser/components/series-card/series-card.component.ts
@@ -1,0 +1,56 @@
+import {Component, EventEmitter, inject, Input, Output} from '@angular/core';
+import {NgClass} from '@angular/common';
+import {ProgressBar} from 'primeng/progressbar';
+import {Button} from 'primeng/button';
+import {Tooltip} from 'primeng/tooltip';
+import {TranslocoPipe} from '@jsverse/transloco';
+import {SeriesSummary} from '../../model/series.model';
+import {BookService} from '../../../book/service/book.service';
+import {UrlHelperService} from '../../../../shared/service/url-helper.service';
+
+@Component({
+  selector: 'app-series-card',
+  standalone: true,
+  templateUrl: './series-card.component.html',
+  styleUrls: ['./series-card.component.scss'],
+  imports: [NgClass, ProgressBar, Button, Tooltip, TranslocoPipe]
+})
+export class SeriesCardComponent {
+
+  @Input({required: true}) series!: SeriesSummary;
+  @Output() cardClick = new EventEmitter<SeriesSummary>();
+
+  protected urlHelper = inject(UrlHelperService);
+  private bookService = inject(BookService);
+
+  get progressPercent(): number {
+    return Math.round(this.series.progress * 100);
+  }
+
+  get authorsDisplay(): string {
+    if (!this.series.authors.length) return '';
+    if (this.series.authors.length <= 2) return this.series.authors.join(', ');
+    return this.series.authors.slice(0, 2).join(', ') + ' +' + (this.series.authors.length - 2);
+  }
+
+  getCoverUrl(index: number): string {
+    const book = this.series.coverBooks[index];
+    if (!book) return '';
+    const isAudiobook = book.primaryFile?.bookType === 'AUDIOBOOK';
+    return isAudiobook
+      ? this.urlHelper.getAudiobookThumbnailUrl(book.id, book.metadata?.audiobookCoverUpdatedOn)
+      : this.urlHelper.getThumbnailUrl(book.id, book.metadata?.coverUpdatedOn);
+  }
+
+  onCardClick(event: MouseEvent): void {
+    event.stopPropagation();
+    this.cardClick.emit(this.series);
+  }
+
+  readNext(event: MouseEvent): void {
+    event.stopPropagation();
+    if (this.series.nextUnread) {
+      this.bookService.readBook(this.series.nextUnread.id);
+    }
+  }
+}

--- a/booklore-ui/src/app/features/series-browser/components/series-scroller/series-scroller.component.html
+++ b/booklore-ui/src/app/features/series-browser/components/series-scroller/series-scroller.component.html
@@ -1,0 +1,24 @@
+<ng-container *transloco="let t; prefix: 'seriesBrowser'">
+  <div class="series-scroller-container">
+    <h2 class="series-scroller-title">{{ title }}</h2>
+
+    @if (!series || series.length === 0) {
+      <div class="series-scroller-empty">
+        <div class="empty-state-icon">
+          <i class="pi pi-list"></i>
+        </div>
+        <p>{{ t('noSeriesInCategory') }}</p>
+      </div>
+    } @else {
+      <div class="series-scroller-track">
+        @for (s of series; track s.seriesName) {
+          <app-series-card
+            [series]="s"
+            [compact]="true"
+            (cardClick)="onSeriesClick($event)">
+          </app-series-card>
+        }
+      </div>
+    }
+  </div>
+</ng-container>

--- a/booklore-ui/src/app/features/series-browser/components/series-scroller/series-scroller.component.scss
+++ b/booklore-ui/src/app/features/series-browser/components/series-scroller/series-scroller.component.scss
@@ -1,0 +1,97 @@
+.series-scroller-container {
+  border-radius: 20px;
+  padding: 1rem 2rem 0;
+  margin-bottom: 2rem;
+  position: relative;
+  overflow: hidden;
+  backdrop-filter: blur(20px);
+  border: color-mix(in srgb, var(--p-surface-500), transparent 50%) 1px solid;
+}
+
+.series-scroller-title {
+  text-align: left;
+  font-size: 1.5rem;
+  font-weight: 800;
+  margin-bottom: 1rem;
+  padding: 0;
+  background: linear-gradient(135deg, #ffffff, #e2e8f0, #3b82f6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  position: relative;
+  z-index: 2;
+  letter-spacing: -0.02em;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -6px;
+    left: 0;
+    width: 80px;
+    height: 4px;
+    background: linear-gradient(90deg, var(--primary-color), var(--primary-color));
+    border-radius: 2px;
+  }
+}
+
+.series-scroller-empty {
+  padding: 3rem 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+
+  .empty-state-icon {
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 2rem;
+
+    i {
+      font-size: 2rem;
+      color: white;
+      filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
+    }
+  }
+
+  p {
+    color: #e2e8f0;
+    font-size: 1rem;
+    font-weight: 500;
+    max-width: 400px;
+    line-height: 1.7;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  }
+}
+
+.series-scroller-track {
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  padding: 1rem 0.5rem 1rem;
+  gap: 1.25rem;
+  width: 100%;
+  position: relative;
+  z-index: 2;
+
+  scrollbar-color: var(--primary-color) rgba(20, 20, 30, 0.5);
+
+  > * {
+    scroll-snap-align: start;
+  }
+}
+
+@media (max-width: 767px) {
+  .series-scroller-container {
+    padding: 1rem 1rem 0;
+  }
+
+  .series-scroller-track {
+    gap: 1rem;
+  }
+}

--- a/booklore-ui/src/app/features/series-browser/components/series-scroller/series-scroller.component.ts
+++ b/booklore-ui/src/app/features/series-browser/components/series-scroller/series-scroller.component.ts
@@ -1,0 +1,22 @@
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {TranslocoDirective} from '@jsverse/transloco';
+import {SeriesCardComponent} from '../series-card/series-card.component';
+import {SeriesSummary} from '../../model/series.model';
+
+@Component({
+  selector: 'app-series-scroller',
+  standalone: true,
+  templateUrl: './series-scroller.component.html',
+  styleUrls: ['./series-scroller.component.scss'],
+  imports: [SeriesCardComponent, TranslocoDirective]
+})
+export class SeriesScrollerComponent {
+
+  @Input({required: true}) title!: string;
+  @Input({required: true}) series!: SeriesSummary[];
+  @Output() seriesClick = new EventEmitter<SeriesSummary>();
+
+  onSeriesClick(s: SeriesSummary): void {
+    this.seriesClick.emit(s);
+  }
+}

--- a/booklore-ui/src/app/features/series-browser/model/series.model.ts
+++ b/booklore-ui/src/app/features/series-browser/model/series.model.ts
@@ -1,0 +1,16 @@
+import {Book, ReadStatus} from '../../book/model/book.model';
+
+export interface SeriesSummary {
+  seriesName: string;
+  books: Book[];
+  authors: string[];
+  categories: string[];
+  bookCount: number;
+  readCount: number;
+  progress: number;
+  seriesStatus: ReadStatus;
+  nextUnread: Book | null;
+  lastReadTime: string | null;
+  coverBooks: Book[];
+  addedOn: string | null;
+}

--- a/booklore-ui/src/app/features/series-browser/service/series-data.service.ts
+++ b/booklore-ui/src/app/features/series-browser/service/series-data.service.ts
@@ -1,0 +1,107 @@
+import {inject, Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
+import {filter, map, shareReplay} from 'rxjs/operators';
+import {BookService} from '../../book/service/book.service';
+import {Book, ReadStatus} from '../../book/model/book.model';
+import {SeriesSummary} from '../model/series.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SeriesDataService {
+
+  private bookService = inject(BookService);
+
+  allSeries$: Observable<SeriesSummary[]> = this.bookService.bookState$.pipe(
+    filter(state => state.loaded && !!state.books),
+    map(state => this.buildSeriesSummaries(state.books || [])),
+    shareReplay(1)
+  );
+
+  private buildSeriesSummaries(books: Book[]): SeriesSummary[] {
+    const seriesMap = new Map<string, Book[]>();
+
+    for (const book of books) {
+      const seriesName = book.metadata?.seriesName;
+      if (!seriesName) continue;
+
+      const key = seriesName.toLowerCase();
+      if (!seriesMap.has(key)) {
+        seriesMap.set(key, []);
+      }
+      seriesMap.get(key)!.push(book);
+    }
+
+    const summaries: SeriesSummary[] = [];
+
+    for (const seriesBooks of seriesMap.values()) {
+      const sorted = seriesBooks.sort((a, b) => {
+        const aNum = a.metadata?.seriesNumber ?? Number.MAX_SAFE_INTEGER;
+        const bNum = b.metadata?.seriesNumber ?? Number.MAX_SAFE_INTEGER;
+        return aNum - bNum;
+      });
+
+      const displayName = sorted[0].metadata?.seriesName || '';
+      const authorSet = new Set<string>();
+      const categorySet = new Set<string>();
+
+      for (const book of sorted) {
+        book.metadata?.authors?.forEach(a => authorSet.add(a));
+        book.metadata?.categories?.forEach(c => categorySet.add(c));
+      }
+
+      const readCount = sorted.filter(b => b.readStatus === ReadStatus.READ).length;
+      const bookCount = sorted.length;
+
+      const lastReadTime = sorted
+        .map(b => b.lastReadTime)
+        .filter((t): t is string => !!t)
+        .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0] || null;
+
+      const addedOn = sorted
+        .map(b => b.addedOn)
+        .filter((t): t is string => !!t)
+        .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0] || null;
+
+      const nextUnread = sorted.find(b => b.readStatus !== ReadStatus.READ) || null;
+
+      summaries.push({
+        seriesName: displayName,
+        books: sorted,
+        authors: Array.from(authorSet),
+        categories: Array.from(categorySet),
+        bookCount,
+        readCount,
+        progress: bookCount > 0 ? readCount / bookCount : 0,
+        seriesStatus: this.computeSeriesStatus(sorted),
+        nextUnread,
+        lastReadTime,
+        coverBooks: sorted.slice(0, 7),
+        addedOn
+      });
+    }
+
+    return summaries;
+  }
+
+  private computeSeriesStatus(books: Book[]): ReadStatus {
+    if (!books || books.length === 0) return ReadStatus.UNREAD;
+    const statuses = books.map(b => (b.readStatus as ReadStatus) ?? ReadStatus.UNREAD);
+
+    if (statuses.includes(ReadStatus.WONT_READ)) return ReadStatus.WONT_READ;
+    if (statuses.includes(ReadStatus.ABANDONED)) return ReadStatus.ABANDONED;
+    if (statuses.every(s => s === ReadStatus.READ)) return ReadStatus.READ;
+
+    const isAnyReading = statuses.some(
+      s => s === ReadStatus.READING || s === ReadStatus.RE_READING || s === ReadStatus.PAUSED
+    );
+    if (isAnyReading) return ReadStatus.READING;
+
+    const someRead = statuses.some(s => s === ReadStatus.READ);
+    if (someRead) return ReadStatus.PARTIALLY_READ;
+
+    if (statuses.every(s => s === ReadStatus.UNREAD)) return ReadStatus.UNREAD;
+
+    return ReadStatus.PARTIALLY_READ;
+  }
+}

--- a/booklore-ui/src/app/features/series-browser/service/series-scale-preference.service.ts
+++ b/booklore-ui/src/app/features/series-browser/service/series-scale-preference.service.ts
@@ -1,0 +1,43 @@
+import {inject, Injectable} from '@angular/core';
+import {Subject} from 'rxjs';
+import {debounceTime} from 'rxjs/operators';
+import {LocalStorageService} from '../../../shared/service/local-storage.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SeriesScalePreferenceService {
+
+  private readonly DEBOUNCE_MS = 1000;
+  private readonly STORAGE_KEY = 'seriesScalePreference';
+
+  private readonly localStorageService = inject(LocalStorageService);
+
+  private readonly scaleChangeSubject = new Subject<number>();
+
+  scaleFactor = 1.0;
+
+  constructor() {
+    this.loadScaleFromStorage();
+
+    this.scaleChangeSubject
+      .pipe(debounceTime(this.DEBOUNCE_MS))
+      .subscribe(scale => this.saveScalePreference(scale));
+  }
+
+  setScale(scale: number): void {
+    this.scaleFactor = scale;
+    this.scaleChangeSubject.next(scale);
+  }
+
+  private saveScalePreference(scale: number): void {
+    this.localStorageService.set(this.STORAGE_KEY, scale);
+  }
+
+  private loadScaleFromStorage(): void {
+    const saved = this.localStorageService.get<number>(this.STORAGE_KEY);
+    if (saved !== null && !isNaN(saved)) {
+      this.scaleFactor = saved;
+    }
+  }
+}

--- a/booklore-ui/src/app/shared/layout/component/layout-menu/app.menu.component.ts
+++ b/booklore-ui/src/app/shared/layout/component/layout-menu/app.menu.component.ts
@@ -12,6 +12,7 @@ import {AppVersion, VersionService} from '../../../service/version.service';
 import {DynamicDialogRef} from 'primeng/dynamicdialog';
 import {UserService} from '../../../../features/settings/user-management/user.service';
 import {MagicShelfService, MagicShelfState} from '../../../../features/magic-shelf/service/magic-shelf.service';
+import {SeriesDataService} from '../../../../features/series-browser/service/series-data.service';
 import {MenuItem} from 'primeng/api';
 import {DialogLauncherService} from '../../../services/dialog-launcher.service';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
@@ -44,6 +45,7 @@ export class AppMenuComponent implements OnInit {
   private dialogLauncherService = inject(DialogLauncherService);
   private userService = inject(UserService);
   private magicShelfService = inject(MagicShelfService);
+  private seriesDataService = inject(SeriesDataService);
   private t = inject(TranslocoService);
   private localStorageService = inject(LocalStorageService);
 
@@ -97,6 +99,13 @@ export class AppMenuComponent implements OnInit {
               icon: 'pi pi-fw pi-book',
               routerLink: ['/all-books'],
               bookCount$: of(bookState.books ? bookState.books.length : 0),
+            },
+            {
+              label: this.t.translate('layout.menu.series'),
+              type: 'Series',
+              icon: 'pi pi-fw pi-objects-column',
+              routerLink: ['/series'],
+              bookCount$: this.seriesDataService.allSeries$.pipe(map(series => series.length)),
             },
             {
               label: this.t.translate('layout.menu.notebook'),

--- a/booklore-ui/src/app/shared/layout/component/layout-menu/app.menuitem.component.html
+++ b/booklore-ui/src/app/shared/layout/component/layout-menu/app.menuitem.component.html
@@ -83,7 +83,7 @@
       <p-menu #entitymenu [model]="item.menu" [popup]="true" appendTo="body"></p-menu>
     }
 
-        @if (item.type === 'Library' && (!admin && !canManipulateLibrary) || item.type === 'All Books' || item.label === 'Unshelved' || item.label === 'Kobo') {
+        @if (item.type === 'Library' && (!admin && !canManipulateLibrary) || item.type === 'All Books' || item.type === 'Series' || item.label === 'Unshelved' || item.label === 'Kobo') {
           <p class="book-count">
         {{ (item.bookCount$ | async)?.toString() || '0' }}
       </p>

--- a/booklore-ui/src/i18n/en/index.ts
+++ b/booklore-ui/src/i18n/en/index.ts
@@ -33,8 +33,9 @@ import readerPdf from './reader-pdf.json';
 import statsLibrary from './stats-library.json';
 import statsUser from './stats-user.json';
 import magicShelf from './magic-shelf.json';
+import seriesBrowser from './series-browser.json';
 
 // To add a new domain: create the JSON file and add it here.
 // Settings tabs each get their own file: settings-email, settings-reader, settings-view, etc.
-const translations: Translation = {common, auth, nav, dashboard, settings, settingsEmail, settingsReader, settingsView, settingsMeta, settingsLibMeta, settingsApp, settingsUsers, settingsNaming, settingsOpds, settingsTasks, settingsAuditLogs, settingsAuth, settingsDevice, settingsProfile, app, shared, layout, libraryCreator, bookdrop, metadata, notebook, book, readerAudiobook, readerCbx, readerEbook, readerPdf, statsLibrary, statsUser, magicShelf};
+const translations: Translation = {common, auth, nav, dashboard, settings, settingsEmail, settingsReader, settingsView, settingsMeta, settingsLibMeta, settingsApp, settingsUsers, settingsNaming, settingsOpds, settingsTasks, settingsAuditLogs, settingsAuth, settingsDevice, settingsProfile, app, shared, layout, libraryCreator, bookdrop, metadata, notebook, book, readerAudiobook, readerCbx, readerEbook, readerPdf, statsLibrary, statsUser, magicShelf, seriesBrowser};
 export default translations;

--- a/booklore-ui/src/i18n/en/layout.json
+++ b/booklore-ui/src/i18n/en/layout.json
@@ -25,6 +25,7 @@
     "shelves": "Shelves",
     "magicShelves": "Magic Shelves",
     "unshelved": "Unshelved",
+    "series": "Series",
     "notebook": "Notebook",
     "update": "(Update)"
   },

--- a/booklore-ui/src/i18n/en/series-browser.json
+++ b/booklore-ui/src/i18n/en/series-browser.json
@@ -1,0 +1,25 @@
+{
+  "pageTitle": "Series",
+  "browseAllSeries": "Browse All Series",
+  "searchPlaceholder": "Search by series name or author...",
+  "readNext": "Read Next",
+  "booksRead": "books read",
+  "noSeriesFound": "No series match your search or filters.",
+  "noSeriesInCategory": "No series found in this category.",
+  "cardSize": "Card Size",
+  "filters": {
+    "all": "All",
+    "notStarted": "Not Started",
+    "inProgress": "In Progress",
+    "completed": "Completed",
+    "abandoned": "Abandoned"
+  },
+  "sort": {
+    "nameAsc": "Name (A-Z)",
+    "nameDesc": "Name (Z-A)",
+    "bookCount": "Book Count",
+    "progress": "Progress",
+    "recentlyRead": "Recently Read",
+    "recentlyAdded": "Recently Added"
+  }
+}

--- a/booklore-ui/src/i18n/es/index.ts
+++ b/booklore-ui/src/i18n/es/index.ts
@@ -33,8 +33,9 @@ import readerPdf from './reader-pdf.json';
 import statsLibrary from './stats-library.json';
 import statsUser from './stats-user.json';
 import magicShelf from './magic-shelf.json';
+import seriesBrowser from './series-browser.json';
 
 // To add a new domain: create the JSON file and add it here.
 // Settings tabs each get their own file: settings-email, settings-reader, settings-view, etc.
-const translations: Translation = {common, auth, nav, dashboard, settings, settingsEmail, settingsReader, settingsView, settingsMeta, settingsLibMeta, settingsApp, settingsUsers, settingsNaming, settingsOpds, settingsTasks, settingsAuditLogs, settingsAuth, settingsDevice, settingsProfile, app, shared, layout, libraryCreator, bookdrop, metadata, notebook, book, readerAudiobook, readerCbx, readerEbook, readerPdf, statsLibrary, statsUser, magicShelf};
+const translations: Translation = {common, auth, nav, dashboard, settings, settingsEmail, settingsReader, settingsView, settingsMeta, settingsLibMeta, settingsApp, settingsUsers, settingsNaming, settingsOpds, settingsTasks, settingsAuditLogs, settingsAuth, settingsDevice, settingsProfile, app, shared, layout, libraryCreator, bookdrop, metadata, notebook, book, readerAudiobook, readerCbx, readerEbook, readerPdf, statsLibrary, statsUser, magicShelf, seriesBrowser};
 export default translations;

--- a/booklore-ui/src/i18n/es/layout.json
+++ b/booklore-ui/src/i18n/es/layout.json
@@ -25,6 +25,7 @@
     "shelves": "Estantes",
     "magicShelves": "Estantes mágicos",
     "unshelved": "Sin estante",
+    "series": "Series",
     "notebook": "Cuaderno",
     "update": "(Actualizar)"
   },

--- a/booklore-ui/src/i18n/es/series-browser.json
+++ b/booklore-ui/src/i18n/es/series-browser.json
@@ -1,0 +1,25 @@
+{
+  "pageTitle": "Series",
+  "browseAllSeries": "Explorar todas las series",
+  "searchPlaceholder": "Buscar por nombre de serie o autor...",
+  "readNext": "Leer siguiente",
+  "booksRead": "libros leídos",
+  "noSeriesFound": "Ninguna serie coincide con tu búsqueda o filtros.",
+  "noSeriesInCategory": "No se encontraron series en esta categoría.",
+  "cardSize": "Tamaño de tarjeta",
+  "filters": {
+    "all": "Todas",
+    "notStarted": "Sin empezar",
+    "inProgress": "En progreso",
+    "completed": "Completadas",
+    "abandoned": "Abandonadas"
+  },
+  "sort": {
+    "nameAsc": "Nombre (A-Z)",
+    "nameDesc": "Nombre (Z-A)",
+    "bookCount": "Cantidad de libros",
+    "progress": "Progreso",
+    "recentlyRead": "Leídas recientemente",
+    "recentlyAdded": "Agregadas recientemente"
+  }
+}


### PR DESCRIPTION
New series browser page. You can browse all your book series, search by name or author, filter by read status, and sort by various criteria. Each series card shows stacked covers, a progress bar, and a Read Next button. The whole thing is frontend only, no backend changes needed.