### PR TITLE
Fix column gap +/- buttons in eBook reader default settings

### DIFF
--- a/booklore-ui/src/app/features/settings/reader-preferences/epub-reader-preferences/epub-reader-preferences-component.html
+++ b/booklore-ui/src/app/features/settings/reader-preferences/epub-reader-preferences/epub-reader-preferences-component.html
@@ -245,7 +245,7 @@
             <label class="setting-label">{{ t('columnGap') }}</label>
             <div class="font-size-controls">
               <p-button icon="pi pi-minus" size="small" rounded outlined (click)="decreaseGap()"></p-button>
-              <span class="font-size-value">{{ gap }}px</span>
+              <span class="font-size-value">{{ gap * 100 | number : '1.0-0' }}%</span>
               <p-button icon="pi pi-plus" size="small" rounded outlined (click)="increaseGap()"></p-button>
             </div>
           </div>

--- a/booklore-ui/src/app/features/settings/reader-preferences/epub-reader-preferences/epub-reader-preferences-component.ts
+++ b/booklore-ui/src/app/features/settings/reader-preferences/epub-reader-preferences/epub-reader-preferences-component.ts
@@ -1,3 +1,4 @@
+import {DecimalPipe} from '@angular/common';
 import {Component, inject, Input, OnDestroy, OnInit} from '@angular/core';
 import {Button} from 'primeng/button';
 import {FormsModule} from '@angular/forms';
@@ -16,6 +17,7 @@ import {themes} from '../../../readers/ebook-reader/state/themes.constant';
   selector: 'app-epub-reader-preferences-component',
   imports: [
     Button,
+    DecimalPipe,
     FormsModule,
     TranslocoDirective,
     Tooltip,
@@ -249,25 +251,26 @@ export class EpubReaderPreferencesComponent implements OnInit, OnDestroy {
 
   increaseLineHeight() {
     if (this.lineHeight < 3) {
-      this.lineHeight += 0.1;
+      this.lineHeight = Math.round((this.lineHeight + 0.1) * 10) / 10;
     }
   }
 
   decreaseLineHeight() {
     if (this.lineHeight > 1) {
-      this.lineHeight -= 0.1;
+      this.lineHeight = Math.round((this.lineHeight - 0.1) * 10) / 10;
     }
   }
 
   increaseGap() {
-    if (this.gap < 100) {
-      this.gap += 5;
+
+    if (this.gap < 0.5) {
+      this.gap = Math.round((this.gap + 0.05) * 100) / 100;
     }
   }
 
   decreaseGap() {
     if (this.gap > 0) {
-      this.gap -= 5;
+      this.gap = Math.round((this.gap - 0.05) * 100) / 100;
     }
   }
 


### PR DESCRIPTION
The column gap +/- buttons in the eBook reader default settings were using the wrong scale. The gap value is stored as a fraction (0 to 0.5) but the buttons were stepping by 5 and showing px units, which made no sense. Fixed the step size and changed the display to percentages.