### PR TITLE
Fix CBZ reader scroll position reset in infinite scroll mode

### DIFF
--- a/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.html
+++ b/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.html
@@ -77,8 +77,8 @@
           }
         } @else {
           <div class="infinite-scroll-wrapper" [class.long-strip-wrapper]="scrollMode === CbxScrollMode.LONG_STRIP">
-            @for (url of infiniteScrollImageUrls; track url; let i = $index) {
-              <img [src]="url" alt="Page {{ infiniteScrollPages[i] + 1 }}" class="page-image" (click)="onImageClick()" (dblclick)="onImageDoubleClick()" (load)="onPageImageLoad($event, infiniteScrollPages[i])"/>
+            @for (pageIdx of infiniteScrollPages; track pageIdx; let i = $index) {
+              <img [src]="getPageImageUrl(pageIdx)" alt="Page {{ pageIdx + 1 }}" class="page-image" (click)="onImageClick()" (dblclick)="onImageDoubleClick()" (load)="onPageImageLoad($event, pageIdx)"/>
             }
             @if (isLoadingMore) {
               <div class="loading-more">


### PR DESCRIPTION
CBZ reader in infinite scroll mode was jumping back to the saved progress position after scrolling about 10 pages. The issue was that the template loop was tracking by image URL, which includes the auth token. When the token refreshes, all URLs change and Angular recreates every image element, resetting scroll position. Switched to tracking by page index so the DOM stays stable. Also debounced progress saves during scrolling.