### PR TITLE
Fix PWA offline fallback blocking localhost access when internet is disconnected

### DIFF
--- a/booklore-ui/src/app/app.component.spec.ts
+++ b/booklore-ui/src/app/app.component.spec.ts
@@ -1,0 +1,109 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {AppComponent} from './app.component';
+import {AuthInitializationService} from './core/security/auth-initialization-service';
+import {BehaviorSubject, of} from 'rxjs';
+import {RxStompService} from './shared/websocket/rx-stomp.service';
+import {BookService} from './features/book/service/book.service';
+import {NotificationEventService} from './shared/websocket/notification-event.service';
+import {AppConfigService} from './shared/service/app-config.service';
+import {MetadataProgressService} from './shared/service/metadata-progress.service';
+import {BookdropFileService} from './features/bookdrop/service/bookdrop-file.service';
+import {TaskService} from './features/settings/task-management/task.service';
+import {LibraryService} from './features/book/service/library.service';
+import {LibraryLoadingService} from './features/library-creator/library-loading.service';
+import {TranslocoTestingModule} from '@jsverse/transloco';
+
+describe('AppComponent offline detection', () => {
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let authInitSubject: BehaviorSubject<boolean>;
+
+  beforeEach(() => {
+    authInitSubject = new BehaviorSubject<boolean>(false);
+
+    TestBed.configureTestingModule({
+      imports: [TranslocoTestingModule.forRoot({langs: {}})],
+      providers: [
+        {provide: AuthInitializationService, useValue: {initialized$: authInitSubject.asObservable()}},
+        {provide: RxStompService, useValue: {watch: vi.fn(() => of())}},
+        {provide: BookService, useValue: {}},
+        {provide: NotificationEventService, useValue: {}},
+        {provide: AppConfigService, useValue: {}},
+        {provide: MetadataProgressService, useValue: {}},
+        {provide: BookdropFileService, useValue: {}},
+        {provide: TaskService, useValue: {}},
+        {provide: LibraryService, useValue: {largeLibraryLoading$: of({isLoading: false, expectedCount: 0})}},
+        {provide: LibraryLoadingService, useValue: {hide: vi.fn()}},
+      ]
+    });
+
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should initialize with offline set to false', () => {
+    expect(component.offline).toBe(false);
+  });
+
+  it('should set offline to false when online event fires', () => {
+    component.offline = true;
+    window.dispatchEvent(new Event('online'));
+    expect(component.offline).toBe(false);
+  });
+
+  it('should not show offline when server is reachable despite browser offline event', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, {status: 200}));
+
+    window.dispatchEvent(new Event('offline'));
+
+    await vi.waitFor(() => {
+      expect(component.offline).toBe(false);
+    });
+  });
+
+  it('should show offline when server is unreachable on browser offline event', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'));
+
+    window.dispatchEvent(new Event('offline'));
+
+    await vi.waitFor(() => {
+      expect(component.offline).toBe(true);
+    });
+  });
+
+  it('should ping server with HEAD method and no-store cache', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, {status: 200}));
+
+    window.dispatchEvent(new Event('offline'));
+
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith('/api/public/settings', {method: 'HEAD', cache: 'no-store'});
+    });
+  });
+
+  it('should treat server errors as reachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, {status: 500}));
+
+    window.dispatchEvent(new Event('offline'));
+
+    await vi.waitFor(() => {
+      expect(component.offline).toBe(false);
+    });
+  });
+
+  it('should treat network timeout as unreachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('network timeout'));
+
+    window.dispatchEvent(new Event('offline'));
+
+    await vi.waitFor(() => {
+      expect(component.offline).toBe(true);
+    });
+  });
+});

--- a/booklore-ui/src/app/app.component.ts
+++ b/booklore-ui/src/app/app.component.ts
@@ -28,7 +28,7 @@ import {scan, withLatestFrom} from 'rxjs/operators';
 export class AppComponent implements OnInit, OnDestroy {
 
   loading = true;
-  offline = !navigator.onLine;
+  offline = false;
   private subscriptions: Subscription[] = [];
   private subscriptionsInitialized = false;
 
@@ -61,8 +61,16 @@ export class AppComponent implements OnInit, OnDestroy {
   };
 
   private onOffline = () => {
-    this.offline = true;
+    this.checkServerReachable().then(reachable => {
+      this.offline = !reachable;
+    });
   };
+
+  private checkServerReachable(): Promise<boolean> {
+    return fetch('/api/public/settings', {method: 'HEAD', cache: 'no-store'})
+      .then(() => true)
+      .catch(() => false);
+  }
 
   reload(): void {
     window.location.reload();

--- a/booklore-ui/src/app/core/security/auth-initializer.spec.ts
+++ b/booklore-ui/src/app/core/security/auth-initializer.spec.ts
@@ -1,0 +1,60 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {TestBed} from '@angular/core/testing';
+import {initializeAuthFactory} from './auth-initializer';
+import {AuthInitializationService} from './auth-initialization-service';
+import {OAuthService} from 'angular-oauth2-oidc';
+import {AuthService} from '../../shared/service/auth.service';
+import {AppSettingsService, PublicAppSettings} from '../../shared/service/app-settings.service';
+import {BehaviorSubject} from 'rxjs';
+
+describe('initializeAuthFactory', () => {
+  let authInitService: AuthInitializationService;
+  let publicSettingsSubject: BehaviorSubject<PublicAppSettings | null>;
+
+  beforeEach(() => {
+    publicSettingsSubject = new BehaviorSubject<PublicAppSettings | null>(null);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: OAuthService, useValue: {configure: vi.fn(), loadDiscoveryDocumentAndTryLogin: vi.fn()}},
+        {provide: AuthService, useValue: {tokenSubject: {next: vi.fn()}}},
+        {provide: AppSettingsService, useValue: {publicAppSettings$: publicSettingsSubject.asObservable()}},
+        AuthInitializationService,
+      ]
+    });
+
+    authInitService = TestBed.inject(AuthInitializationService);
+  });
+
+  it('should proceed with auth initialization when navigator.onLine is false', async () => {
+    const markSpy = vi.spyOn(authInitService, 'markAsInitialized');
+
+    Object.defineProperty(navigator, 'onLine', {value: false, configurable: true});
+
+    const factory = TestBed.runInInjectionContext(() => initializeAuthFactory());
+    const initPromise = TestBed.runInInjectionContext(() => factory());
+
+    publicSettingsSubject.next({oidcEnabled: false, remoteAuthEnabled: false, oidcProviderDetails: null!});
+
+    await initPromise;
+
+    expect(markSpy).toHaveBeenCalled();
+
+    Object.defineProperty(navigator, 'onLine', {value: true, configurable: true});
+  });
+
+  it('should initialize normally when navigator.onLine is true', async () => {
+    const markSpy = vi.spyOn(authInitService, 'markAsInitialized');
+
+    Object.defineProperty(navigator, 'onLine', {value: true, configurable: true});
+
+    const factory = TestBed.runInInjectionContext(() => initializeAuthFactory());
+    const initPromise = TestBed.runInInjectionContext(() => factory());
+
+    publicSettingsSubject.next({oidcEnabled: false, remoteAuthEnabled: false, oidcProviderDetails: null!});
+
+    await initPromise;
+
+    expect(markSpy).toHaveBeenCalled();
+  });
+});

--- a/booklore-ui/src/app/core/security/auth-initializer.ts
+++ b/booklore-ui/src/app/core/security/auth-initializer.ts
@@ -27,12 +27,6 @@ export function initializeAuthFactory() {
     const authInitService = inject(AuthInitializationService);
 
     return new Promise<void>((resolve) => {
-      if (!navigator.onLine) {
-        console.warn('[Auth] App is offline, skipping auth initialization');
-        authInitService.markAsInitialized();
-        resolve();
-        return;
-      }
 
       const settingsTimeout = setTimeout(() => {
         console.warn('[Auth] Public settings fetch timed out, falling back to local auth');


### PR DESCRIPTION
The PWA offline fallback was blocking localhost access when internet was disconnected. The browser's navigator.onLine API only checks if a network interface is active, not whether the server is reachable. Now it actually pings the server before showing the offline screen, so localhost users can keep using BookLore without internet.