### PR TITLE
Fix bookdrop race condition processing files before fully written

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
@@ -21,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
+import org.apache.commons.io.FilenameUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
@@ -46,6 +48,12 @@ public class BookdropMetadataService {
     public BookdropFileEntity attachInitialMetadata(Long bookdropFileId) throws JacksonException {
         BookdropFileEntity entity = getOrThrow(bookdropFileId);
         BookMetadata initial = extractInitialMetadata(entity);
+        if (initial == null) {
+            log.warn("Metadata extraction returned null for file: {}. Using filename as fallback.", entity.getFileName());
+            initial = BookMetadata.builder()
+                    .title(FilenameUtils.getBaseName(entity.getFileName()))
+                    .build();
+        }
         extractAndSaveCover(entity);
         String initialJson = objectMapper.writeValueAsString(initial);
         entity.setOriginalMetadata(initialJson);

--- a/booklore-api/src/main/java/org/booklore/service/metadata/MetadataRefreshService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/MetadataRefreshService.java
@@ -413,6 +413,11 @@ public class MetadataRefreshService {
 
     private FetchMetadataRequest buildFetchMetadataRequestFromBook(Book book) {
         BookMetadata metadata = book.getMetadata();
+        if (metadata == null) {
+            return FetchMetadataRequest.builder()
+                    .bookId(book.getId())
+                    .build();
+        }
         String isbn = metadata.getIsbn13();
         if (isbn == null || isbn.isBlank()) {
             isbn = metadata.getIsbn10();


### PR DESCRIPTION
Fixed a race condition where bookdrop was trying to process files before they were fully written to disk. Now it polls the file size and waits for it to stabilize before doing anything. Also added a null fallback so if metadata extraction still fails, it just uses the filename as the title instead of blowing up.