### PR TITLE
Add Croatian and Swedish translations for login page

### DIFF
--- a/booklore-ui/src/app/core/config/transloco-loader.ts
+++ b/booklore-ui/src/app/core/config/transloco-loader.ts
@@ -15,6 +15,8 @@ const LAZY_LANG_LOADERS: Record<string, () => Promise<{default: Translation}>> =
   pl: () => import('../../../i18n/pl'),
   pt: () => import('../../../i18n/pt'),
   ru: () => import('../../../i18n/ru'),
+  hr: () => import('../../../i18n/hr'),
+  sv: () => import('../../../i18n/sv'),
 };
 
 export const AVAILABLE_LANGS = ['en', ...Object.keys(LAZY_LANG_LOADERS)];
@@ -29,6 +31,8 @@ export const LANG_LABELS: Record<string, string> = {
   pl: 'Polski',
   pt: 'Português',
   ru: 'Русский',
+  hr: 'Hrvatski',
+  sv: 'Svenska',
 };
 
 function deepMerge(base: Record<string, any>, override: Record<string, any>): Record<string, any> {

--- a/booklore-ui/src/i18n/hr/auth.json
+++ b/booklore-ui/src/i18n/hr/auth.json
@@ -1,0 +1,29 @@
+{
+  "oidc": {
+    "loginFailedSummary": "OIDC prijava nije uspjela",
+    "redirectingDetail": "Preusmjeravanje na lokalnu prijavu..."
+  },
+  "login": {
+    "title": "Dobrodošli natrag",
+    "subtitle": "Prijavite se za nastavak putovanja",
+    "usernameLabel": "Korisničko ime",
+    "usernamePlaceholder": "Unesite korisničko ime",
+    "passwordLabel": "Lozinka",
+    "passwordPlaceholder": "Unesite lozinku",
+    "signIn": "Prijava",
+    "orContinueWith": "ili nastavite s",
+    "redirectingTo": "Preusmjeravanje na {{provider}}...",
+    "oidcTrouble": "Imate problema s {{provider}}? Koristite lokalnu prijavu",
+    "reEnableOidc": "Ponovno omogući {{provider}} prijavu",
+    "connectionError": "Povezivanje s poslužiteljem nije moguće. Provjerite vezu i pokušajte ponovno.",
+    "unexpectedError": "Došlo je do neočekivane pogreške. Pokušajte ponovno.",
+    "oidcInitError": "Pokretanje OIDC prijave nije uspjelo. Pokušajte ponovno ili koristite lokalnu prijavu.",
+    "oidcWarningTitle": "Problemi s OIDC autentifikacijom",
+    "retryOidc": "Pokušaj ponovno OIDC",
+    "useLocalLogin": "Koristi lokalnu prijavu",
+    "oidcAutoDisabled": "{{provider}} autentifikacija je automatski onemogućena nakon {{count}} uzastopnih neuspjeha (uključujući isteke vremena). Možete pokušati ponovno ili nastaviti s lokalnom prijavom.",
+    "oidcManuallyDisabled": "{{provider}} autentifikacija je ručno onemogućena. Možete je ponovno omogućiti ili nastaviti s lokalnom prijavom.",
+    "oidcErrors": "{{provider}} autentifikacija je naišla na {{count}} pogrešku/pogreške, moguće zbog isteka vremena ili problema s poslužiteljem.",
+    "rateLimited": "Previše neuspjelih pokušaja prijave. Pokušajte ponovno kasnije."
+  }
+}

--- a/booklore-ui/src/i18n/hr/index.ts
+++ b/booklore-ui/src/i18n/hr/index.ts
@@ -1,0 +1,5 @@
+import {Translation} from '@jsverse/transloco';
+import auth from './auth.json';
+
+const translations: Translation = {auth};
+export default translations;

--- a/booklore-ui/src/i18n/sv/auth.json
+++ b/booklore-ui/src/i18n/sv/auth.json
@@ -1,0 +1,29 @@
+{
+  "oidc": {
+    "loginFailedSummary": "OIDC-inloggning misslyckades",
+    "redirectingDetail": "Omdirigerar till lokal inloggning..."
+  },
+  "login": {
+    "title": "Välkommen tillbaka",
+    "subtitle": "Logga in för att fortsätta din resa",
+    "usernameLabel": "Användarnamn",
+    "usernamePlaceholder": "Ange ditt användarnamn",
+    "passwordLabel": "Lösenord",
+    "passwordPlaceholder": "Ange ditt lösenord",
+    "signIn": "Logga in",
+    "orContinueWith": "eller fortsätt med",
+    "redirectingTo": "Omdirigerar till {{provider}}...",
+    "oidcTrouble": "Har du problem med {{provider}}? Använd lokal inloggning",
+    "reEnableOidc": "Återaktivera {{provider}}-inloggning",
+    "connectionError": "Kan inte ansluta till servern. Kontrollera din anslutning och försök igen.",
+    "unexpectedError": "Ett oväntat fel inträffade. Försök igen.",
+    "oidcInitError": "Det gick inte att starta OIDC-inloggning. Försök igen eller använd lokal inloggning.",
+    "oidcWarningTitle": "Problem med OIDC-autentisering",
+    "retryOidc": "Försök igen med OIDC",
+    "useLocalLogin": "Använd lokal inloggning",
+    "oidcAutoDisabled": "{{provider}}-autentisering har automatiskt inaktiverats efter {{count}} på varandra följande misslyckanden (inklusive tidsgränser). Du kan försöka igen eller fortsätta med lokal inloggning.",
+    "oidcManuallyDisabled": "{{provider}}-autentisering har inaktiverats manuellt. Du kan återaktivera den eller fortsätta med lokal inloggning.",
+    "oidcErrors": "{{provider}}-autentisering stötte på {{count}} fel, möjligen på grund av tidsgränser eller serverproblem.",
+    "rateLimited": "För många misslyckade inloggningsförsök. Försök igen senare."
+  }
+}

--- a/booklore-ui/src/i18n/sv/index.ts
+++ b/booklore-ui/src/i18n/sv/index.ts
@@ -1,0 +1,5 @@
+import {Translation} from '@jsverse/transloco';
+import auth from './auth.json';
+
+const translations: Translation = {auth};
+export default translations;


### PR DESCRIPTION
Adds Croatian and Swedish translations for the login page. Community contributed. Everything else falls back to English automatically.