### PR TITLE
Fix audit logs pagination bug and add URL query param sync

### DIFF
--- a/booklore-ui/src/app/features/settings/audit-logs/audit-logs.component.html
+++ b/booklore-ui/src/app/features/settings/audit-logs/audit-logs.component.html
@@ -65,6 +65,7 @@
           [lazy]="true"
           [paginator]="true"
           [rows]="rows"
+          [first]="currentPage * rows"
           [totalRecords]="totalRecords"
           [loading]="loading"
           [showCurrentPageReport]="true"


### PR DESCRIPTION
Changing the page size on the audit logs table (e.g. 25 to 50) wasn't actually sending the new size to the API because onLazyLoad never updated this.rows. Fixed that, and while at it added URL query param sync so pagination state, filters, and date range all persist across page refreshes. The existing tab param is preserved via queryParamsHandling merge.