### PR TITLE
Add visual polish to book card component

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.html
@@ -39,7 +39,10 @@
     }
 
     @if (!_isSeriesViewActive && hasDigitalFile()) {
-      <p-button [rounded]="true" [icon]="_isAudiobook ? 'pi pi-play' : 'pi pi-book'" class="read-btn" (click)="readBook(book)" [ariaLabel]="_isAudiobook ? ('book.card.alt.playAudiobook' | transloco) : ('book.card.alt.readBook' | transloco)"></p-button>
+      <p-button [rounded]="true" [icon]="readButtonIcon" class="read-btn" (click)="readBook(book)"
+        [pTooltip]="_isContinueReading ? ('book.card.alt.continueReading' | transloco) : ''"
+        tooltipPosition="bottom"
+        [ariaLabel]="_isContinueReading ? ('book.card.alt.continueReading' | transloco) : (_isAudiobook ? ('book.card.alt.playAudiobook' | transloco) : ('book.card.alt.readBook' | transloco))"></p-button>
     }
 
     @if (isCheckboxEnabled) {
@@ -53,7 +56,7 @@
     }
 
     @if (hasProgress) {
-      <div class="cover-progress-bar-container">
+      <div class="cover-progress-bar-container" [pTooltip]="progressTooltip" tooltipPosition="top">
         @if (_progressPercentage !== null) {
           <p-progressBar
             [value]="_progressPercentage"

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.scss
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.scss
@@ -1,14 +1,30 @@
 .book-card {
   background-color: var(--card-background);
-  border-radius: 8px 8px 8px 8px;
+  border-radius: 8px;
   position: relative;
   overflow: hidden;
   height: 100%;
   display: flex;
   flex-direction: column;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition: box-shadow 0.25s ease, transform 0.25s ease;
+
+  &:hover {
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+    transform: translateY(-2px);
+  }
 
   &.selected {
     border: 2px solid var(--primary-color);
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
   }
 }
 
@@ -24,9 +40,18 @@
   justify-content: center;
 }
 
+.cover-container:not(.loaded) {
+  background: linear-gradient(
+    90deg,
+    var(--surface-ground) 25%,
+    var(--surface-hover, rgba(255, 255, 255, 0.08)) 50%,
+    var(--surface-ground) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
 .cover-container.audiobook-cover {
-  // Use same aspect-ratio as ebooks for uniform virtual scroller row heights.
-  // The square audiobook cover image will be centered via object-fit: contain.
   aspect-ratio: 5/7;
   background-color: var(--surface-ground);
 }
@@ -36,11 +61,15 @@
   height: 100%;
   border-radius: 8px 8px 0 0;
   opacity: 0;
-  transition: opacity 0.2s ease-in;
+  transition: opacity 0.2s ease-in, transform 0.35s ease;
 }
 
 .book-cover.loaded {
   opacity: 1;
+}
+
+.book-card:hover .book-cover.loaded {
+  transform: scale(1.04);
 }
 
 .book-cover.square-cover {

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -91,6 +91,9 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
   protected _titleTooltip: string = '';
   protected _hasProgress: boolean = false;
   protected _isAudiobook: boolean = false;
+  protected _progressTooltip: string = '';
+  protected _isContinueReading: boolean = false;
+  protected _readButtonIcon: string = 'pi pi-book';
 
   private metadataCenterViewMode: 'route' | 'dialog' = 'route';
   private destroy$ = new Subject<void>();
@@ -177,6 +180,31 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
 
     this._seriesCountTooltip = this.t.translate('book.card.alt.seriesCollapsed', { count: this.book.seriesCount });
     this._titleTooltip = this.t.translate('book.card.alt.titleTooltip', { title: this._displayTitle });
+
+    const progressParts: string[] = [];
+    if (this._progressPercentage !== null) {
+      progressParts.push(`${this._progressPercentage}% (BookLore)`);
+    }
+    if (this._koProgressPercentage !== null) {
+      progressParts.push(`${this._koProgressPercentage}% (KOReader)`);
+    }
+    if (this._koboProgressPercentage !== null) {
+      progressParts.push(`${this._koboProgressPercentage}% (Kobo)`);
+    }
+    this._progressTooltip = progressParts.join(' | ');
+
+    const maxProgress = Math.max(
+      this._progressPercentage ?? 0,
+      this._koProgressPercentage ?? 0,
+      this._koboProgressPercentage ?? 0
+    );
+    this._isContinueReading = maxProgress > 0 && maxProgress < 100;
+
+    if (this._isAudiobook) {
+      this._readButtonIcon = this._isContinueReading ? 'pi pi-forward' : 'pi pi-play';
+    } else {
+      this._readButtonIcon = this._isContinueReading ? 'pi pi-forward' : 'pi pi-book';
+    }
   }
 
   get hasProgress(): boolean {
@@ -193,6 +221,14 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
 
   get readStatusTooltip(): string {
     return this._readStatusTooltip;
+  }
+
+  get progressTooltip(): string {
+    return this._progressTooltip;
+  }
+
+  get readButtonIcon(): string {
+    return this._readButtonIcon;
   }
 
   get displayTitle(): string | undefined {

--- a/booklore-ui/src/i18n/en/book.json
+++ b/booklore-ui/src/i18n/en/book.json
@@ -133,7 +133,8 @@
       "viewDetails": "View book details",
       "readBook": "Read book",
       "playAudiobook": "Play audiobook",
-      "bookMenu": "Book actions menu"
+      "bookMenu": "Book actions menu",
+      "continueReading": "Continue reading"
     }
   },
   "notes": {

--- a/booklore-ui/src/i18n/es/book.json
+++ b/booklore-ui/src/i18n/es/book.json
@@ -133,7 +133,8 @@
       "viewDetails": "Ver detalles del libro",
       "readBook": "Leer libro",
       "playAudiobook": "Reproducir audiolibro",
-      "bookMenu": "Menú de acciones del libro"
+      "bookMenu": "Menú de acciones del libro",
+      "continueReading": "Continuar leyendo"
     }
   },
   "notes": {


### PR DESCRIPTION
Adds a few small visual improvements to the book card. Cards now have a subtle shadow that deepens on hover with a slight lift, and covers do a gentle zoom on hover (clipped cleanly by overflow). There's a shimmer animation while covers are loading, a tooltip on the progress bar showing percentages per source, and in-progress books show a forward icon instead of the default read/play icon.