### PR TITLE
Fix Kobo sync HeadersTooLargeException for large libraries

### DIFF
--- a/booklore-api/src/main/resources/application.yaml
+++ b/booklore-api/src/main/resources/application.yaml
@@ -17,6 +17,7 @@ app:
   disk-type: ${DISK_TYPE:LOCAL}
 
 server:
+  max-http-header-size: 128KB
   forward-headers-strategy: native
   port: ${BOOKLORE_PORT:6060}
   compression:


### PR DESCRIPTION
The Kobo sync endpoint round-trips a sync token through HTTP response headers. This token wraps both BookLore's snapshot IDs and the raw Kobo store sync token (which grows with library size). With many books, the Base64-encoded token exceeds Tomcat's default 8KB header buffer, causing a HeadersTooLargeException. Bumping max-http-header-size to 128KB fixes this.

Closes #2799