### PR TITLE
Fix additional file uploader bugs and improve metadata viewer

### DIFF
--- a/booklore-api/src/main/java/org/booklore/exception/ApiError.java
+++ b/booklore-api/src/main/java/org/booklore/exception/ApiError.java
@@ -20,7 +20,7 @@ public enum ApiError {
     INVALID_VIEWER_SETTING(HttpStatus.BAD_REQUEST, "Invalid viewer setting for the book"),
     FILE_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Error reading files from path: %s"),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "Image not found or not readable"),
-    INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "Invalid file format, only pdf and epub are supported"),
+    INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "Invalid file format: %s"),
     LIBRARY_NOT_FOUND(HttpStatus.NOT_FOUND, "Library not found with ID: %d"),
     FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "File size exceeds the limit: %d MB"),
     CACHE_TOO_LARGE(HttpStatus.BAD_REQUEST, "Book archive is too large to cache with current settings"),

--- a/booklore-api/src/main/java/org/booklore/model/entity/BookFileEntity.java
+++ b/booklore-api/src/main/java/org/booklore/model/entity/BookFileEntity.java
@@ -128,9 +128,7 @@ public class BookFileEntity {
                     .filter(java.nio.file.Files::isRegularFile)
                     .filter(p -> {
                         String name = p.getFileName().toString().toLowerCase();
-                        return name.endsWith(".mp3") || name.endsWith(".m4a") || name.endsWith(".m4b")
-                                || name.endsWith(".flac") || name.endsWith(".ogg") || name.endsWith(".opus")
-                                || name.endsWith(".aac");
+                        return name.endsWith(".mp3") || name.endsWith(".m4a") || name.endsWith(".m4b");
                     })
                     .sorted()
                     .findFirst()

--- a/booklore-api/src/main/java/org/booklore/model/enums/BookFileExtension.java
+++ b/booklore-api/src/main/java/org/booklore/model/enums/BookFileExtension.java
@@ -20,11 +20,7 @@ public enum BookFileExtension {
     FB2("fb2", BookFileType.FB2),
     M4B("m4b", BookFileType.AUDIOBOOK),
     M4A("m4a", BookFileType.AUDIOBOOK),
-    MP3("mp3", BookFileType.AUDIOBOOK),
-    AAC("aac", BookFileType.AUDIOBOOK),
-    FLAC("flac", BookFileType.AUDIOBOOK),
-    OPUS("opus", BookFileType.AUDIOBOOK),
-    OGG("ogg", BookFileType.AUDIOBOOK);
+    MP3("mp3", BookFileType.AUDIOBOOK);
 
     private final String extension;
     private final BookFileType type;

--- a/booklore-api/src/main/java/org/booklore/model/enums/BookFileType.java
+++ b/booklore-api/src/main/java/org/booklore/model/enums/BookFileType.java
@@ -15,7 +15,7 @@ public enum BookFileType {
     FB2(Set.of("fb2")),
     MOBI(Set.of("mobi")),
     AZW3(Set.of("azw3", "azw")),
-    AUDIOBOOK(Set.of("m4b", "m4a", "mp3", "aac", "flac", "opus", "ogg"));
+    AUDIOBOOK(Set.of("m4b", "m4a", "mp3"));
 
     private final Set<String> extensions;
 

--- a/booklore-api/src/main/java/org/booklore/repository/BookAdditionalFileRepository.java
+++ b/booklore-api/src/main/java/org/booklore/repository/BookAdditionalFileRepository.java
@@ -1,7 +1,6 @@
 package org.booklore.repository;
 
 import org.booklore.model.entity.BookFileEntity;
-import org.booklore.model.enums.BookFileType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,31 +17,12 @@ public interface BookAdditionalFileRepository extends JpaRepository<BookFileEnti
 
     List<BookFileEntity> findByBookIdAndIsBookFormat(Long bookId, boolean isBookFormat);
 
-    List<BookFileEntity> findByBookIdAndBookType(Long bookId, BookFileType bookType);
-
-    /**
-     * Finds a {@link BookFileEntity} by its alternative format current hash.
-     * <p>
-     * This method queries against the {@code alt_format_current_hash} virtual column, which is indexed
-     * and only contains values for files where the {@code additional_file_type} is 'ALTERNATIVE_FORMAT'.
-     * This implicitly filters by the file type and provides an efficient lookup.
-     *
-     * @param altFormatCurrentHash The current hash of the file, which is only considered for alternative format files.
-     * @return an {@link Optional} containing the found entity, or an empty {@link Optional} if no match is found.
-     */
     Optional<BookFileEntity> findByAltFormatCurrentHash(String altFormatCurrentHash);
 
     @Query("SELECT bf FROM BookFileEntity bf WHERE bf.book.libraryPath.id = :libraryPathId AND bf.fileSubPath = :fileSubPath AND bf.fileName = :fileName")
     Optional<BookFileEntity> findByLibraryPath_IdAndFileSubPathAndFileName(@Param("libraryPathId") Long libraryPathId,
-                                                                                      @Param("fileSubPath") String fileSubPath,
-                                                                                      @Param("fileName") String fileName);
-
-    List<BookFileEntity> findByIsBookFormat(boolean isBookFormat);
-
-    List<BookFileEntity> findByBookType(BookFileType bookType);
-
-    @Query("SELECT COUNT(bf) FROM BookFileEntity bf WHERE bf.book.id = :bookId AND bf.isBookFormat = :isBookFormat")
-    long countByBookIdAndIsBookFormat(@Param("bookId") Long bookId, @Param("isBookFormat") boolean isBookFormat);
+                                                                           @Param("fileSubPath") String fileSubPath,
+                                                                           @Param("fileName") String fileName);
 
     @Query("SELECT bf FROM BookFileEntity bf WHERE bf.book.library.id = :libraryId")
     List<BookFileEntity> findByLibraryId(@Param("libraryId") Long libraryId);

--- a/booklore-api/src/main/java/org/booklore/service/file/FileFingerprint.java
+++ b/booklore-api/src/main/java/org/booklore/service/file/FileFingerprint.java
@@ -85,8 +85,6 @@ public class FileFingerprint {
     private static boolean isAudioFile(String fileName) {
         if (fileName == null) return false;
         String lower = fileName.toLowerCase();
-        return lower.endsWith(".mp3") || lower.endsWith(".m4a") || lower.endsWith(".m4b")
-                || lower.endsWith(".flac") || lower.endsWith(".ogg") || lower.endsWith(".opus")
-                || lower.endsWith(".aac");
+        return lower.endsWith(".mp3") || lower.endsWith(".m4a") || lower.endsWith(".m4b");
     }
 }

--- a/booklore-api/src/main/java/org/booklore/service/metadata/extractor/MetadataExtractorFactory.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/extractor/MetadataExtractorFactory.java
@@ -40,7 +40,7 @@ public class MetadataExtractorFactory {
             case FB2 -> fb2MetadataExtractor.extractMetadata(file);
             case MOBI -> mobiMetadataExtractor.extractMetadata(file);
             case AZW3, AZW -> azw3MetadataExtractor.extractMetadata(file);
-            case M4B, M4A, MP3, AAC, FLAC, OPUS, OGG -> audiobookMetadataExtractor.extractMetadata(file);
+            case M4B, M4A, MP3 -> audiobookMetadataExtractor.extractMetadata(file);
         };
     }
 
@@ -52,7 +52,7 @@ public class MetadataExtractorFactory {
             case FB2 -> fb2MetadataExtractor.extractCover(file);
             case MOBI -> mobiMetadataExtractor.extractCover(file);
             case AZW3, AZW -> azw3MetadataExtractor.extractCover(file);
-            case M4B, M4A, MP3, AAC, FLAC, OPUS, OGG -> audiobookMetadataExtractor.extractCover(file);
+            case M4B, M4A, MP3 -> audiobookMetadataExtractor.extractCover(file);
         };
     }
 

--- a/booklore-api/src/main/java/org/booklore/service/opds/OpdsFeedService.java
+++ b/booklore-api/src/main/java/org/booklore/service/opds/OpdsFeedService.java
@@ -691,11 +691,7 @@ public class OpdsFeedService {
             }
             case AUDIOBOOK -> {
                 String lower = bookFile.getFileName().toLowerCase();
-                if (lower.endsWith(".m4b") || lower.endsWith(".m4a")) yield "audio/mp4";
                 if (lower.endsWith(".mp3")) yield "audio/mpeg";
-                if (lower.endsWith(".flac")) yield "audio/flac";
-                if (lower.endsWith(".ogg") || lower.endsWith(".opus")) yield "audio/ogg";
-                if (lower.endsWith(".aac")) yield "audio/aac";
                 yield "audio/mp4";
             }
         };

--- a/booklore-api/src/main/java/org/booklore/service/reader/AudioFileUtilityService.java
+++ b/booklore-api/src/main/java/org/booklore/service/reader/AudioFileUtilityService.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 public class AudioFileUtilityService {
 
     private static final Set<String> AUDIO_EXTENSIONS = Set.of(
-            ".mp3", ".m4a", ".m4b", ".aac", ".flac", ".ogg", ".opus"
+            ".mp3", ".m4a", ".m4b"
     );
 
     /**
@@ -55,14 +55,6 @@ public class AudioFileUtilityService {
             return "audio/mp4";
         } else if (fileName.endsWith(".mp3")) {
             return "audio/mpeg";
-        } else if (fileName.endsWith(".aac")) {
-            return "audio/aac";
-        } else if (fileName.endsWith(".flac")) {
-            return "audio/flac";
-        } else if (fileName.endsWith(".ogg")) {
-            return "audio/ogg";
-        } else if (fileName.endsWith(".opus")) {
-            return "audio/opus";
         }
         return "application/octet-stream";
     }

--- a/booklore-api/src/main/java/org/booklore/util/BookFileGroupingUtils.java
+++ b/booklore-api/src/main/java/org/booklore/util/BookFileGroupingUtils.java
@@ -59,7 +59,7 @@ public class BookFileGroupingUtils {
     // Known book file extensions - only strip these, not arbitrary dots in folder names
     private static final Set<String> KNOWN_EXTENSIONS = Set.of(
             "pdf", "epub", "cbz", "cbr", "cb7", "mobi", "azw3", "azw", "fb2",
-            "m4b", "m4a", "mp3", "aac", "flac", "opus", "ogg"
+            "m4b", "m4a", "mp3"
     );
 
     public String extractGroupingKey(String fileName) {

--- a/booklore-api/src/main/java/org/booklore/util/FileUtils.java
+++ b/booklore-api/src/main/java/org/booklore/util/FileUtils.java
@@ -125,9 +125,7 @@ public class FileUtils {
     public boolean isAudioFile(String fileName) {
         if (fileName == null) return false;
         String lower = fileName.toLowerCase();
-        return lower.endsWith(".mp3") || lower.endsWith(".m4a") || lower.endsWith(".m4b")
-                || lower.endsWith(".flac") || lower.endsWith(".ogg") || lower.endsWith(".opus")
-                || lower.endsWith(".aac");
+        return lower.endsWith(".mp3") || lower.endsWith(".m4a") || lower.endsWith(".m4b");
     }
 
     /**

--- a/booklore-api/src/test/java/org/booklore/service/reader/AudioFileUtilityServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/reader/AudioFileUtilityServiceTest.java
@@ -39,7 +39,7 @@ class AudioFileUtilityServiceTest {
         // Create audio files
         Files.createFile(tempDir.resolve("track1.mp3"));
         Files.createFile(tempDir.resolve("track2.m4b"));
-        Files.createFile(tempDir.resolve("track3.flac"));
+        Files.createFile(tempDir.resolve("track3.m4a"));
 
         // Create non-audio files
         Files.createFile(tempDir.resolve("readme.txt"));
@@ -51,7 +51,7 @@ class AudioFileUtilityServiceTest {
         assertEquals(3, result.size());
         assertTrue(result.stream().anyMatch(p -> p.getFileName().toString().equals("track1.mp3")));
         assertTrue(result.stream().anyMatch(p -> p.getFileName().toString().equals("track2.m4b")));
-        assertTrue(result.stream().anyMatch(p -> p.getFileName().toString().equals("track3.flac")));
+        assertTrue(result.stream().anyMatch(p -> p.getFileName().toString().equals("track3.m4a")));
     }
 
     @Test
@@ -112,20 +112,16 @@ class AudioFileUtilityServiceTest {
         Files.createFile(tempDir.resolve("track.mp3"));
         Files.createFile(tempDir.resolve("track.m4a"));
         Files.createFile(tempDir.resolve("track.m4b"));
-        Files.createFile(tempDir.resolve("track.aac"));
-        Files.createFile(tempDir.resolve("track.flac"));
-        Files.createFile(tempDir.resolve("track.ogg"));
-        Files.createFile(tempDir.resolve("track.opus"));
 
         List<Path> result = audioFileUtility.listAudioFiles(tempDir);
 
-        assertEquals(7, result.size());
+        assertEquals(3, result.size());
     }
 
     // ==================== isAudioFile tests ====================
 
     @ParameterizedTest
-    @ValueSource(strings = {"track.mp3", "book.m4b", "audio.m4a", "sound.aac", "music.flac", "song.ogg", "voice.opus"})
+    @ValueSource(strings = {"track.mp3", "book.m4b", "audio.m4a"})
     void isAudioFile_returnsTrueForAudioExtensions(String filename) throws IOException {
         Path file = tempDir.resolve(filename);
         Files.createFile(file);
@@ -133,7 +129,7 @@ class AudioFileUtilityServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"TRACK.MP3", "Book.M4B", "Audio.M4A", "SOUND.AAC", "Music.FLAC", "Song.OGG", "Voice.OPUS"})
+    @ValueSource(strings = {"TRACK.MP3", "Book.M4B", "Audio.M4A"})
     void isAudioFile_isCaseInsensitive(String filename) throws IOException {
         Path file = tempDir.resolve(filename);
         Files.createFile(file);
@@ -161,11 +157,7 @@ class AudioFileUtilityServiceTest {
     @CsvSource({
             "track.m4b, audio/mp4",
             "track.m4a, audio/mp4",
-            "track.mp3, audio/mpeg",
-            "track.aac, audio/aac",
-            "track.flac, audio/flac",
-            "track.ogg, audio/ogg",
-            "track.opus, audio/opus"
+            "track.mp3, audio/mpeg"
     })
     void getContentType_returnsCorrectMimeType(String filename, String expectedMimeType) {
         Path file = tempDir.resolve(filename);
@@ -175,8 +167,7 @@ class AudioFileUtilityServiceTest {
     @ParameterizedTest
     @CsvSource({
             "TRACK.M4B, audio/mp4",
-            "TRACK.MP3, audio/mpeg",
-            "Track.Flac, audio/flac"
+            "TRACK.MP3, audio/mpeg"
     })
     void getContentType_isCaseInsensitive(String filename, String expectedMimeType) {
         Path file = tempDir.resolve(filename);
@@ -243,14 +234,10 @@ class AudioFileUtilityServiceTest {
     void getSupportedExtensions_returnsAllExpectedExtensions() {
         var extensions = audioFileUtility.getSupportedExtensions();
 
-        assertEquals(7, extensions.size());
+        assertEquals(3, extensions.size());
         assertTrue(extensions.contains(".mp3"));
         assertTrue(extensions.contains(".m4a"));
         assertTrue(extensions.contains(".m4b"));
-        assertTrue(extensions.contains(".aac"));
-        assertTrue(extensions.contains(".flac"));
-        assertTrue(extensions.contains(".ogg"));
-        assertTrue(extensions.contains(".opus"));
     }
 
     @Test

--- a/booklore-api/src/test/java/org/booklore/service/upload/FileUploadServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/upload/FileUploadServiceTest.java
@@ -134,7 +134,7 @@ class FileUploadServiceTest {
                 .isThrownBy(() -> service.uploadFileBookDrop(file))
                 .satisfies(ex -> {
                     assertThat(ex.getStatus()).isEqualTo(ApiError.INVALID_FILE_FORMAT.getStatus());
-                    assertThat(ex.getMessage()).contains("Invalid file format, only pdf and epub are supported");
+                    assertThat(ex.getMessage()).contains("Invalid file format");
                 });
     }
 

--- a/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.html
+++ b/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.html
@@ -30,22 +30,11 @@
     [disabled]="isUploading"
   ></p-select>
 
-  <!-- Description Field -->
-  <div class="description-field">
-    <label for="description" class="description-label">{{ t('descriptionLabel') }}</label>
-    <p-textarea
-      [(ngModel)]="description"
-      rows="3"
-      [attr.placeholder]="t('descriptionPlaceholder')"
-      class="full-width"
-      [disabled]="isUploading"
-    ></p-textarea>
-  </div>
-
   <!-- File Upload -->
   <p-fileupload class="file-upload" name="file"
     [customUpload]="true"
     [multiple]="false"
+    accept=".pdf,.epub,.cbz,.cbr,.cb7,.fb2,.mobi,.azw,.azw3,.m4b,.m4a,.mp3"
     (onSelect)="onFilesSelect($event)"
     (uploadHandler)="uploadFiles($event)"
     [disabled]="isUploading">
@@ -133,7 +122,11 @@
       <div class="empty-state">
         <i class="pi pi-cloud-upload empty-icon"></i>
         <p class="empty-text">{{ t('dragDropText') }}</p>
-        <p class="empty-subtext" [innerHTML]="t('uploadForBook', { title: book.metadata?.title || t('thisBook') })"></p>
+        <p class="empty-subtext">
+          <span [innerHTML]="t('supportedFormats')"></span>
+          <br/>
+          {{ t('maxFileSize', { size: maxFileSizeDisplay }) }}
+        </p>
       </div>
     </ng-template>
   </p-fileupload>

--- a/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.scss
+++ b/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.scss
@@ -40,17 +40,6 @@
   width: 100%;
 }
 
-.description-field {
-  width: 100%;
-}
-
-.description-label {
-  display: block;
-  font-size: 0.875rem;
-  font-weight: 500;
-  margin-bottom: 0.5rem;
-}
-
 .upload-header-actions {
   display: flex;
   flex-wrap: wrap;

--- a/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.ts
+++ b/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.ts
@@ -1,19 +1,19 @@
-import { Component, OnInit, OnDestroy, ChangeDetectorRef, inject } from '@angular/core';
+import {ChangeDetectorRef, Component, inject, OnDestroy, OnInit} from '@angular/core';
 
-import { FormsModule } from '@angular/forms';
-import { DynamicDialogRef, DynamicDialogConfig } from 'primeng/dynamicdialog';
-import { Select } from 'primeng/select';
-import { Button } from 'primeng/button';
-import { FileSelectEvent, FileUpload, FileUploadHandlerEvent } from 'primeng/fileupload';
-import { Badge } from 'primeng/badge';
-import { Tooltip } from 'primeng/tooltip';
-import { Subject, takeUntil } from 'rxjs';
-import { BookFileService } from '../../service/book-file.service';
-import { AppSettingsService } from '../../../../shared/service/app-settings.service';
-import { Book, AdditionalFileType } from '../../model/book.model';
-import { MessageService } from 'primeng/api';
-import { filter, take } from 'rxjs/operators';
-import { TranslocoDirective, TranslocoService } from '@jsverse/transloco';
+import {FormsModule} from '@angular/forms';
+import {DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+import {Select} from 'primeng/select';
+import {Button} from 'primeng/button';
+import {FileSelectEvent, FileUpload, FileUploadHandlerEvent} from 'primeng/fileupload';
+import {Badge} from 'primeng/badge';
+import {Tooltip} from 'primeng/tooltip';
+import {Subject} from 'rxjs';
+import {BookFileService} from '../../service/book-file.service';
+import {AppSettingsService} from '../../../../shared/service/app-settings.service';
+import {AdditionalFileType, Book} from '../../model/book.model';
+import {MessageService} from 'primeng/api';
+import {filter, take} from 'rxjs/operators';
+import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 
 interface FileTypeOption {
   label: string;
@@ -37,7 +37,7 @@ interface UploadingFile {
     Badge,
     Tooltip,
     TranslocoDirective
-],
+  ],
   templateUrl: './additional-file-uploader.component.html',
   styleUrls: ['./additional-file-uploader.component.scss']
 })
@@ -47,9 +47,9 @@ export class AdditionalFileUploaderComponent implements OnInit, OnDestroy {
   book!: Book;
   files: UploadingFile[] = [];
   fileType: AdditionalFileType = AdditionalFileType.ALTERNATIVE_FORMAT;
-  description: string = '';
   isUploading = false;
   maxFileSizeBytes?: number;
+  maxFileSizeDisplay: string = '100 MB';
 
   fileTypeOptions: FileTypeOption[] = [];
 
@@ -77,7 +77,9 @@ export class AdditionalFileUploaderComponent implements OnInit, OnDestroy {
       )
       .subscribe(settings => {
         if (settings) {
-          this.maxFileSizeBytes = (settings.maxFileUploadSizeInMb || 100) * 1024 * 1024;
+          const maxSizeMb = settings.maxFileUploadSizeInMb || 100;
+          this.maxFileSizeBytes = maxSizeMb * 1024 * 1024;
+          this.maxFileSizeDisplay = `${maxSizeMb} MB`;
         }
       });
   }
@@ -155,8 +157,7 @@ export class AdditionalFileUploaderComponent implements OnInit, OnDestroy {
       this.bookFileService.uploadAdditionalFile(
         this.book.id,
         uploadFile.file,
-        this.fileType,
-        this.description || undefined
+        this.fileType
       ).subscribe({
         next: () => {
           uploadFile.status = 'Uploaded';

--- a/booklore-ui/src/app/features/book/service/book-file.service.ts
+++ b/booklore-ui/src/app/features/book/service/book-file.service.ts
@@ -136,7 +136,7 @@ export class BookFileService {
     );
   }
 
-  uploadAdditionalFile(bookId: number, file: File, fileType: AdditionalFileType, description?: string): Observable<AdditionalFile> {
+  uploadAdditionalFile(bookId: number, file: File, fileType: AdditionalFileType): Observable<AdditionalFile> {
     const formData = new FormData();
     formData.append('file', file);
 
@@ -146,24 +146,21 @@ export class BookFileService {
     if (isBook) {
       const lower = (file?.name || '').toLowerCase();
       const ext = lower.includes('.') ? lower.substring(lower.lastIndexOf('.') + 1) : '';
-      const bookType = ext === 'pdf'
-        ? 'PDF'
-        : ext === 'epub'
-          ? 'EPUB'
-          : (ext === 'cbz' || ext === 'cbr' || ext === 'cb7' || ext === 'cbt')
-            ? 'CBX'
-            : (ext === 'm4b' || ext === 'm4a' || ext === 'mp3')
-              ? 'AUDIOBOOK'
-              : null;
+      const EXTENSION_TO_BOOK_TYPE: Record<string, string> = {
+        pdf: 'PDF',
+        epub: 'EPUB',
+        cbz: 'CBX', cbr: 'CBX', cb7: 'CBX',
+        mobi: 'MOBI',
+        azw3: 'AZW3', azw: 'AZW3',
+        fb2: 'FB2',
+        m4b: 'AUDIOBOOK', m4a: 'AUDIOBOOK', mp3: 'AUDIOBOOK',
+      };
+      const bookType = EXTENSION_TO_BOOK_TYPE[ext] ?? null;
 
       if (bookType) {
         formData.append('bookType', bookType);
       }
     }
-    if (description) {
-      formData.append('description', description);
-    }
-
     return this.http.post<AdditionalFile>(`${this.url}/${bookId}/files`, formData).pipe(
       tap((newFile) => {
         const currentState = this.bookStateService.getCurrentBookState();

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
@@ -128,6 +128,30 @@
                 }
               </p>
             </div>
+
+            <div class="formats-inline">
+              @if (getDisplayFormat(book?.primaryFile); as displayFormat) {
+                <span class="format-tag-wrapper primary-format" (click)="goToFileType(book?.primaryFile?.filePath)" [pTooltip]="book?.primaryFile?.fileName ?? ''" tooltipPosition="top">
+                  <app-tag size="3xs" variant="pill" [customBgColor]="getFileTypeBgColor(displayFormat)" customTextColor="#fff">
+                    {{ displayFormat }}
+                  </app-tag>
+                  <span class="format-badge">{{ t('primaryBadge') }}</span>
+                </span>
+              }
+              @if (getDisplayFormat(book?.primaryFile) && getUniqueAlternativeFormats(book).length > 0) {
+                <span class="format-pipe">|</span>
+              }
+              @for (formatExt of getUniqueAlternativeFormats(book); track formatExt) {
+                <span class="format-tag-wrapper" (click)="goToFileType('.' + formatExt)" [pTooltip]="formatExt" tooltipPosition="top">
+                  <app-tag size="3xs" variant="pill" [customBgColor]="getFileTypeBgColor(formatExt)" customTextColor="#fff">
+                    {{ formatExt }}
+                  </app-tag>
+                </span>
+              }
+              @if (!book?.primaryFile?.filePath && !book?.alternativeFormats?.length) {
+                <app-tag size="3xs" variant="pill" [customBgColor]="'var(--book-type-physical-color)'" customTextColor="#fff">{{ t('physicalBadge') }}</app-tag>
+              }
+            </div>
           </div>
 
           <div class="ratings-section">
@@ -369,30 +393,6 @@
               } @else {
                 <span class="metadata-value">-</span>
               }
-            </div>
-
-            <div class="metadata-item">
-              <span class="metadata-key">{{ t('formatsLabel') }}</span>
-              <span class="metadata-value-group format-tags">
-                @if (getDisplayFormat(book?.primaryFile); as displayFormat) {
-                  <span class="format-tag-wrapper primary-format" (click)="goToFileType(book?.primaryFile?.filePath)" [pTooltip]="book?.primaryFile?.fileName ?? ''" tooltipPosition="top">
-                    <app-tag size="3xs" variant="pill" [customBgColor]="getFileTypeBgColor(displayFormat)" customTextColor="#fff">
-                      {{ displayFormat }}
-                    </app-tag>
-                    <span class="format-badge">{{ t('primaryBadge') }}</span>
-                  </span>
-                }
-                @for (formatExt of getUniqueAlternativeFormats(book); track formatExt) {
-                  <span class="format-tag-wrapper" (click)="goToFileType('.' + formatExt)" [pTooltip]="formatExt" tooltipPosition="top">
-                    <app-tag size="3xs" variant="pill" [customBgColor]="getFileTypeBgColor(formatExt)" customTextColor="#fff">
-                      {{ formatExt }}
-                    </app-tag>
-                  </span>
-                }
-                @if (!book?.primaryFile?.filePath && !book?.alternativeFormats?.length) {
-                  <app-tag size="3xs" variant="pill" [customBgColor]="'var(--book-type-physical-color)'" customTextColor="#fff">{{ t('physicalBadge') }}</app-tag>
-                }
-              </span>
             </div>
 
             <div class="metadata-item">

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.scss
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.scss
@@ -222,6 +222,27 @@
   text-decoration: underline;
 }
 
+.formats-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  @media (min-width: 768px) {
+    justify-content: flex-start;
+  }
+}
+
+.format-pipe {
+  color: var(--text-color-secondary);
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1;
+  user-select: none;
+
+}
+
 .author-separator {
   color: var(--text-secondary-color);
 }
@@ -437,6 +458,7 @@
 
 .format-badge {
   display: none;
+  align-items: center;
   font-size: 0.55rem;
   font-weight: 700;
   color: var(--primary-color);
@@ -659,7 +681,7 @@
 }
 
 .description-content.line-clamp-7 {
-  max-height: 75px;
+  max-height: 37px;
 }
 
 .description-content:not(.line-clamp-7) {

--- a/booklore-ui/src/i18n/en/book.json
+++ b/booklore-ui/src/i18n/en/book.json
@@ -436,8 +436,6 @@
     "selectFileType": "Select file type",
     "typeAlternativeFormat": "Alternative Format",
     "typeSupplementary": "Supplementary File",
-    "descriptionLabel": "Description (Optional)",
-    "descriptionPlaceholder": "Add a description for this file...",
     "statusUploading": "Uploading",
     "statusUploaded": "Uploaded",
     "statusUploadFailed": "Upload failed",
@@ -445,6 +443,8 @@
     "statusReady": "Ready",
     "statusFailed": "Failed",
     "dragDropText": "Drag and drop a file here to upload.",
+    "supportedFormats": "Supported formats: <strong>.pdf</strong>, <strong>.epub</strong>, <strong>.cbz</strong>, <strong>.cbr</strong>, <strong>.cb7</strong>, <strong>.fb2</strong>, <strong>.mobi</strong>, <strong>.azw3</strong>, <strong>.m4b</strong>, <strong>.mp3</strong>",
+    "maxFileSize": "Maximum file size: {{ size }} per file",
     "uploadForBook": "Upload an additional file for <strong>{{ title }}</strong>.",
     "thisBook": "this book",
     "toast": {

--- a/booklore-ui/src/i18n/es/book.json
+++ b/booklore-ui/src/i18n/es/book.json
@@ -436,8 +436,6 @@
     "selectFileType": "Seleccionar tipo de archivo",
     "typeAlternativeFormat": "Formato alternativo",
     "typeSupplementary": "Archivo complementario",
-    "descriptionLabel": "Descripción (Opcional)",
-    "descriptionPlaceholder": "Agregar una descripción para este archivo...",
     "statusUploading": "Subiendo",
     "statusUploaded": "Subido",
     "statusUploadFailed": "Error al subir",
@@ -445,6 +443,8 @@
     "statusReady": "Listo",
     "statusFailed": "Fallido",
     "dragDropText": "Arrastre y suelte un archivo aquí para subir.",
+    "supportedFormats": "Formatos compatibles: <strong>.pdf</strong>, <strong>.epub</strong>, <strong>.cbz</strong>, <strong>.cbr</strong>, <strong>.cb7</strong>, <strong>.fb2</strong>, <strong>.mobi</strong>, <strong>.azw3</strong>, <strong>.m4b</strong>, <strong>.mp3</strong>",
+    "maxFileSize": "Tamaño máximo de archivo: {{ size }} por archivo",
     "uploadForBook": "Subir un archivo adicional para <strong>{{ title }}</strong>.",
     "thisBook": "este libro",
     "toast": {


### PR DESCRIPTION
Bunch of fixes for the additional file uploader. The error message for invalid formats was still saying "only pdf and epub are supported" which hasn't been true for a while. Also the frontend bookType mapping was missing mobi, azw3, and fb2 so those wouldn't show up under Book Type filters. The description field textarea was never rendering because the PrimeNG Textarea component wasn't imported, ended up just removing the description field entirely since it wasn't adding much value.

Dropped support for aac, flac, opus, and ogg audio formats across the whole stack. Also added an accept filter and supported formats hint to the upload dialog so users can see what's allowed.

Moved the book format pills up into the metadata header (below title/authors) with a pipe separator between primary and additional formats, and cut the collapsed description height in half.