### PR TITLE
Fix null collection errors for PDFs, audiobooks, and physical books

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/dto/BookMetadata.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/BookMetadata.java
@@ -61,7 +61,6 @@ public class BookMetadata {
     private Instant coverUpdatedOn;
     private Instant audiobookCoverUpdatedOn;
     private Set<String> authors;
-    @Singular
     private Set<String> categories;
     private Set<String> moods;
     private Set<String> tags;

--- a/booklore-api/src/main/java/org/booklore/service/book/BookCreatorService.java
+++ b/booklore-api/src/main/java/org/booklore/service/book/BookCreatorService.java
@@ -126,6 +126,7 @@ public class BookCreatorService {
     }
 
     public void addCategoriesToBook(Set<String> categories, BookEntity bookEntity) {
+        if (categories == null || categories.isEmpty()) return;
         if (bookEntity.getMetadata().getCategories() == null) {
             bookEntity.getMetadata().setCategories(new HashSet<>());
         }
@@ -137,6 +138,7 @@ public class BookCreatorService {
     }
 
     public void addAuthorsToBook(Set<String> authors, BookEntity bookEntity) {
+        if (authors == null || authors.isEmpty()) return;
         if (bookEntity.getMetadata().getAuthors() == null) {
             bookEntity.getMetadata().setAuthors(new HashSet<>());
         }
@@ -149,6 +151,7 @@ public class BookCreatorService {
     }
 
     public void addMoodsToBook(Set<String> moods, BookEntity bookEntity) {
+        if (moods == null || moods.isEmpty()) return;
         if (bookEntity.getMetadata().getMoods() == null) {
             bookEntity.getMetadata().setMoods(new HashSet<>());
         }
@@ -160,6 +163,7 @@ public class BookCreatorService {
     }
 
     public void addTagsToBook(Set<String> tags, BookEntity bookEntity) {
+        if (tags == null || tags.isEmpty()) return;
         if (bookEntity.getMetadata().getTags() == null) {
             bookEntity.getMetadata().setTags(new HashSet<>());
         }

--- a/booklore-api/src/test/java/org/booklore/model/dto/BookMetadataBuilderTest.java
+++ b/booklore-api/src/test/java/org/booklore/model/dto/BookMetadataBuilderTest.java
@@ -1,0 +1,97 @@
+package org.booklore.model.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BookMetadataBuilderTest {
+
+    @Test
+    void builder_withoutCategories_buildsWithNullCategories() {
+        BookMetadata metadata = BookMetadata.builder()
+                .title("Test Book")
+                .build();
+
+        assertNull(metadata.getCategories());
+    }
+
+    @Test
+    void builder_withNullCategories_doesNotThrow() {
+        BookMetadata metadata = BookMetadata.builder()
+                .title("Test Book")
+                .categories(null)
+                .build();
+
+        assertNull(metadata.getCategories());
+    }
+
+    @Test
+    void builder_withValidCategories_setsCategories() {
+        Set<String> categories = Set.of("Fiction", "Thriller");
+
+        BookMetadata metadata = BookMetadata.builder()
+                .categories(categories)
+                .build();
+
+        assertEquals(categories, metadata.getCategories());
+    }
+
+    @Test
+    void builder_withNullAuthors_doesNotThrow() {
+        BookMetadata metadata = BookMetadata.builder()
+                .authors(null)
+                .build();
+
+        assertNull(metadata.getAuthors());
+    }
+
+    @Test
+    void builder_withNullMoods_doesNotThrow() {
+        BookMetadata metadata = BookMetadata.builder()
+                .moods(null)
+                .build();
+
+        assertNull(metadata.getMoods());
+    }
+
+    @Test
+    void builder_withNullTags_doesNotThrow() {
+        BookMetadata metadata = BookMetadata.builder()
+                .tags(null)
+                .build();
+
+        assertNull(metadata.getTags());
+    }
+
+    @Test
+    void builder_allCollectionsNull_buildsSuccessfully() {
+        BookMetadata metadata = BookMetadata.builder()
+                .title("Title Only Book")
+                .authors(null)
+                .categories(null)
+                .moods(null)
+                .tags(null)
+                .build();
+
+        assertEquals("Title Only Book", metadata.getTitle());
+        assertNull(metadata.getAuthors());
+        assertNull(metadata.getCategories());
+        assertNull(metadata.getMoods());
+        assertNull(metadata.getTags());
+    }
+
+    @Test
+    void builder_minimalMetadata_simulatesPhysicalBookCreation() {
+        BookMetadata metadata = BookMetadata.builder()
+                .title("My Physical Book")
+                .build();
+
+        assertNotNull(metadata);
+        assertEquals("My Physical Book", metadata.getTitle());
+        assertNull(metadata.getAuthors());
+        assertNull(metadata.getCategories());
+        assertNull(metadata.getDescription());
+    }
+}

--- a/booklore-api/src/test/java/org/booklore/service/book/BookCreatorServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/book/BookCreatorServiceTest.java
@@ -1,0 +1,197 @@
+package org.booklore.service.book;
+
+import org.booklore.model.entity.AuthorEntity;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookMetadataEntity;
+import org.booklore.model.entity.CategoryEntity;
+import org.booklore.model.entity.MoodEntity;
+import org.booklore.model.entity.TagEntity;
+import org.booklore.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BookCreatorServiceTest {
+
+    @Mock private AuthorRepository authorRepository;
+    @Mock private CategoryRepository categoryRepository;
+    @Mock private MoodRepository moodRepository;
+    @Mock private TagRepository tagRepository;
+    @Mock private BookRepository bookRepository;
+    @Mock private BookMetadataRepository bookMetadataRepository;
+    @Mock private ComicMetadataRepository comicMetadataRepository;
+    @Mock private ComicCharacterRepository comicCharacterRepository;
+    @Mock private ComicTeamRepository comicTeamRepository;
+    @Mock private ComicLocationRepository comicLocationRepository;
+    @Mock private ComicCreatorRepository comicCreatorRepository;
+
+    @InjectMocks
+    private BookCreatorService bookCreatorService;
+
+    private BookEntity bookEntity;
+
+    @BeforeEach
+    void setUp() {
+        BookMetadataEntity metadata = new BookMetadataEntity();
+        bookEntity = BookEntity.builder().metadata(metadata).build();
+    }
+
+    @Test
+    void addAuthorsToBook_nullAuthors_doesNothing() {
+        bookCreatorService.addAuthorsToBook(null, bookEntity);
+
+        assertNull(bookEntity.getMetadata().getAuthors());
+        verifyNoInteractions(authorRepository);
+    }
+
+    @Test
+    void addAuthorsToBook_emptyAuthors_doesNothing() {
+        bookCreatorService.addAuthorsToBook(Set.of(), bookEntity);
+
+        assertNull(bookEntity.getMetadata().getAuthors());
+        verifyNoInteractions(authorRepository);
+    }
+
+    @Test
+    void addAuthorsToBook_validAuthors_addsToBook() {
+        AuthorEntity author = AuthorEntity.builder().name("Test Author").build();
+        when(authorRepository.findByName("Test Author")).thenReturn(Optional.of(author));
+
+        bookCreatorService.addAuthorsToBook(Set.of("Test Author"), bookEntity);
+
+        assertNotNull(bookEntity.getMetadata().getAuthors());
+        assertEquals(1, bookEntity.getMetadata().getAuthors().size());
+    }
+
+    @Test
+    void addAuthorsToBook_nullExistingAuthorsOnEntity_initializesSet() {
+        assertNull(bookEntity.getMetadata().getAuthors());
+
+        AuthorEntity author = AuthorEntity.builder().name("Author").build();
+        when(authorRepository.findByName("Author")).thenReturn(Optional.of(author));
+
+        bookCreatorService.addAuthorsToBook(Set.of("Author"), bookEntity);
+
+        assertNotNull(bookEntity.getMetadata().getAuthors());
+        assertTrue(bookEntity.getMetadata().getAuthors().contains(author));
+    }
+
+    @Test
+    void addCategoriesToBook_nullCategories_doesNothing() {
+        bookCreatorService.addCategoriesToBook(null, bookEntity);
+
+        assertNull(bookEntity.getMetadata().getCategories());
+        verifyNoInteractions(categoryRepository);
+    }
+
+    @Test
+    void addCategoriesToBook_emptyCategories_doesNothing() {
+        bookCreatorService.addCategoriesToBook(Set.of(), bookEntity);
+
+        assertNull(bookEntity.getMetadata().getCategories());
+        verifyNoInteractions(categoryRepository);
+    }
+
+    @Test
+    void addCategoriesToBook_validCategories_addsToBook() {
+        CategoryEntity category = CategoryEntity.builder().name("Fiction").build();
+        when(categoryRepository.findByName("Fiction")).thenReturn(Optional.of(category));
+
+        bookCreatorService.addCategoriesToBook(Set.of("Fiction"), bookEntity);
+
+        assertNotNull(bookEntity.getMetadata().getCategories());
+        assertEquals(1, bookEntity.getMetadata().getCategories().size());
+    }
+
+    @Test
+    void addMoodsToBook_nullMoods_doesNothing() {
+        bookCreatorService.addMoodsToBook(null, bookEntity);
+
+        assertNull(bookEntity.getMetadata().getMoods());
+        verifyNoInteractions(moodRepository);
+    }
+
+    @Test
+    void addMoodsToBook_emptyMoods_doesNothing() {
+        bookCreatorService.addMoodsToBook(Set.of(), bookEntity);
+
+        assertNull(bookEntity.getMetadata().getMoods());
+        verifyNoInteractions(moodRepository);
+    }
+
+    @Test
+    void addMoodsToBook_validMoods_addsToBook() {
+        MoodEntity mood = MoodEntity.builder().name("Dark").build();
+        when(moodRepository.findByName("Dark")).thenReturn(Optional.of(mood));
+
+        bookCreatorService.addMoodsToBook(Set.of("Dark"), bookEntity);
+
+        assertNotNull(bookEntity.getMetadata().getMoods());
+        assertEquals(1, bookEntity.getMetadata().getMoods().size());
+    }
+
+    @Test
+    void addTagsToBook_nullTags_doesNothing() {
+        bookCreatorService.addTagsToBook(null, bookEntity);
+
+        assertNull(bookEntity.getMetadata().getTags());
+        verifyNoInteractions(tagRepository);
+    }
+
+    @Test
+    void addTagsToBook_emptyTags_doesNothing() {
+        bookCreatorService.addTagsToBook(Set.of(), bookEntity);
+
+        assertNull(bookEntity.getMetadata().getTags());
+        verifyNoInteractions(tagRepository);
+    }
+
+    @Test
+    void addTagsToBook_validTags_addsToBook() {
+        TagEntity tag = TagEntity.builder().name("favorite").build();
+        when(tagRepository.findByName("favorite")).thenReturn(Optional.of(tag));
+
+        bookCreatorService.addTagsToBook(Set.of("favorite"), bookEntity);
+
+        assertNotNull(bookEntity.getMetadata().getTags());
+        assertEquals(1, bookEntity.getMetadata().getTags().size());
+    }
+
+    @Test
+    void addAuthorsToBook_existingAuthorsOnEntity_appendsWithoutOverwriting() {
+        AuthorEntity existingAuthor = AuthorEntity.builder().name("Existing").build();
+        bookEntity.getMetadata().setAuthors(new HashSet<>(Set.of(existingAuthor)));
+
+        AuthorEntity newAuthor = AuthorEntity.builder().name("New Author").build();
+        when(authorRepository.findByName("New Author")).thenReturn(Optional.of(newAuthor));
+
+        bookCreatorService.addAuthorsToBook(Set.of("New Author"), bookEntity);
+
+        assertEquals(2, bookEntity.getMetadata().getAuthors().size());
+    }
+
+    @Test
+    void addAuthorsToBook_newAuthorNotInRepo_savesAndAdds() {
+        AuthorEntity saved = AuthorEntity.builder().name("Brand New").build();
+        when(authorRepository.findByName("Brand New")).thenReturn(Optional.empty());
+        when(authorRepository.save(any())).thenReturn(saved);
+
+        bookCreatorService.addAuthorsToBook(Set.of("Brand New"), bookEntity);
+
+        verify(authorRepository).save(any());
+        assertEquals(1, bookEntity.getMetadata().getAuthors().size());
+    }
+}


### PR DESCRIPTION
Files without metadata (like bare PDFs and MP3s with empty tags) were throwing null errors during library scanning because the `@Singular` annotation on `BookMetadata.categories` rejects null input, and `BookCreatorService.addAuthorsToBook()` didn't guard against null authors. Removed the inconsistent `@Singular` annotation (the other collection fields never had it) and added null/empty guards to all four `add*ToBook` methods. Also added unit tests covering these null paths.