### PR TITLE
Fix reading stats queries not accounting for timezone

### DIFF
--- a/booklore-api/src/main/java/org/booklore/repository/ReadingSessionRepository.java
+++ b/booklore-api/src/main/java/org/booklore/repository/ReadingSessionRepository.java
@@ -18,29 +18,35 @@ import java.util.List;
 @Repository
 public interface ReadingSessionRepository extends JpaRepository<ReadingSessionEntity, Long> {
 
-    @Query("""
-            SELECT CAST(rs.startTime AS LocalDate) as date, COUNT(rs) as count
-            FROM ReadingSessionEntity rs
-            WHERE rs.user.id = :userId
-            AND YEAR(rs.startTime) = :year
-            GROUP BY CAST(rs.startTime AS LocalDate)
+    @Query(value = """
+            SELECT DATE(CONVERT_TZ(start_time, '+00:00', :tzOffset)) as date,
+                   COUNT(*) as count
+            FROM reading_sessions
+            WHERE user_id = :userId
+            AND YEAR(CONVERT_TZ(start_time, '+00:00', :tzOffset)) = :year
+            GROUP BY DATE(CONVERT_TZ(start_time, '+00:00', :tzOffset))
             ORDER BY date
-            """)
-    List<ReadingSessionCountDto> findSessionCountsByUserAndYear(@Param("userId") Long userId, @Param("year") int year);
+            """, nativeQuery = true)
+    List<ReadingSessionCountDto> findSessionCountsByUserAndYear(
+            @Param("userId") Long userId,
+            @Param("year") int year,
+            @Param("tzOffset") String tzOffset);
 
-    @Query("""
-            SELECT CAST(rs.startTime AS LocalDate) as date, COUNT(rs) as count
-            FROM ReadingSessionEntity rs
-            WHERE rs.user.id = :userId
-            AND YEAR(rs.startTime) = :year
-            AND MONTH(rs.startTime) = :month
-            GROUP BY CAST(rs.startTime AS LocalDate)
+    @Query(value = """
+            SELECT DATE(CONVERT_TZ(start_time, '+00:00', :tzOffset)) as date,
+                   COUNT(*) as count
+            FROM reading_sessions
+            WHERE user_id = :userId
+            AND YEAR(CONVERT_TZ(start_time, '+00:00', :tzOffset)) = :year
+            AND MONTH(CONVERT_TZ(start_time, '+00:00', :tzOffset)) = :month
+            GROUP BY DATE(CONVERT_TZ(start_time, '+00:00', :tzOffset))
             ORDER BY date
-            """)
+            """, nativeQuery = true)
     List<ReadingSessionCountDto> findSessionCountsByUserAndYearAndMonth(
             @Param("userId") Long userId,
             @Param("year") int year,
-            @Param("month") int month);
+            @Param("month") int month,
+            @Param("tzOffset") String tzOffset);
 
         @Query("""
                         SELECT
@@ -79,39 +85,41 @@ public interface ReadingSessionRepository extends JpaRepository<ReadingSessionEn
             """)
     List<ReadingSpeedDto> findReadingSpeedByUserAndYear(@Param("userId") Long userId, @Param("year") int year);
 
-    @Query("""
+    @Query(value = """
             SELECT
-                HOUR(rs.startTime) as hourOfDay,
-                COUNT(rs) as sessionCount,
-                SUM(rs.durationSeconds) as totalDurationSeconds
-            FROM ReadingSessionEntity rs
-            WHERE rs.user.id = :userId
-            AND (:year IS NULL OR YEAR(rs.startTime) = :year)
-            AND (:month IS NULL OR MONTH(rs.startTime) = :month)
-            GROUP BY HOUR(rs.startTime)
+                HOUR(CONVERT_TZ(start_time, '+00:00', :tzOffset)) as hourOfDay,
+                COUNT(*) as sessionCount,
+                SUM(duration_seconds) as totalDurationSeconds
+            FROM reading_sessions
+            WHERE user_id = :userId
+            AND (:year IS NULL OR YEAR(CONVERT_TZ(start_time, '+00:00', :tzOffset)) = :year)
+            AND (:month IS NULL OR MONTH(CONVERT_TZ(start_time, '+00:00', :tzOffset)) = :month)
+            GROUP BY HOUR(CONVERT_TZ(start_time, '+00:00', :tzOffset))
             ORDER BY hourOfDay
-            """)
+            """, nativeQuery = true)
     List<PeakReadingHourDto> findPeakReadingHoursByUser(
             @Param("userId") Long userId,
             @Param("year") Integer year,
-            @Param("month") Integer month);
+            @Param("month") Integer month,
+            @Param("tzOffset") String tzOffset);
 
-    @Query("""
+    @Query(value = """
             SELECT
-                DAYOFWEEK(rs.startTime) as dayOfWeek,
-                COUNT(rs) as sessionCount,
-                COALESCE(SUM(rs.durationSeconds), 0) as totalDurationSeconds
-            FROM ReadingSessionEntity rs
-            WHERE rs.user.id = :userId
-            AND (:year IS NULL OR YEAR(rs.startTime) = :year)
-            AND (:month IS NULL OR MONTH(rs.startTime) = :month)
-            GROUP BY DAYOFWEEK(rs.startTime)
+                DAYOFWEEK(CONVERT_TZ(start_time, '+00:00', :tzOffset)) as dayOfWeek,
+                COUNT(*) as sessionCount,
+                COALESCE(SUM(duration_seconds), 0) as totalDurationSeconds
+            FROM reading_sessions
+            WHERE user_id = :userId
+            AND (:year IS NULL OR YEAR(CONVERT_TZ(start_time, '+00:00', :tzOffset)) = :year)
+            AND (:month IS NULL OR MONTH(CONVERT_TZ(start_time, '+00:00', :tzOffset)) = :month)
+            GROUP BY DAYOFWEEK(CONVERT_TZ(start_time, '+00:00', :tzOffset))
             ORDER BY dayOfWeek
-            """)
+            """, nativeQuery = true)
     List<FavoriteReadingDayDto> findFavoriteReadingDaysByUser(
             @Param("userId") Long userId,
             @Param("year") Integer year,
-            @Param("month") Integer month);
+            @Param("month") Integer month,
+            @Param("tzOffset") String tzOffset);
 
     @Query("""
             SELECT
@@ -179,12 +187,15 @@ public interface ReadingSessionRepository extends JpaRepository<ReadingSessionEn
             @Param("userId") Long userId,
             @Param("year") int year);
 
-    @Query("""
-            SELECT CAST(rs.startTime AS LocalDate) as date, COUNT(rs) as count
-            FROM ReadingSessionEntity rs
-            WHERE rs.user.id = :userId
-            GROUP BY CAST(rs.startTime AS LocalDate)
+    @Query(value = """
+            SELECT DATE(CONVERT_TZ(start_time, '+00:00', :tzOffset)) as date,
+                   COUNT(*) as count
+            FROM reading_sessions
+            WHERE user_id = :userId
+            GROUP BY DATE(CONVERT_TZ(start_time, '+00:00', :tzOffset))
             ORDER BY date
-            """)
-    List<ReadingSessionCountDto> findAllSessionCountsByUser(@Param("userId") Long userId);
+            """, nativeQuery = true)
+    List<ReadingSessionCountDto> findAllSessionCountsByUser(
+            @Param("userId") Long userId,
+            @Param("tzOffset") String tzOffset);
 }

--- a/booklore-api/src/main/java/org/booklore/service/ReadingSessionService.java
+++ b/booklore-api/src/main/java/org/booklore/service/ReadingSessionService.java
@@ -41,6 +41,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.WeekFields;
@@ -57,6 +58,11 @@ public class ReadingSessionService {
     private final BookRepository bookRepository;
     private final UserRepository userRepository;
     private final UserBookProgressRepository userBookProgressRepository;
+
+    private String getTimezoneOffset() {
+        ZoneOffset offset = ZoneId.systemDefault().getRules().getOffset(Instant.now());
+        return offset.getId().equals("Z") ? "+00:00" : offset.getId();
+    }
 
     @Transactional
     public void recordSession(ReadingSessionRequest request) {
@@ -91,7 +97,7 @@ public class ReadingSessionService {
         BookLoreUser authenticatedUser = authenticationService.getAuthenticatedUser();
         Long userId = authenticatedUser.getId();
 
-        return readingSessionRepository.findSessionCountsByUserAndYear(userId, year)
+        return readingSessionRepository.findSessionCountsByUserAndYear(userId, year, getTimezoneOffset())
                 .stream()
                 .map(dto -> ReadingSessionHeatmapResponse.builder()
                         .date(dto.getDate())
@@ -105,7 +111,7 @@ public class ReadingSessionService {
         BookLoreUser authenticatedUser = authenticationService.getAuthenticatedUser();
         Long userId = authenticatedUser.getId();
 
-        return readingSessionRepository.findSessionCountsByUserAndYearAndMonth(userId, year, month)
+        return readingSessionRepository.findSessionCountsByUserAndYearAndMonth(userId, year, month, getTimezoneOffset())
                 .stream()
                 .map(dto -> ReadingSessionHeatmapResponse.builder()
                         .date(dto.getDate())
@@ -158,7 +164,7 @@ public class ReadingSessionService {
         BookLoreUser authenticatedUser = authenticationService.getAuthenticatedUser();
         Long userId = authenticatedUser.getId();
 
-        return readingSessionRepository.findPeakReadingHoursByUser(userId, year, month)
+        return readingSessionRepository.findPeakReadingHoursByUser(userId, year, month, getTimezoneOffset())
                 .stream()
                 .map(dto -> PeakReadingHoursResponse.builder()
                         .hourOfDay(dto.getHourOfDay())
@@ -175,7 +181,7 @@ public class ReadingSessionService {
 
         String[] dayNames = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
 
-        return readingSessionRepository.findFavoriteReadingDaysByUser(userId, year, month)
+        return readingSessionRepository.findFavoriteReadingDaysByUser(userId, year, month, getTimezoneOffset())
                 .stream()
                 .map(dto -> FavoriteReadingDaysResponse.builder()
                         .dayOfWeek(dto.getDayOfWeek())
@@ -414,7 +420,7 @@ public class ReadingSessionService {
         BookLoreUser authenticatedUser = authenticationService.getAuthenticatedUser();
         Long userId = authenticatedUser.getId();
 
-        return readingSessionRepository.findAllSessionCountsByUser(userId)
+        return readingSessionRepository.findAllSessionCountsByUser(userId, getTimezoneOffset())
                 .stream()
                 .map(dto -> ReadingSessionHeatmapResponse.builder()
                         .date(dto.getDate())


### PR DESCRIPTION
Fixes #2842

Hibernate stores Instant values as UTC in DATETIME columns, but the reading stats queries were extracting time components (HOUR, DAYOFWEEK, DATE) directly from these UTC values. Switched the affected queries to native SQL with CONVERT_TZ to convert from UTC to the server's local timezone before grouping. This fixes peak reading hours, favorite reading days, and the session heatmaps for users whose TZ is set in their Docker config.