### PR TITLE
Redesign series page layout and book list tab

### DIFF
--- a/booklore-ui/src/app/features/book/components/series-page/series-page.component.html
+++ b/booklore-ui/src/app/features/book/components/series-page/series-page.component.html
@@ -274,31 +274,77 @@
       <!-- BOOK LIST TAB -->
       <p-tabpanel value="list">
         <div class="book-list-container">
-          @for (book of books; track book.id) {
-            <div class="book-list-row" (click)="readBook(book.id)">
-              <span class="list-series-number">
-                {{ book.metadata?.seriesNumber != null ? '#' + book.metadata?.seriesNumber : '-' }}
-              </span>
+          @for (book of books; track book.id; let i = $index) {
+            <div class="book-list-card">
+              <div class="list-number-col">
+                <span class="list-series-number">
+                  {{ book.metadata?.seriesNumber != null ? '#' + book.metadata?.seriesNumber : '-' }}
+                </span>
+              </div>
               <img [src]="getBookThumbnailUrl(book)"
                 [alt]="book.metadata?.title || ''"
                 class="list-thumb"
                 loading="lazy"/>
               <div class="list-book-info">
                 <span class="list-book-title">{{ book.metadata?.title || '' }}</span>
-                @if (book.metadata?.publishedDate; as date) {
-                  <span class="list-book-year">{{ date }}</span>
+                <div class="list-book-meta">
+                  @if (book.metadata?.authors?.length) {
+                    <span class="list-book-authors">{{ book.metadata!.authors!.join(', ') }}</span>
+                  }
+                  @if (book.metadata?.publishedDate; as date) {
+                    <span class="list-meta-dot">·</span>
+                    <span class="list-book-year">{{ date }}</span>
+                  }
+                  @if (book.metadata?.pageCount; as pages) {
+                    <span class="list-meta-dot">·</span>
+                    <span class="list-book-pages">{{ pages }} {{ t('listPages') }}</span>
+                  }
+                </div>
+                @if (getBookProgress(book); as progress) {
+                  <div class="list-progress-row">
+                    <div class="list-progress-bar">
+                      <div class="list-progress-fill" [ngStyle]="{'width': progress + '%'}"></div>
+                    </div>
+                    <span class="list-progress-text">{{ progress }}%</span>
+                  </div>
+                }
+                @if (book.personalRating) {
+                  <div class="list-rating-row">
+                    @for (star of [1,2,3,4,5]; track star) {
+                      <i class="pi list-star"
+                        [ngClass]="book.personalRating! >= star * 2 ? 'pi-star-fill' : (book.personalRating! >= star * 2 - 1 ? 'pi-star-half-fill' : 'pi-star')">
+                      </i>
+                    }
+                    <span class="list-rating-value">{{ book.personalRating }}/10</span>
+                  </div>
                 }
               </div>
-              @if (book.metadata?.pageCount; as pages) {
-                <span class="list-pages">{{ pages }} {{ t('listPages') }}</span>
-              }
-              <span class="list-status-badge"
-                [ngStyle]="{'background-color': getStatusColor(book.readStatus)}">
-                {{ getStatusLabel(book.readStatus) }}
-              </span>
-              @if (book.primaryFile?.bookType; as bookType) {
-                <p-tag [value]="bookType" class="list-format-tag" severity="secondary"></p-tag>
-              }
+              <div class="list-right-col">
+                <div class="list-badges">
+                  <span class="list-status-badge"
+                    [ngStyle]="{'background-color': getStatusColor(book.readStatus)}">
+                    {{ getStatusLabel(book.readStatus) }}
+                  </span>
+                  @if (book.primaryFile?.bookType; as bookType) {
+                    <span class="list-format-badge"
+                      [style.background-color]="'color-mix(in srgb, var(--book-type-' + bookType.toLowerCase() + '-color) 20%, transparent)'"
+                      [style.border-color]="'var(--book-type-' + bookType.toLowerCase() + '-color)'"
+                      [style.color]="'var(--book-type-' + bookType.toLowerCase() + '-color)'">
+                      {{ bookType }}
+                    </span>
+                  }
+                </div>
+                <div class="list-actions">
+                  <button class="list-action-btn btn-read" (click)="readBook(book.id); $event.stopPropagation()"
+                    [pTooltip]="t('readButton')" tooltipPosition="top">
+                    <i class="pi pi-book"></i>
+                  </button>
+                  <button class="list-action-btn btn-details" (click)="viewBookDetails(book.id); $event.stopPropagation()"
+                    [pTooltip]="t('viewDetails')" tooltipPosition="top">
+                    <i class="pi pi-info-circle"></i>
+                  </button>
+                </div>
+              </div>
             </div>
           }
           @if (books.length === 0) {

--- a/booklore-ui/src/app/features/book/components/series-page/series-page.component.scss
+++ b/booklore-ui/src/app/features/book/components/series-page/series-page.component.scss
@@ -559,19 +559,25 @@
 .book-list-container {
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
 }
 
-.book-list-row {
+.book-list-card {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
+  gap: 0.85rem;
+  padding: 0.65rem 0.85rem;
   cursor: pointer;
-  transition: background 0.15s ease;
-  border-bottom: 1px solid color-mix(in srgb, var(--border-color), transparent 70%);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--p-surface-700), transparent 65%);
+  border: 1px solid color-mix(in srgb, var(--border-color), transparent 60%);
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 
   &:hover {
-    background: color-mix(in srgb, var(--p-surface-700), transparent 60%);
+    background: color-mix(in srgb, var(--p-surface-700), transparent 40%);
+    border-color: var(--border-color);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   }
 
   @media (max-width: 768px) {
@@ -580,70 +586,207 @@
   }
 }
 
+.list-number-col {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.375rem;
+  background: color-mix(in srgb, var(--primary-color), transparent 85%);
+}
+
 .list-series-number {
   font-weight: 700;
-  font-size: 0.875rem;
-  color: var(--text-secondary-color);
-  min-width: 2rem;
-  text-align: center;
-  flex-shrink: 0;
+  font-size: 0.8rem;
+  color: var(--primary-color);
 }
 
 .list-thumb {
-  width: 2.25rem;
-  height: 3.25rem;
+  width: 2.75rem;
+  height: 4rem;
   object-fit: cover;
-  border-radius: 0.25rem;
+  border-radius: 0.375rem;
   flex-shrink: 0;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
 
 .list-book-info {
   display: flex;
   flex-direction: column;
+  gap: 0.2rem;
   min-width: 0;
   flex: 1;
 }
 
 .list-book-title {
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: 0.95rem;
+  color: var(--text-color);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.list-book-year {
-  font-size: 0.75rem;
-  color: var(--text-secondary-color);
+.list-book-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-color-secondary);
+  flex-wrap: wrap;
 }
 
-.list-pages {
-  font-size: 0.8rem;
-  color: var(--text-secondary-color);
+.list-meta-dot {
+  color: var(--text-color-secondary);
+  opacity: 0.5;
+}
+
+.list-book-authors {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 16rem;
+}
+
+.list-book-year,
+.list-book-pages {
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.list-right-col {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-shrink: 0;
+}
+
+.list-badges {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.list-status-badge {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: white;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+}
+
+.list-format-badge {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  border: 1px solid;
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 
   @media (max-width: 768px) {
     display: none;
   }
 }
 
-.list-status-badge {
-  display: inline-block;
-  padding: 0.2rem 0.5rem;
-  border-radius: 9999px;
-  font-size: 0.65rem;
-  font-weight: 700;
-  color: white;
-  white-space: nowrap;
-  flex-shrink: 0;
+// ── List: progress bar ──
+
+.list-progress-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.15rem;
 }
 
-.list-format-tag {
-  flex-shrink: 0;
+.list-progress-bar {
+  width: 5rem;
+  height: 0.25rem;
+  border-radius: 0.25rem;
+  background: color-mix(in srgb, var(--p-surface-600), transparent 50%);
+  overflow: hidden;
+}
 
-  @media (max-width: 768px) {
-    display: none;
+.list-progress-fill {
+  height: 100%;
+  border-radius: 0.25rem;
+  background: var(--primary-color);
+  transition: width 0.3s ease;
+}
+
+.list-progress-text {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--text-color-secondary);
+}
+
+// ── List: rating stars ──
+
+.list-rating-row {
+  display: flex;
+  align-items: center;
+  gap: 0.1rem;
+  margin-top: 0.1rem;
+}
+
+.list-star {
+  font-size: 0.65rem;
+  color: #facc15;
+}
+
+.list-rating-value {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--text-color-secondary);
+  margin-left: 0.25rem;
+}
+
+// ── List: action buttons ──
+
+.list-actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.list-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 0.4rem;
+  border: 1px solid;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  i {
+    font-size: 0.85rem;
+  }
+
+  &.btn-read {
+    background: color-mix(in srgb, #10b981, transparent 85%);
+    border-color: color-mix(in srgb, #10b981, transparent 55%);
+    color: #6ee7b7;
+
+    &:hover {
+      background: color-mix(in srgb, #10b981, transparent 65%);
+    }
+  }
+
+  &.btn-details {
+    background: color-mix(in srgb, #3b82f6, transparent 85%);
+    border-color: color-mix(in srgb, #3b82f6, transparent 55%);
+    color: #93c5fd;
+
+    &:hover {
+      background: color-mix(in srgb, #3b82f6, transparent 65%);
+    }
   }
 }
 

--- a/booklore-ui/src/app/features/book/components/series-page/series-page.component.ts
+++ b/booklore-ui/src/app/features/book/components/series-page/series-page.component.ts
@@ -549,6 +549,24 @@ export class SeriesPageComponent implements OnDestroy, AfterViewChecked {
     this.bookService.readBook(bookId);
   }
 
+  viewBookDetails(bookId: number): void {
+    this.router.navigate(['/book', bookId], {
+      queryParams: {tab: 'view'}
+    });
+  }
+
+  getBookProgress(book: Book): number | null {
+    const progress = book.epubProgress?.percentage
+      ?? book.pdfProgress?.percentage
+      ?? book.cbxProgress?.percentage
+      ?? book.audiobookProgress?.percentage
+      ?? book.koreaderProgress?.percentage
+      ?? book.koboProgress?.percentage;
+    if (progress == null || progress <= 0) return null;
+    const pct = progress > 1 ? progress : Math.round(progress * 100);
+    return Math.min(Math.round(pct), 100);
+  }
+
   formatDuration(totalSeconds: number): string {
     if (!totalSeconds || !isFinite(totalSeconds)) return '0:00';
     const h = Math.floor(totalSeconds / 3600);

--- a/booklore-ui/src/i18n/en/book.json
+++ b/booklore-ui/src/i18n/en/book.json
@@ -760,6 +760,7 @@
     "nextUp": "Next Up",
     "continueReading": "Continue Reading",
     "readButton": "Read",
+    "viewDetails": "View Details",
     "continueButton": "Continue",
     "readPercent": "{{ progress }} read",
     "listPages": "pages",

--- a/booklore-ui/src/i18n/es/book.json
+++ b/booklore-ui/src/i18n/es/book.json
@@ -760,6 +760,7 @@
     "nextUp": "Siguiente",
     "continueReading": "Continuar leyendo",
     "readButton": "Leer",
+    "viewDetails": "Ver detalles",
     "continueButton": "Continuar",
     "readPercent": "{{ progress }} leídos",
     "listPages": "páginas",


### PR DESCRIPTION
Overhaul of the series detail page. The hero section now uses a single large cover instead of the stacked fan, with colorful metadata cards, genre tags matching the metadata-viewer style, and the synopsis section styled as a collapsible card. Next Up and reading progress sit at the bottom of the hero aligned with the cover.

The book list tab got a full rework too: card-based rows with series number badges, author/date/pages metadata, reading progress bars, star ratings, colorful format badges using the global book-type color variables, and dedicated Read/Details action buttons.