### PR TITLE
Fix reading session timeline long sessions, tooltip perf, and week mismatch

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/ReadingSessionService.java
+++ b/booklore-api/src/main/java/org/booklore/service/ReadingSessionService.java
@@ -126,7 +126,7 @@ public class ReadingSessionService {
         Long userId = authenticatedUser.getId();
 
         LocalDate date = LocalDate.of(year, 1, 1)
-                .with(WeekFields.of(DayOfWeek.MONDAY, 1).weekOfYear(), week);
+                .with(WeekFields.ISO.weekOfYear(), week);
         LocalDateTime startOfWeek = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).atStartOfDay();
         LocalDateTime endOfWeek = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)).plusDays(1).atStartOfDay();
 

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.html
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.html
@@ -84,7 +84,7 @@
                      [style.width.%]="session.width"
                      [style.top]="session.totalLevels > 1 ? 'calc(' + session.level + ' / ' + session.totalLevels + ' * 100% + ' + session.level * 2 + 'px)' : '0'"
                      [style.height]="session.totalLevels > 1 ? 'calc((1 / ' + session.totalLevels + ' * 100%) - ' + (session.totalLevels - 1) * 2 / session.totalLevels + 'px)' : '100%'"
-                     [pTooltip]="getTooltipContent(session)"
+                     [pTooltip]="session.tooltipContent"
                      [escape]="false"
                      tooltipPosition="top"
                      tooltipStyleClass="session-timeline-tooltip"

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.ts
@@ -42,6 +42,7 @@ interface TimelineSession {
   bookType: BookType;
   level: number;
   totalLevels: number;
+  tooltipContent: string;
 }
 
 interface DayTimeline {
@@ -319,7 +320,7 @@ export class ReadingSessionTimelineComponent implements OnInit {
       width = 0.5;
     }
 
-    return {
+    const timelineSession: TimelineSession = {
       startHour,
       startMinute,
       endHour,
@@ -331,8 +332,11 @@ export class ReadingSessionTimelineComponent implements OnInit {
       bookId: session.bookId,
       bookType: session.bookType,
       level,
-      totalLevels
+      totalLevels,
+      tooltipContent: ''
     };
+    timelineSession.tooltipContent = this.buildTooltipContent(timelineSession);
+    return timelineSession;
   }
 
   public formatTime(hour: number, minute: number): string {
@@ -375,7 +379,7 @@ export class ReadingSessionTimelineComponent implements OnInit {
     return this.urlHelperService.getDirectThumbnailUrl(bookId);
   }
 
-  public getTooltipContent(session: TimelineSession): string {
+  private buildTooltipContent(session: TimelineSession): string {
     return `
       <div class="session-tooltip-content">
         <div class="session-tooltip-cover">


### PR DESCRIPTION
The reading session tracker wasn't ending sessions when a browser tab stayed hidden past the idle timeout, so you'd get these 20+ hour sessions in the DB from people leaving tabs open overnight. Now if the tab is hidden longer than the idle threshold, the session gets capped and closed. Also covers the case where someone closes the tab directly without ever making it visible again.

Precomputed the tooltip HTML for the timeline chart instead of regenerating it on every change detection cycle. Weeks with hundreds of sessions were getting sluggish because of all those pTooltip function calls.

Also fixed an ISO week numbering mismatch between frontend (date-fns getISOWeek, minimalDaysInFirstWeek=4) and backend (WeekFields with minimalDaysInFirstWeek=1). At year boundaries the backend could return sessions from a different week than what the frontend was displaying.