### PR TITLE
Fix multiple author card menus opening simultaneously

### DIFF
--- a/booklore-ui/src/app/features/author-browser/components/author-card/author-card.component.ts
+++ b/booklore-ui/src/app/features/author-browser/components/author-card/author-card.component.ts
@@ -71,6 +71,10 @@ export class AuthorCardComponent implements OnChanges {
   }
 
   onCardClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement;
+    if (target.closest('.menu-button-container')) {
+      return;
+    }
     if (event.ctrlKey || event.metaKey) {
       event.preventDefault();
       event.stopPropagation();
@@ -103,7 +107,6 @@ export class AuthorCardComponent implements OnChanges {
   }
 
   onMenuToggle(event: Event, menu: TieredMenu): void {
-    event.stopPropagation();
     if (!this.menuInitialized) {
       this.menuInitialized = true;
       this.initMenu();


### PR DESCRIPTION
The author card's menu toggle was calling stopPropagation, which prevented PrimeNG's document-level click listener from dismissing other open menus. Removed that and instead skip the card navigation when the click originates from the menu button area.