### PR TITLE
Fix ebook reader header not hiding on mobile tap

### DIFF
--- a/booklore-ui/src/app/features/readers/ebook-reader/shared/visibility.util.ts
+++ b/booklore-ui/src/app/features/readers/ebook-reader/shared/visibility.util.ts
@@ -5,7 +5,7 @@ export interface HeaderFooterVisibilityState {
 
 export class ReaderHeaderFooterVisibilityManager {
   private isPinned = false;
-  private mouseY = 0;
+  private mouseY: number;
 
   private readonly HEADER_HEIGHT = 20;
   private readonly FOOTER_HEIGHT = 40;
@@ -18,6 +18,7 @@ export class ReaderHeaderFooterVisibilityManager {
   private onStateChangeCallback?: (state: HeaderFooterVisibilityState) => void;
 
   constructor(private windowHeight: number) {
+    this.mouseY = windowHeight / 2;
   }
 
   onStateChange(callback: (state: HeaderFooterVisibilityState) => void): void {


### PR DESCRIPTION
The reader header was stuck visible on mobile because mouseY defaulted to 0, which always fell inside the header trigger zone (top 20px). Since mobile doesn't fire mouse events, it never changed. Initializing it to the center of the screen so the trigger zones don't activate until the mouse actually moves.