### PR TITLE
Fix cbx reader prev/next book stacking on close

### DIFF
--- a/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -1026,14 +1026,14 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
   navigateToPreviousBook(): void {
     if (this.previousBookInSeries) {
       this.endReadingSession();
-      this.router.navigate(['/cbx-reader/book', this.previousBookInSeries.id]);
+      this.router.navigate(['/cbx-reader/book', this.previousBookInSeries.id], {replaceUrl: true});
     }
   }
 
   navigateToNextBook(): void {
     if (this.nextBookInSeries) {
       this.endReadingSession();
-      this.router.navigate(['/cbx-reader/book', this.nextBookInSeries.id]);
+      this.router.navigate(['/cbx-reader/book', this.nextBookInSeries.id], {replaceUrl: true});
     }
   }
 


### PR DESCRIPTION
Navigating between books in a series (prev/next) was pushing new entries onto the browser history stack, so closing the reader would land you on the previous book instead of back to the library. Added replaceUrl to the series navigation so closing always returns to where you opened the reader from.