### PR TITLE
Fix app crash on startup when /bookdrop volume is not mounted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ LABEL org.opencontainers.image.title="BookLore" \
 
 ENV JAVA_TOOL_OPTIONS="-XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=75.0"
 
-RUN apk update && apk add --no-cache su-exec
+RUN apk update && apk add --no-cache su-exec && \
+    mkdir -p /bookdrop
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
The bookdrop monitoring service was crashing the entire app on startup if the /bookdrop directory didn't exist or wasn't writable (e.g. no volume mount in docker-compose). Now the Dockerfile pre-creates /bookdrop so it's always present in the image, and the monitoring service gracefully disables itself instead of throwing if it still can't initialize for whatever reason.

Closes #2870