### PR TITLE
Fix Kobo download/image URLs using wrong port behind reverse proxy

### DIFF
--- a/booklore-api/src/main/java/org/booklore/util/kobo/KoboUrlBuilder.java
+++ b/booklore-api/src/main/java/org/booklore/util/kobo/KoboUrlBuilder.java
@@ -1,50 +1,21 @@
 package org.booklore.util.kobo;
 
-import org.booklore.util.RequestUtils;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.util.regex.Pattern;
 
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class KoboUrlBuilder {
 
-    private static final Pattern IP_ADDRESS_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+\\.\\d+");
-    @Value("${server.port}")
-    private int serverPort;
-
     public UriComponentsBuilder baseBuilder() {
-        HttpServletRequest request = RequestUtils.getCurrentRequest();
-
         UriComponentsBuilder builder = ServletUriComponentsBuilder
                 .fromCurrentContextPath()
                 .replacePath("")
-                .replaceQuery(null)
-                .port(-1);
-
-        String host = builder.build().getHost();
-
-        if (host == null) host = "";
-
-        String xfPort = request.getHeader("X-Forwarded-Port");
-        try {
-            int port = Integer.parseInt(xfPort);
-
-            if (IP_ADDRESS_PATTERN.matcher(host).matches() || "localhost".equals(host)) {
-                builder.port(port);
-            }
-            log.info("Applied X-Forwarded-Port: {}", port);
-        } catch (NumberFormatException e) {
-            builder.port(serverPort);
-            log.debug("Invalid X-Forwarded-Port header: {}", xfPort);
-        }
+                .replaceQuery(null);
 
         log.debug("Final base URL: {}", builder.build().toUriString());
         return builder;


### PR DESCRIPTION
KoboUrlBuilder had custom port-resolution logic that was resetting the correct port from the request and then trying to re-derive it with broken fallback logic. Behind a reverse proxy with a domain name, or with Docker port mapping, the URLs sent to the Kobo device would point to the internal server port (6060) instead of the actual external port, so book downloads and cover images would silently fail.

Removed the manual port handling and just let Spring's native forward-headers-strategy do its job, since `fromCurrentContextPath()` already resolves scheme, host, and port correctly from forwarded headers.

Closes #2861
Closes #2804