### PR TITLE
Fix metadata settings not saving due to null deserialization error

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/dto/settings/MetadataMatchWeights.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/settings/MetadataMatchWeights.java
@@ -1,6 +1,8 @@
 package org.booklore.model.dto.settings;
 
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,30 +13,54 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MetadataMatchWeights {
-    private int title;
-    private int subtitle;
-    private int description;
-    private int authors;
-    private int publisher;
-    private int publishedDate;
-    private int seriesName;
-    private int seriesNumber;
-    private int seriesTotal;
-    private int isbn13;
-    private int isbn10;
-    private int language;
-    private int pageCount;
-    private int categories;
-    private int amazonRating;
-    private int amazonReviewCount;
-    private int goodreadsRating;
-    private int goodreadsReviewCount;
-    private int hardcoverRating;
-    private int hardcoverReviewCount;
-    private int doubanRating;
-    private int doubanReviewCount;
-    private int ranobedbRating;
-    private int coverImage;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int title = 10;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int subtitle = 1;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int description = 10;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int authors = 10;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int publisher = 5;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int publishedDate = 3;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int seriesName = 2;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int seriesNumber = 2;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int seriesTotal = 1;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int isbn13 = 3;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int isbn10 = 5;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int language = 2;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int pageCount = 1;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int categories = 10;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int amazonRating = 3;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int amazonReviewCount = 2;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int goodreadsRating = 4;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int goodreadsReviewCount = 2;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int hardcoverRating = 2;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int hardcoverReviewCount = 1;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int doubanRating = 3;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int doubanReviewCount = 2;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int ranobedbRating = 2;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int coverImage = 5;
 
     public int totalWeight() {
         return title + subtitle + description + authors + publisher + publishedDate +

--- a/booklore-api/src/test/java/org/booklore/service/metadata/MetadataMatchServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/MetadataMatchServiceTest.java
@@ -33,12 +33,12 @@ class MetadataMatchServiceTest {
 
     @BeforeEach
     void setUp() {
-        weights = MetadataMatchWeights.builder()
+        weights = zeroWeights()
                 .title(10)
                 .subtitle(5)
                 .description(5)
                 .authors(10)
-                .build(); // other fields default to 0
+                .build();
 
         AppSettings appSettings = AppSettings.builder()
                 .metadataMatchWeights(weights)
@@ -80,7 +80,7 @@ class MetadataMatchServiceTest {
 
     @Test
     void calculateMatchScore_shouldScoreLockedNullSeriesNumber() {
-         weights = MetadataMatchWeights.builder()
+         weights = zeroWeights()
                  .title(10)
                  .seriesNumber(5)
                  .build();
@@ -105,5 +105,15 @@ class MetadataMatchServiceTest {
         Float score = metadataMatchService.calculateMatchScore(book);
 
         assertEquals(100.0f, score, 0.01f);
+    }
+
+    private MetadataMatchWeights.MetadataMatchWeightsBuilder zeroWeights() {
+        return MetadataMatchWeights.builder()
+                .title(0).subtitle(0).description(0).authors(0).publisher(0)
+                .publishedDate(0).seriesName(0).seriesNumber(0).seriesTotal(0)
+                .isbn13(0).isbn10(0).language(0).pageCount(0).categories(0)
+                .amazonRating(0).amazonReviewCount(0).goodreadsRating(0)
+                .goodreadsReviewCount(0).hardcoverRating(0).hardcoverReviewCount(0)
+                .doubanRating(0).doubanReviewCount(0).ranobedbRating(0).coverImage(0);
     }
 }


### PR DESCRIPTION
Fixes #2884. Users upgrading from older versions had metadata_match_weights stored in the DB without newer fields (like seriesTotal, doubanRating, etc). Jackson was choking on null values for primitive int fields, which caused settings reads and saves to silently fail and fall back to defaults every time.

Added @JsonSetter(nulls = Nulls.SKIP) with @Builder.Default on all MetadataMatchWeights fields so missing/null values just keep sensible defaults instead of blowing up. Same pattern already used in MetadataRefreshOptions.