### PR TITLE
Hide sidecar tab for physical books

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.html
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.html
@@ -37,7 +37,7 @@
           {{ t('tabSearch') }}
         </p-tab>
       }
-      @if (admin || canEditMetadata) {
+      @if ((admin || canEditMetadata) && !isPhysical) {
         <p-tab value="sidecar">
           <i [class]="'pi pi-file'"></i>
           {{ t('tabSidecar') }}
@@ -63,7 +63,7 @@
           <app-metadata-searcher [book$]="book$"></app-metadata-searcher>
         </p-tabpanel>
       }
-      @if (admin || canEditMetadata) {
+      @if ((admin || canEditMetadata) && !isPhysical) {
         <p-tabpanel value="sidecar">
           <app-sidecar-viewer [book$]="book$"></app-sidecar-viewer>
         </p-tabpanel>

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
@@ -3,7 +3,7 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {UserService} from '../../../settings/user-management/user.service';
 import {Book, BookRecommendation} from '../../../book/model/book.model';
 import {BehaviorSubject, Observable, Subject} from 'rxjs';
-import {distinctUntilChanged, filter, map, shareReplay, switchMap, take, takeUntil,} from 'rxjs/operators';
+import {distinctUntilChanged, filter, map, shareReplay, switchMap, take, takeUntil, tap,} from 'rxjs/operators';
 import {BookService} from '../../../book/service/book.service';
 import {AppSettingsService} from '../../../../shared/service/app-settings.service';
 import {Tab, TabList, TabPanel, TabPanels, Tabs,} from 'primeng/tabs';
@@ -49,6 +49,7 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
   private _tab: string = 'view';
   canEditMetadata: boolean = false;
   admin: boolean = false;
+  isPhysical: boolean = false;
 
   private appSettings$ = this.appSettingsService.appSettings$;
   private currentBookId$ = new BehaviorSubject<number | null>(null);
@@ -113,6 +114,7 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
           )
         )
       ),
+      tap(book => this.isPhysical = book.isPhysical ?? false),
       takeUntil(this.destroy$),
       shareReplay({bufferSize: 1, refCount: true})
     );


### PR DESCRIPTION
Physical books don't have files on disk, so the sidecar tab was showing up but doing nothing useful (export silently fails, import shows an error toast). Now the sidecar tab just won't render when viewing a physical book.

Closes #2881