### PR TITLE
Fix magic shelf physical book filter and polish UI

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.scss
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.scss
@@ -365,7 +365,7 @@
   color: #fff;
 }
 
-.book-type-physical {
+.book-type-phy {
   background: var(--book-type-physical-color);
   color: #fff;
 }

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -800,7 +800,7 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
 
   getDisplayFormat(): string | null {
     if (!this.book?.primaryFile) {
-      return 'PHYSICAL';
+      return 'PHY';
     }
     if (this.forceEbookMode && this.book.primaryFile?.bookType === 'AUDIOBOOK') {
       const ebookType = this.getEbookType(this.book);

--- a/booklore-ui/src/app/features/magic-shelf/service/book-rule-evaluator.service.spec.ts
+++ b/booklore-ui/src/app/features/magic-shelf/service/book-rule-evaluator.service.spec.ts
@@ -677,9 +677,13 @@ describe('BookRuleEvaluatorService', () => {
       expect(service.evaluateGroup(book, rule('audiobookDuration', 'is_empty', null))).toBe(true);
     });
 
-    it('should filter by isPhysical', () => {
-      const book = createBook({isPhysical: true});
-      expect(service.evaluateGroup(book, rule('isPhysical', 'equals', true))).toBe(true);
+    it('should filter by isPhysical with string value from UI', () => {
+      const physical = createBook({isPhysical: true});
+      const digital = createBook({isPhysical: false});
+      expect(service.evaluateGroup(physical, rule('isPhysical', 'equals', 'true'))).toBe(true);
+      expect(service.evaluateGroup(digital, rule('isPhysical', 'equals', 'true'))).toBe(false);
+      expect(service.evaluateGroup(digital, rule('isPhysical', 'equals', 'false'))).toBe(true);
+      expect(service.evaluateGroup(physical, rule('isPhysical', 'not_equals', 'true'))).toBe(false);
     });
 
     it('should filter by lubimyczytacRating', () => {

--- a/booklore-ui/src/app/features/magic-shelf/service/book-rule-evaluator.service.ts
+++ b/booklore-ui/src/app/features/magic-shelf/service/book-rule-evaluator.service.ts
@@ -30,6 +30,7 @@ export class BookRuleEvaluatorService {
     const normalize = (val: unknown): unknown => {
       if (val === null || val === undefined) return val;
       if (val instanceof Date) return val;
+      if (typeof val === 'boolean') return String(val);
       if (typeof val === 'string') {
         const date = new Date(val);
         if (!isNaN(date.getTime())) return date;

--- a/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.scss
+++ b/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.scss
@@ -108,27 +108,28 @@
 
 .heart-orbit-1 {
   background: #f472b6;
-  box-shadow: 0 0 6px #f472b6;
+  box-shadow: 0 0 10px #f472b6, 0 0 4px #f472b6;
   animation: orbit-1 2.5s linear infinite;
 }
 
 .heart-orbit-2 {
   background: #a78bfa;
-  box-shadow: 0 0 6px #a78bfa;
+  box-shadow: 0 0 10px #a78bfa, 0 0 4px #a78bfa;
   animation: orbit-2 3.2s linear infinite reverse;
 }
 
 .heart-orbit-3 {
   background: #38bdf8;
-  box-shadow: 0 0 6px #38bdf8;
+  box-shadow: 0 0 10px #38bdf8, 0 0 4px #38bdf8;
   animation: orbit-3 4s linear infinite;
 }
 
 .heart-icon {
   z-index: 10;
-  color: #ec4899 !important;
+  color: #e8366d !important;
+  font-size: 1.05rem;
   animation: heart-float 2.5s ease-in-out infinite;
-  filter: drop-shadow(0 0 4px rgba(236, 72, 153, 0.5));
+  filter: drop-shadow(0 0 6px rgba(232, 54, 109, 0.8));
   transition: filter 0.3s;
 }
 
@@ -203,8 +204,8 @@
 }
 
 @keyframes heart-float {
-  0%, 100% { transform: translateY(2px); }
-  50% { transform: translateY(-2px); }
+  0%, 100% { transform: translateY(1px); }
+  50% { transform: translateY(-1px); }
 }
 
 @keyframes heartbeat {


### PR DESCRIPTION
The magic shelf rule evaluator wasn't normalizing booleans to strings, so comparing book.isPhysical (boolean true) against the UI dropdown value (string "true") always failed. Added boolean-to-string conversion in the normalize function. Also shortened the physical book badge from "PHYSICAL" to "PHY" so it doesn't look oversized, and punched up the support heart icon and its orbit particles.

Closes #2876