### PR TITLE
Fix max upload size description to include all file formats

### DIFF
--- a/booklore-ui/src/i18n/en/settings-application.json
+++ b/booklore-ui/src/i18n/en/settings-application.json
@@ -29,7 +29,7 @@
     "sectionTitle": "File Management",
     "maxUploadSize": "Max File Upload Size",
     "maxUploadPlaceholder": "Max size",
-    "maxUploadDesc": "Defines the maximum allowed size (in MB) for each uploaded file. Applies to EPUB, PDF, CBZ, CBR, and CB7 formats.",
+    "maxUploadDesc": "Defines the maximum allowed size (in MB) for each uploaded file. Applies to all supported file formats.",
     "restartWarning": "Changes will take effect after restarting the server",
     "invalidInput": "Invalid Input",
     "invalidInputDetail": "Please enter a valid max file upload size in MB."

--- a/booklore-ui/src/i18n/es/settings-application.json
+++ b/booklore-ui/src/i18n/es/settings-application.json
@@ -29,7 +29,7 @@
     "sectionTitle": "Gestión de archivos",
     "maxUploadSize": "Tamaño máximo de carga de archivo",
     "maxUploadPlaceholder": "Tamaño máximo",
-    "maxUploadDesc": "Define el tamaño máximo permitido (en MB) para cada archivo cargado. Se aplica a los formatos EPUB, PDF, CBZ, CBR y CB7.",
+    "maxUploadDesc": "Define el tamaño máximo permitido (en MB) para cada archivo cargado. Se aplica a todos los formatos de archivo compatibles.",
     "restartWarning": "Los cambios surtirán efecto después de reiniciar el servidor",
     "invalidInput": "Entrada inválida",
     "invalidInputDetail": "Introduce un tamaño máximo de carga de archivo válido en MB."


### PR DESCRIPTION
The settings page description for max file upload size only listed EPUB, PDF, CBZ, CBR, and CB7 as affected formats, but the limit actually applies to all uploads including audiobooks. Updated the text in both en and es to say "all supported file formats" instead of listing specific ones.

Closes #2893