### PR TITLE
Fix i18n fallback for languages with empty translation strings

### DIFF
--- a/booklore-ui/src/app/core/config/transloco-loader.ts
+++ b/booklore-ui/src/app/core/config/transloco-loader.ts
@@ -51,7 +51,7 @@ function deepMerge(base: Record<string, any>, override: Record<string, any>): Re
     if (override[key] && typeof override[key] === 'object' && !Array.isArray(override[key])
       && base[key] && typeof base[key] === 'object' && !Array.isArray(base[key])) {
       result[key] = deepMerge(base[key], override[key]);
-    } else {
+    } else if (override[key] !== '') {
       result[key] = override[key];
     }
   }


### PR DESCRIPTION
Languages with scaffolded but untranslated strings (empty `""` values) weren't falling back to English. The `deepMerge` in the Transloco loader was overwriting English values with empty strings instead of skipping them. Now empty strings are treated as missing, so English shows through until a real translation is provided.