### PR TITLE
Smarter AUTO_DETECT for audiobook series folders and multi-part files

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/library/LibraryFileHelper.java
+++ b/booklore-api/src/main/java/org/booklore/service/library/LibraryFileHelper.java
@@ -109,22 +109,25 @@ public class LibraryFileHelper {
                 boolean hasNonAudioBooks = dirHasNonAudioBooks.getOrDefault(dir, false);
 
                 if (audioFiles != null && audioFiles.size() >= MIN_AUDIO_FILES_FOR_FOLDER_AUDIOBOOK && !hasNonAudioBooks) {
-                    // This is a folder-based audiobook: contains 2+ audio files and no ebook files
                     // Don't treat library root as audiobook folder
                     if (!dir.equals(libraryPath)) {
-                        log.info("Detected folder-based audiobook: {} ({} audio files)", dir.getFileName(), audioFiles.size());
+                        if (FileUtils.isSeriesFolder(audioFiles)) {
+                            log.info("Detected series folder: {} ({} audio files with distinct titles)", dir.getFileName(), audioFiles.size());
+                            addIndividualAudioFiles(audioFiles, libraryEntity, pathEntity, libraryFiles);
+                        } else {
+                            log.info("Detected folder-based audiobook: {} ({} audio files)", dir.getFileName(), audioFiles.size());
 
-                        processedAsFolderAudiobook.add(dir);
+                            processedAsFolderAudiobook.add(dir);
 
-                        // Add a single LibraryFile representing the folder
-                        libraryFiles.add(LibraryFile.builder()
-                                .libraryEntity(libraryEntity)
-                                .libraryPathEntity(pathEntity)
-                                .fileSubPath(FileUtils.getRelativeSubPath(pathEntity.getPath(), dir))
-                                .fileName(dir.getFileName().toString())
-                                .bookFileType(BookFileType.AUDIOBOOK)
-                                .folderBased(true)
-                                .build());
+                            libraryFiles.add(LibraryFile.builder()
+                                    .libraryEntity(libraryEntity)
+                                    .libraryPathEntity(pathEntity)
+                                    .fileSubPath(FileUtils.getRelativeSubPath(pathEntity.getPath(), dir))
+                                    .fileName(dir.getFileName().toString())
+                                    .bookFileType(BookFileType.AUDIOBOOK)
+                                    .folderBased(true)
+                                    .build());
+                        }
                     } else {
                         // Library root - add individual audio files
                         addIndividualAudioFiles(audioFiles, libraryEntity, pathEntity, libraryFiles);

--- a/booklore-api/src/test/java/org/booklore/util/BookFileGroupingUtilsTest.java
+++ b/booklore-api/src/test/java/org/booklore/util/BookFileGroupingUtilsTest.java
@@ -510,6 +510,152 @@ class BookFileGroupingUtilsTest {
         assertThat(groups.values().iterator().next()).containsExactlyInAnyOrder(basic, withAuthor);
     }
 
+    // ========== Part Indicator Stripping Tests ==========
+
+    @Test
+    void extractGroupingKey_shouldStripPartIndicators() {
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Lost Hero (part 1).m4b")).isEqualTo("the lost hero");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Lost Hero (pt 2).m4b")).isEqualTo("the lost hero");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Lost Hero (disc 1).m4b")).isEqualTo("the lost hero");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Lost Hero [cd 3].m4b")).isEqualTo("the lost hero");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Lost Hero - part 1.m4b")).isEqualTo("the lost hero");
+    }
+
+    @Test
+    void extractGroupingKey_shouldPreserveNonPartParenthetical() {
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit (Extended Edition).epub"))
+                .isEqualTo("the hobbit (extended edition)");
+    }
+
+    @Test
+    void extractGroupingKey_shouldProduceSameKeyForMultiPartFiles() {
+        String key1 = BookFileGroupingUtils.extractGroupingKey("1. The Lost Hero (part 1).m4b");
+        String key2 = BookFileGroupingUtils.extractGroupingKey("1. The Lost Hero (part 2).m4b");
+        assertThat(key1).isEqualTo(key2);
+    }
+
+    // ========== Bare-Number Series Detection Tests ==========
+
+    @Test
+    void extractGroupingKey_shouldNotStripBarePartAsSeriesLabel() {
+        // "Part 1" without brackets/dash is a series label, not a multi-file indicator
+        assertThat(BookFileGroupingUtils.extractGroupingKey("Harry Potter Part 1.epub"))
+                .isEqualTo("harry potter part 1");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("Harry Potter Part 2.epub"))
+                .isEqualTo("harry potter part 2");
+    }
+
+    @Test
+    void groupByBaseName_shouldKeepBarePartSeriesEntriesSeparate() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile part1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Harry Potter")
+                .fileName("Harry Potter Part 1.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        LibraryFile part2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Harry Potter")
+                .fileName("Harry Potter Part 2.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(part1, part2));
+
+        assertThat(groups).hasSize(2);
+    }
+
+    @Test
+    void groupByBaseName_shouldSeparateBareNumberedSeriesFiles() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile file1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Percy Jackson")
+                .fileName("1. The Lightning Thief.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile file2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Percy Jackson")
+                .fileName("2. The Sea of Monsters.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(file1, file2));
+
+        assertThat(groups).hasSize(2);
+    }
+
+    @Test
+    void groupByBaseName_shouldGroupMultiPartFilesOfSameBook() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile part1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus")
+                .fileName("1. The Lost Hero (part 1).m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile part2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus")
+                .fileName("1. The Lost Hero (part 2).m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(part1, part2));
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.values().iterator().next()).containsExactlyInAnyOrder(part1, part2);
+    }
+
+    @Test
+    void groupByBaseName_shouldHandleMixedPartsAndSeparateBooks() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile lostHeroPt1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus")
+                .fileName("1. The Lost Hero (part 1).m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile lostHeroPt2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus")
+                .fileName("1. The Lost Hero (part 2).m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile sonOfNeptune = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus")
+                .fileName("2. The Son of Neptune.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(lostHeroPt1, lostHeroPt2, sonOfNeptune));
+
+        assertThat(groups).hasSize(2);
+        boolean foundLostHeroGroup = groups.values().stream()
+                .anyMatch(list -> list.size() == 2 && list.containsAll(List.of(lostHeroPt1, lostHeroPt2)));
+        assertThat(foundLostHeroGroup).isTrue();
+    }
+
     @Test
     void groupByBaseName_shouldHandleFolderBasedAudiobook() {
         // Folder-based audiobook (MP3 folder) with ebook files
@@ -635,6 +781,453 @@ class BookFileGroupingUtilsTest {
 
         assertThat(groups).hasSize(1);
         assertThat(groups.values().iterator().next()).containsExactlyInAnyOrder(epub, audiobook1);
+    }
+
+    // ========== Part Indicator Pattern Edge Cases ==========
+
+    @Test
+    void extractGroupingKey_shouldStripBareDiscAndCdAndPt() {
+        // pt, disc, disk, cd are unambiguous and stripped even without brackets/dash
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit disc 1.m4b")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit disk 2.m4b")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit cd 3.m4b")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit pt 1.m4b")).isEqualTo("the hobbit");
+    }
+
+    @Test
+    void extractGroupingKey_shouldStripPartInSquareBrackets() {
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit [part 1].m4b")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit [Part 2].m4b")).isEqualTo("the hobbit");
+    }
+
+    @Test
+    void extractGroupingKey_shouldStripPartCaseInsensitive() {
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit (PART 1).m4b")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit (Part 1).m4b")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit - PART 1.m4b")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit DISC 1.m4b")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit CD 3.m4b")).isEqualTo("the hobbit");
+    }
+
+    @Test
+    void extractGroupingKey_shouldNotStripPartWithoutNumber() {
+        // "part" keyword without a trailing number should not be stripped
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Best Part.epub")).isEqualTo("the best part");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("Disc Jockey.m4b")).isEqualTo("disc jockey");
+    }
+
+    @Test
+    void extractGroupingKey_shouldStripAudioFormatIndicators() {
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit (m4b).m4b")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit (mp3).mp3")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit [audiobook].m4b")).isEqualTo("the hobbit");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit (audio).m4b")).isEqualTo("the hobbit");
+    }
+
+    @Test
+    void extractGroupingKey_shouldStripFormatThenPartIndicator() {
+        // Both format indicator and part indicator present
+        assertThat(BookFileGroupingUtils.extractGroupingKey("The Hobbit (mp3) (part 1).mp3")).isEqualTo("the hobbit");
+    }
+
+    // ========== Bare-Number Prefix Edge Cases ==========
+
+    @Test
+    void extractGroupingKey_shouldPreserveBareNumberDotPrefix() {
+        // "N. Title" prefix is preserved in the grouping key (series detection handles it separately)
+        assertThat(BookFileGroupingUtils.extractGroupingKey("01. The Lightning Thief.m4b")).isEqualTo("01. the lightning thief");
+        assertThat(BookFileGroupingUtils.extractGroupingKey("100. War and Peace.epub")).isEqualTo("100. war and peace");
+    }
+
+    @Test
+    void extractGroupingKey_shouldStripDashPrefixViaAuthorPattern() {
+        // "01 - The Lightning Thief" looks like "number - Author Name" to the trailing author pattern,
+        // so the author pattern strips it. This is expected existing behavior.
+        assertThat(BookFileGroupingUtils.extractGroupingKey("01 - The Lightning Thief.m4b")).isEqualTo("01");
+    }
+
+    @Test
+    void extractGroupingKey_shouldNotTreatFourDigitNumberAsPrefix() {
+        // 4-digit numbers should not be treated as series prefixes
+        assertThat(BookFileGroupingUtils.extractGroupingKey("1984.epub")).isEqualTo("1984");
+    }
+
+    @Test
+    void extractGroupingKey_shouldNotTreatNumberWithoutSeparatorAsPrefix() {
+        // "101 Dalmatians" has no dot or dash after the number
+        assertThat(BookFileGroupingUtils.extractGroupingKey("101 Dalmatians.epub")).isEqualTo("101 dalmatians");
+    }
+
+    @Test
+    void groupByBaseName_shouldSeparateFiveBookSeriesWithBareNumbers() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        List<LibraryFile> files = new java.util.ArrayList<>();
+        String[] titles = {
+                "1. The Lightning Thief.m4b",
+                "2. The Sea of Monsters.m4b",
+                "3. The Titans Curse.m4b",
+                "4. The Battle of the Labyrinth.m4b",
+                "5. The Last Olympian.m4b"
+        };
+        for (String title : titles) {
+            files.add(LibraryFile.builder()
+                    .libraryPathEntity(pathEntity)
+                    .fileSubPath("Percy Jackson")
+                    .fileName(title)
+                    .bookFileType(BookFileType.AUDIOBOOK)
+                    .build());
+        }
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(files);
+
+        assertThat(groups).hasSize(5);
+    }
+
+    @Test
+    void groupByBaseName_shouldGroupSameBareNumberInMultipleFormats() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile epub = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Percy Jackson")
+                .fileName("1. The Lightning Thief.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        LibraryFile m4b = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Percy Jackson")
+                .fileName("1. The Lightning Thief.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile epub2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Percy Jackson")
+                .fileName("2. The Sea of Monsters.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(epub, m4b, epub2));
+
+        // Book 1 in 2 formats = 1 group, Book 2 = 1 group
+        assertThat(groups).hasSize(2);
+        boolean foundBook1Group = groups.values().stream()
+                .anyMatch(list -> list.size() == 2 && list.containsAll(List.of(epub, m4b)));
+        assertThat(foundBook1Group).isTrue();
+    }
+
+    @Test
+    void groupByBaseName_shouldSeparateDashPrefixedSeriesFiles() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile file1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Rick Riordan")
+                .fileName("01 - The Lightning Thief.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile file2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Rick Riordan")
+                .fileName("02 - The Sea of Monsters.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(file1, file2));
+
+        assertThat(groups).hasSize(2);
+    }
+
+    @Test
+    void groupByBaseName_shouldHandleRootLevelBareNumberedFiles() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile file1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath(null)
+                .fileName("1. The Lightning Thief.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        LibraryFile file2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath(null)
+                .fileName("2. The Sea of Monsters.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(file1, file2));
+
+        // Root-level uses exact key matching, different keys = separate groups
+        assertThat(groups).hasSize(2);
+    }
+
+    // ========== Series Detection with Various Keywords ==========
+
+    @Test
+    void groupByBaseName_shouldSeparateEpisodeSeriesEntries() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile ep1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("The Podcast")
+                .fileName("The Podcast Episode 1.mp3")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile ep2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("The Podcast")
+                .fileName("The Podcast Episode 2.mp3")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(ep1, ep2));
+
+        assertThat(groups).hasSize(2);
+    }
+
+    @Test
+    void groupByBaseName_shouldSeparateHashNumberedSeries() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile n1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Discworld")
+                .fileName("Discworld #1.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        LibraryFile n2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Discworld")
+                .fileName("Discworld #2.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(n1, n2));
+
+        assertThat(groups).hasSize(2);
+    }
+
+    // ========== Multi-Part Grouping Edge Cases ==========
+
+    @Test
+    void groupByBaseName_shouldGroupBracketedPartsAtRootLevel() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile pt1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath(null)
+                .fileName("The Lost Hero (part 1).m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile pt2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath(null)
+                .fileName("The Lost Hero (part 2).m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(pt1, pt2));
+
+        // Root-level exact key matching: both produce "the lost hero" → same group
+        assertThat(groups).hasSize(1);
+        assertThat(groups.values().iterator().next()).containsExactlyInAnyOrder(pt1, pt2);
+    }
+
+    @Test
+    void groupByBaseName_shouldGroupDiscVariantsOfSameBook() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile d1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("War and Peace")
+                .fileName("War and Peace disc 1.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile d2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("War and Peace")
+                .fileName("War and Peace disc 2.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile d3 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("War and Peace")
+                .fileName("War and Peace disc 3.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(d1, d2, d3));
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.values().iterator().next()).containsExactlyInAnyOrder(d1, d2, d3);
+    }
+
+    @Test
+    void groupByBaseName_shouldGroupCdVariantsOfSameBook() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile cd1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Moby Dick")
+                .fileName("Moby Dick cd 1.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        LibraryFile cd2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Moby Dick")
+                .fileName("Moby Dick cd 2.m4b")
+                .bookFileType(BookFileType.AUDIOBOOK)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(cd1, cd2));
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.values().iterator().next()).containsExactlyInAnyOrder(cd1, cd2);
+    }
+
+    // ========== Grouping Boundary / Misc Edge Cases ==========
+
+    @Test
+    void groupByBaseName_shouldHandleEmptyList() {
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of());
+        assertThat(groups).isEmpty();
+    }
+
+    @Test
+    void groupByBaseName_shouldHandleSingleFileInFolder() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile file = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Some Folder")
+                .fileName("Lonely Book.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(file));
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.values().iterator().next()).containsExactly(file);
+    }
+
+    @Test
+    void groupByBaseName_shouldHandleEmptySubPath() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile file1 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("")
+                .fileName("Book.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        LibraryFile file2 = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("")
+                .fileName("Book.pdf")
+                .bookFileType(BookFileType.PDF)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(file1, file2));
+
+        // Empty subPath treated as root level
+        assertThat(groups).hasSize(1);
+    }
+
+    @Test
+    void groupByBaseName_shouldSeparateCompletelyUnrelatedFilesInFolder() {
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile war = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Random")
+                .fileName("War and Peace.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        LibraryFile moby = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Random")
+                .fileName("Moby Dick.epub")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+
+        LibraryFile pride = LibraryFile.builder()
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("Random")
+                .fileName("Pride and Prejudice.pdf")
+                .bookFileType(BookFileType.PDF)
+                .build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(war, moby, pride));
+
+        assertThat(groups).hasSize(3);
+    }
+
+    @Test
+    void groupByBaseName_shouldHandleFullHeroesOfOlympusScenario() {
+        // Realistic 5-book series with multi-part splits for some books
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(1L);
+        pathEntity.setPath("/library");
+
+        LibraryFile lh1 = LibraryFile.builder().libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus").fileName("1. The Lost Hero (part 1).m4b").bookFileType(BookFileType.AUDIOBOOK).build();
+        LibraryFile lh2 = LibraryFile.builder().libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus").fileName("1. The Lost Hero (part 2).m4b").bookFileType(BookFileType.AUDIOBOOK).build();
+        LibraryFile son = LibraryFile.builder().libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus").fileName("2. The Son of Neptune.m4b").bookFileType(BookFileType.AUDIOBOOK).build();
+        LibraryFile moa1 = LibraryFile.builder().libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus").fileName("3. The Mark of Athena (part 1).m4b").bookFileType(BookFileType.AUDIOBOOK).build();
+        LibraryFile moa2 = LibraryFile.builder().libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus").fileName("3. The Mark of Athena (part 2).m4b").bookFileType(BookFileType.AUDIOBOOK).build();
+        LibraryFile hoh = LibraryFile.builder().libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus").fileName("4. The House of Hades.m4b").bookFileType(BookFileType.AUDIOBOOK).build();
+        LibraryFile boo = LibraryFile.builder().libraryPathEntity(pathEntity)
+                .fileSubPath("Heroes of Olympus").fileName("5. The Blood of Olympus.m4b").bookFileType(BookFileType.AUDIOBOOK).build();
+
+        Map<String, List<LibraryFile>> groups = BookFileGroupingUtils.groupByBaseName(List.of(lh1, lh2, son, moa1, moa2, hoh, boo));
+
+        // 5 books: Lost Hero (2 parts grouped), Son of Neptune, Mark of Athena (2 parts grouped), House of Hades, Blood of Olympus
+        assertThat(groups).hasSize(5);
+        boolean lhGrouped = groups.values().stream().anyMatch(l -> l.size() == 2 && l.containsAll(List.of(lh1, lh2)));
+        boolean moaGrouped = groups.values().stream().anyMatch(l -> l.size() == 2 && l.containsAll(List.of(moa1, moa2)));
+        assertThat(lhGrouped).isTrue();
+        assertThat(moaGrouped).isTrue();
     }
 
     @Test


### PR DESCRIPTION
The AUTO_DETECT grouping mode was treating all folders with 2+ audio files and no ebooks as a single folder-based audiobook. That's wrong for series folders where each .m4b is a separate complete book (like Percy Jackson with 5 individual .m4b files). Now it extracts base titles from the audio files and checks whether they're actually distinct books or just chapter/track files for one audiobook.

Also added part indicator stripping to the grouping key logic so multi-part files like "The Lost Hero (part 1).m4b" and "The Lost Hero (part 2).m4b" produce the same key and get grouped together. And bare number prefixes like "1. Title" are now recognized as series indicators so they get properly separated.

The series folder detection is shared between LibraryFileHelper (full scans) and LibraryFileEventProcessor (file watcher) so both paths behave consistently.