### PR TITLE
refactor(BookService.getBookContent): use Spring's built-in range request handler & enable HTTP caching

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/BookController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/BookController.java
@@ -139,12 +139,11 @@ public class BookController {
     })
     @GetMapping("/{bookId}/content")
     @CheckBookAccess(bookIdParam = "bookId")
-    public void getBookContent(
+    public ResponseEntity<Resource> getBookContent(
             @Parameter(description = "ID of the book") @PathVariable long bookId,
-            @Parameter(description = "Optional book type for alternative format (e.g., EPUB, PDF, MOBI)") @RequestParam(required = false) String bookType,
-            HttpServletRequest request,
-            HttpServletResponse response) throws java.io.IOException {
-        bookService.streamBookContent(bookId, bookType, request, response);
+            @Parameter(description = "Optional book type for alternative format (e.g., EPUB, PDF, MOBI)") @RequestParam(required = false) String bookType
+            ) {
+        return bookService.getBookContent(bookId, bookType);
     }
 
     @Operation(summary = "Download book", description = "Download the book file. Requires download permission or admin.")

--- a/booklore-api/src/main/java/org/booklore/util/FileUtils.java
+++ b/booklore-api/src/main/java/org/booklore/util/FileUtils.java
@@ -1,5 +1,6 @@
 package org.booklore.util;
 
+import jakarta.annotation.Nullable;
 import org.booklore.model.dto.Book;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookFileEntity;
@@ -10,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -54,6 +56,17 @@ public class FileUtils {
                         .getParent())
                 .map(path -> path.toString().replace("\\", "/"))
                 .orElse("");
+    }
+
+    public @Nullable Instant getFileLastModified(String filePath) { return getFileLastModified(Path.of(filePath)); }
+
+    public @Nullable Instant getFileLastModified(Path filePath) {
+        try {
+            return Files.getLastModifiedTime(filePath).toInstant();
+        } catch (IOException e) {
+            log.warn("Failed to read last modified time of file {}", filePath, e);
+            return null;
+        }
     }
 
     public Long getFileSizeInKb(BookEntity bookEntity) {


### PR DESCRIPTION
## 📝 Description

<!-- Why is this change needed? Explain in your own words. -->

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [x] Refactor (no behavior change)
- [ ] Breaking change (existing functionality affected)
- [ ] Documentation update

## 🔧 Changes

- Use Spring's built-in range request handler because it has been tested and hardened. Additionally, we won't have to maintain it.
- Enable HTTP Caching to optimize subsequent requests to retrieve book content.

## 🧪 Testing (MANDATORY)

> **PRs without this section filled out will be closed.** "Tests pass" or "Tested locally" is not sufficient. You must provide specifics.

**Manual testing steps you performed:**
<!-- Walk through the exact steps you took to verify your change works. Be specific. -->
1. Range requests works as intended (as seen in DevTool below)
2. HTTP Caching works as inteded (as seen in DevTool)


**Regression testing:**
<!-- How did you verify that existing related features still work after your change? -->
- Reading all media types (pdf, epub, cbz,...) still works.

**Edge cases covered:**
<!-- What boundary conditions or unusual inputs did you test? -->
- No edge cases

**Test output:**
<!-- Paste the actual terminal output from running tests. Not "all pass", the real output. -->

<details>
<summary>Backend test output (<code>./gradlew test</code>)</summary>

```
/booklore-api # cd /booklore-api && ./gradlew test
> Task :compileJava UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :compileTestJava UP-TO-DATE
> Task :processTestResources UP-TO-DATE
> Task :testClasses UP-TO-DATE
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
> Task :test

2026-02-25T03:15:30.036Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.s.m.s.b.SimpleBrokerMessageHandler     : Stopping...
2026-02-25T03:15:30.037Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.s.m.s.b.SimpleBrokerMessageHandler     : BrokerAvailabilityEvent[available=false, SimpleBrokerMessageHandler [org.springframework.messaging.simp.broker.DefaultSubscriptionRegistry@385ddd82]]
2026-02-25T03:15:30.037Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.s.m.s.b.SimpleBrokerMessageHandler     : Stopped.
2026-02-25T03:15:30.066Z  INFO 755 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-25T03:15:30.070Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-25T03:15:30.461Z  INFO 755 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-25T03:15:30.463Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-25T03:15:30.464Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-25T03:15:30.465Z  WARN 755 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-25T03:15:30.483Z  INFO 755 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-25T03:15:30.524Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-25T03:15:30.527Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-25T03:15:30.536Z  INFO 755 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-25T03:15:30.536Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-25T03:15:30.537Z  INFO 755 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-25T03:15:30.540Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-25T03:15:30.542Z  WARN 755 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-25T03:15:30.542Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-25T03:15:30.563Z  INFO 755 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-25T03:15:30.567Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-25T03:15:30.569Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-25T03:15:30.577Z  INFO 755 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-25T03:15:30.577Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-25T03:15:30.578Z  INFO 755 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-25T03:15:30.580Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-25T03:15:30.581Z  WARN 755 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-25T03:15:30.581Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-25T03:15:30.595Z  INFO 755 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-25T03:15:30.621Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-25T03:15:30.622Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-25T03:15:30.630Z  INFO 755 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-25T03:15:30.631Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-25T03:15:30.631Z  INFO 755 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-25T03:15:30.635Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-25T03:15:30.636Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-25T03:15:30.636Z  WARN 755 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-25T03:15:30.648Z  INFO 755 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-25T03:15:30.662Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-25T03:15:30.664Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-25T03:15:30.671Z  INFO 755 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-25T03:15:30.672Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-25T03:15:30.672Z  INFO 755 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-25T03:15:30.678Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-25T03:15:30.679Z  WARN 755 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-25T03:15:30.680Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-25T03:15:30.713Z  INFO 755 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-25T03:15:30.729Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-25T03:15:30.730Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-25T03:15:30.739Z  INFO 755 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-25T03:15:30.739Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-25T03:15:30.740Z  INFO 755 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-25T03:15:30.743Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-25T03:15:30.744Z  WARN 755 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-25T03:15:30.744Z  INFO 755 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-25T03:15:30.758Z  INFO 755 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-25T03:15:30.772Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-25T03:15:30.773Z  INFO 755 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.

> Task :jacocoTestReport

BUILD SUCCESSFUL in 3m 18s
6 actionable tasks: 2 executed, 4 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.3.1/userguide/configuration_cache_enabling.html
```

</details>

<details>
<summary>Frontend test output (<code>ng test</code>)</summary>

```
/angular-app # ng test
Using Vitest configuration file: /angular-app/vitest-base.config.ts
Initial chunk files                                                            | Names                                                                       |  Raw size
spec-app-features-magic-shelf-component-magic-shelf-component.js               | spec-app-features-magic-shelf-component-magic-shelf-component               |   1.10 MB | 
spec-app-features-magic-shelf-service-book-rule-evaluator.service.js           | spec-app-features-magic-shelf-service-book-rule-evaluator.service           |  65.08 kB | 
spec-app-app.component.js                                                      | spec-app-app.component                                                      |  58.81 kB | 
chunk-WEHYA5ZK.js                                                              | -                                                                           |  53.30 kB | 
styles.css                                                                     | styles                                                                      |  30.99 kB | 
chunk-5DU7IHVK.js                                                              | -                                                                           |  24.50 kB | 
spec-app-features-magic-shelf-service-book-rule-evaluator-metadata-presence.js | spec-app-features-magic-shelf-service-book-rule-evaluator-metadata-presence |  23.21 kB | 
chunk-4XOGOLT7.js                                                              | -                                                                           |  15.59 kB | 
spec-app-features-magic-shelf-service-magic-shelf-utils.js                     | spec-app-features-magic-shelf-service-magic-shelf-utils                     |  11.36 kB | 
spec-app-core-security-auth-initializer.js                                     | spec-app-core-security-auth-initializer                                     |   8.69 kB | 
chunk-PUIDBMXW.js                                                              | -                                                                           |   6.10 kB | 
chunk-LXUTVRDP.js                                                              | -                                                                           |   4.86 kB | 
chunk-ZPBFDZNO.js                                                              | -                                                                           |   2.19 kB | 
chunk-EBKNP5VF.js                                                              | -                                                                           |   1.33 kB | 
init-testbed.js                                                                | init-testbed                                                                |   1.27 kB | 
spec-app-app.js                                                                | spec-app-app                                                                | 202 bytes | 
polyfills.js                                                                   | polyfills                                                                   | 121 bytes | 

                                                                               | Initial total                                                               |   1.41 MB

Application bundle generation complete. [45.917 seconds] - 2026-02-24T07:45:21.331Z

Watch mode enabled. Watching for file changes...

 DEV  v4.0.18 /angular-app

 ✓  booklore  src/app/features/magic-shelf/service/book-rule-evaluator.service.spec.ts (199 tests) 1345ms
 ✓  booklore  src/app/features/magic-shelf/service/book-rule-evaluator-metadata-presence.spec.ts (85 tests) 532ms
 ✓  booklore  src/app/features/magic-shelf/service/magic-shelf-utils.spec.ts (46 tests) 73ms
 ✓  booklore  src/app/features/magic-shelf/component/magic-shelf-component.spec.ts (73 tests) 2000ms
 ✓  booklore  src/app/core/security/auth-initializer.spec.ts (2 tests) 62ms
 ✓  booklore  src/app/app.spec.ts (1 test) 6ms
 ✓  booklore  src/app/app.component.spec.ts (7 tests) 358ms

 Test Files  7 passed (7)
      Tests  413 passed (413)
   Start at  07:45:27
   Duration  107.40s (transform 4.69s, setup 68.49s, import 31.65s, tests 4.38s, environment 234.98s)

JUNIT report written to /angular-app/test-results/vitest-results.xml
 PASS  Waiting for file changes...
       press h to show help, press q to quit
```

</details>

## 📸 Screen Recording / Screenshots (MANDATORY)
- Non-cached requests (initial requests)
<img width="530" height="531" alt="non_cached" src="https://github.com/user-attachments/assets/ab940147-afd6-45b2-a030-d35359730394" />

- Cached requests (subsequent requests)
<img width="558" height="501" alt="cached" src="https://github.com/user-attachments/assets/75bb5c17-62ee-4039-8d3f-9adff721b361" />

---

## ✅ Pre-Submission Checklist

> **All boxes must be checked before requesting review.** Incomplete PRs will be closed without review. No exceptions.

- [ ] This PR is linked to an approved issue
- [x] Code follows project style guidelines and conventions
- [x] Branch is up to date with `develop` (merge conflicts resolved)
- [x] I ran the full stack locally (backend + frontend + database) and verified the change works
- [x] Automated tests added or updated to cover changes (backend **and** frontend)
- [x] All tests pass locally and output is pasted above
- [x] Screen recording or screenshots are attached above proving the change works
- [x] PR is a single focused change (one bug fix OR one feature, not multiple unrelated changes)
- [x] PR is reasonably scoped (PRs over 1000+ changed lines will be closed, split into smaller PRs)
- [x] No unsolicited refactors, cleanups, or "improvements" are bundled in