### PR TITLE
Fix settings deserialization failure on upgrade

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/dto/settings/KoboSettings.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/settings/KoboSettings.java
@@ -1,5 +1,7 @@
 package org.booklore.model.dto.settings;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,10 +12,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class KoboSettings {
-    private boolean convertToKepub;
-    private int conversionLimitInMb;
-    private boolean convertCbxToEpub;
-    private int conversionLimitInMbForCbx;
-    private boolean forceEnableHyphenation;
-    private int conversionImageCompressionPercentage;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private boolean convertToKepub = false;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int conversionLimitInMb = 100;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private boolean convertCbxToEpub = false;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int conversionLimitInMbForCbx = 100;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private boolean forceEnableHyphenation = false;
+    @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
+    private int conversionImageCompressionPercentage = 85;
 }

--- a/booklore-api/src/main/resources/application.yaml
+++ b/booklore-api/src/main/resources/application.yaml
@@ -28,6 +28,9 @@ server:
     relaxed-query-chars: '[,],%,{,},|'
 
 spring:
+  jackson:
+    deserialization:
+      fail-on-null-for-primitives: false
   servlet:
     multipart:
       enabled: false


### PR DESCRIPTION
Jackson 3 flipped `FAIL_ON_NULL_FOR_PRIMITIVES` to true by default, so when users upgrade and their stored JSON settings are missing fields that were added in newer versions, deserialization blows up instead of gracefully handling the nulls. Disabled it globally in application.yaml, and added proper `@JsonSetter(nulls = Nulls.SKIP)` with `@Builder.Default` to KoboSettings since its int fields have non-zero defaults (100, 85) that would be wrong if coerced to 0.

Closes #2923