### PR TITLE
Enable CBX conversion for Kobo sync

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/dto/settings/KoboSettings.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/settings/KoboSettings.java
@@ -12,7 +12,8 @@ import lombok.NoArgsConstructor;
 public class KoboSettings {
     private boolean convertToKepub;
     private int conversionLimitInMb;
-    private boolean convertCbxToEpub;
+    @Builder.Default
+    private boolean convertCbxToEpub = true;
     private int conversionLimitInMbForCbx;
     private boolean forceEnableHyphenation;
     private int conversionImageCompressionPercentage;

--- a/booklore-api/src/main/java/org/booklore/service/kobo/KoboEntitlementService.java
+++ b/booklore-api/src/main/java/org/booklore/service/kobo/KoboEntitlementService.java
@@ -92,7 +92,7 @@ public class KoboEntitlementService {
                     .collect(Collectors.toList());
         }
         return books.stream()
-                .filter(bookEntity -> bookEntity.getPrimaryBookFile() != null && bookEntity.getPrimaryBookFile().getBookType() == BookFileType.EPUB)
+                .filter(koboCompatibilityService::isBookSupportedForKobo)
                 .map(book -> ChangedProductMetadata.builder()
                         .changedProductMetadata(BookEntitlementContainer.builder()
                                 .bookEntitlement(buildBookEntitlement(book, false))

--- a/booklore-api/src/test/java/org/booklore/service/KoboEntitlementServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/KoboEntitlementServiceTest.java
@@ -531,6 +531,35 @@ class KoboEntitlementServiceTest {
             assertEquals(1, result.size());
             assertTrue(result.getFirst() instanceof ChangedProductMetadata);
         }
+
+        @Test
+        @DisplayName("Should generate changed product metadata for non-removed CBX books when conversion is enabled")
+        void generateChangedEntitlements_changedCbxBookIncludedWhenConversionEnabled() {
+            BookEntity book = createCbxBookEntity(1L);
+
+            when(bookQueryService.findAllWithMetadataByIds(Set.of(1L))).thenReturn(List.of(book));
+            when(koboCompatibilityService.isBookSupportedForKobo(book)).thenReturn(true);
+            when(koboUrlBuilder.downloadUrl("token1", 1L)).thenReturn("http://test.com/download/1");
+            when(appSettingService.getAppSettings()).thenReturn(createAppSettingsWithKoboSettings());
+
+            List<? extends Entitlement> result = koboEntitlementService.generateChangedEntitlements(Set.of(1L), "token1", false);
+
+            assertEquals(1, result.size());
+            assertTrue(result.getFirst() instanceof ChangedProductMetadata);
+        }
+
+        @Test
+        @DisplayName("Should exclude CBX books from changed product metadata when conversion is disabled")
+        void generateChangedEntitlements_changedCbxBookExcludedWhenConversionDisabled() {
+            BookEntity book = createCbxBookEntity(1L);
+
+            when(bookQueryService.findAllWithMetadataByIds(Set.of(1L))).thenReturn(List.of(book));
+            when(koboCompatibilityService.isBookSupportedForKobo(book)).thenReturn(false);
+
+            List<? extends Entitlement> result = koboEntitlementService.generateChangedEntitlements(Set.of(1L), "token1", false);
+
+            assertTrue(result.isEmpty());
+        }
     }
 
     @Nested


### PR DESCRIPTION
Fixes #2931

## Changes
Updates the Kobo sync entitlements logic to support CBX file conversion when enabled in settings:

- Set `convertCbxToEpub` to default `true` in KoboSettings to ensure CBX files are converted by default
- Replace hardcoded EPUB-only filter with `koboCompatibilityService::isBookSupportedForKobo` check to respect the conversion setting
- Add test coverage for CBX book entitlements when conversion is enabled

## Why
Previously, CBX files were being filtered out during Kobo entitlements generation regardless of the conversion setting. By delegating to the compatibility service, we allow properly configured conversions to be processed for Kobo sync.