### PR TITLE
Use square covers for audiobook-only libraries

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.html
@@ -312,6 +312,7 @@
                         [isSeriesCollapsed]="seriesCollapseFilter.isSeriesCollapsed"
                         (checkboxClick)="onCheckboxClicked($event)"
                         [isSelected]="selectedBooks.has(book.id)"
+                        [useSquareCovers]="isAudiobookOnlyLibrary"
                         [overlayPreferenceService]="bookCardOverlayPreferenceService">
                       </app-book-card>
                     </div>

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.html
@@ -2,12 +2,12 @@
      [class.selected]="isSelected"
      (click)="onCardClick($event)">
 
-  <div class="cover-container" [ngClass]="{ 'center-info-btn': _isSeriesViewActive, 'loaded': isImageLoaded, 'audiobook-cover': _isAudiobook }">
+  <div class="cover-container" [ngClass]="{ 'center-info-btn': _isSeriesViewActive, 'loaded': isImageLoaded, 'audiobook-cover': _isAudiobook, 'square-library-cover': useSquareCovers }">
     <img
       [src]="coverImageUrl"
       class="book-cover"
       [class.loaded]="isImageLoaded"
-      [class.square-cover]="_isAudiobook"
+      [class.square-cover]="_isAudiobook || useSquareCovers"
       [alt]="('book.card.alt.cover' | transloco: { title: displayTitle })"
       loading="lazy"
       decoding="async"

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.scss
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.scss
@@ -56,6 +56,11 @@
   background-color: var(--surface-ground);
 }
 
+.cover-container.square-library-cover {
+  aspect-ratio: 1/1;
+  background-color: var(--surface-ground);
+}
+
 .book-cover {
   width: 100%;
   height: 100%;

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -53,6 +53,7 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
   @Input() isSeriesCollapsed: boolean = false;
   @Input() overlayPreferenceService?: BookCardOverlayPreferenceService;
   @Input() forceEbookMode: boolean = false;
+  @Input() useSquareCovers: boolean = false;
 
   @ViewChild('checkboxElem') checkboxElem!: ElementRef<HTMLInputElement>;
 
@@ -138,7 +139,7 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['book'] || changes['forceEbookMode']) {
+    if (changes['book'] || changes['forceEbookMode'] || changes['useSquareCovers']) {
       this.computeAllMemoizedValues();
       if (changes['book'] && !changes['book'].firstChange && this.menuInitialized) {
         this.additionalFilesLoaded = false;


### PR DESCRIPTION
When a library's allowed formats only includes audiobooks, the book browser now renders covers with a square aspect ratio instead of the default portrait 5:7. Card sizing in both desktop and mobile layouts adjusts accordingly so the squares don't look too tiny or too large relative to normal book cards.