### PR TITLE
Fix wrong icon on bookdrop finalize confirmation button

### DIFF
--- a/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.ts
+++ b/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.ts
@@ -426,6 +426,7 @@ export class BookdropFileReviewComponent implements OnInit {
         severity: 'success',
         outlined: true
       },
+      acceptIcon: 'pi pi-check',
       accept: () => this.finalizeImport(),
     });
   }


### PR DESCRIPTION
The finalize confirmation dialog was showing a trash can icon on the accept button because PrimeNG's ConfirmDialog defaults to that. Set it to a checkmark instead. Closes #2929.