### PR TITLE
Allow any file format for supplementary file uploads

### DIFF
--- a/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.html
+++ b/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.html
@@ -23,6 +23,7 @@
   <p-select
     [options]="fileTypeOptions"
     [(ngModel)]="fileType"
+    (ngModelChange)="onFileTypeChange()"
     optionLabel="label"
     optionValue="value"
     [placeholder]="t('selectFileType')"
@@ -34,7 +35,7 @@
   <p-fileupload class="file-upload" name="file"
     [customUpload]="true"
     [multiple]="false"
-    accept=".pdf,.epub,.cbz,.cbr,.cb7,.fb2,.mobi,.azw,.azw3,.m4b,.m4a,.mp3"
+    [accept]="acceptedFormats"
     (onSelect)="onFilesSelect($event)"
     (uploadHandler)="uploadFiles($event)"
     [disabled]="isUploading">
@@ -123,8 +124,13 @@
         <i class="pi pi-cloud-upload empty-icon"></i>
         <p class="empty-text">{{ t('dragDropText') }}</p>
         <p class="empty-subtext">
-          <span [innerHTML]="t('supportedFormats')"></span>
-          <br/>
+          @if (fileType === AdditionalFileType.ALTERNATIVE_FORMAT) {
+            <span [innerHTML]="t('supportedFormats')"></span>
+            <br/>
+          } @else {
+            <span>{{ t('supplementaryAllFormats') }}</span>
+            <br/>
+          }
           {{ t('maxFileSize', { size: maxFileSizeDisplay }) }}
         </p>
       </div>

--- a/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.ts
+++ b/booklore-ui/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectorRef, Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 
 import {FormsModule} from '@angular/forms';
 import {DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
@@ -48,11 +48,14 @@ export class AdditionalFileUploaderComponent implements OnInit, OnDestroy {
   files: UploadingFile[] = [];
   fileType: AdditionalFileType = AdditionalFileType.ALTERNATIVE_FORMAT;
   isUploading = false;
+  readonly AdditionalFileType = AdditionalFileType;
+  private static readonly BOOK_FORMAT_ACCEPT = '.pdf,.epub,.cbz,.cbr,.cb7,.fb2,.mobi,.azw,.azw3,.m4b,.m4a,.mp3';
   maxFileSizeBytes?: number;
   maxFileSizeDisplay: string = '100 MB';
 
   fileTypeOptions: FileTypeOption[] = [];
 
+  @ViewChild(FileUpload) private fileUpload!: FileUpload;
   private destroy$ = new Subject<void>();
 
   constructor(
@@ -87,6 +90,19 @@ export class AdditionalFileUploaderComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  onFileTypeChange(): void {
+    this.files = [];
+    if (this.fileUpload) {
+      this.fileUpload.clear();
+    }
+  }
+
+  get acceptedFormats(): string {
+    return this.fileType === AdditionalFileType.ALTERNATIVE_FORMAT
+      ? AdditionalFileUploaderComponent.BOOK_FORMAT_ACCEPT
+      : '';
   }
 
   hasPendingFiles(): boolean {

--- a/booklore-ui/src/i18n/en/book.json
+++ b/booklore-ui/src/i18n/en/book.json
@@ -445,6 +445,7 @@
     "statusFailed": "Failed",
     "dragDropText": "Drag and drop a file here to upload.",
     "supportedFormats": "Supported formats: <strong>.pdf</strong>, <strong>.epub</strong>, <strong>.cbz</strong>, <strong>.cbr</strong>, <strong>.cb7</strong>, <strong>.fb2</strong>, <strong>.mobi</strong>, <strong>.azw3</strong>, <strong>.m4b</strong>, <strong>.mp3</strong>",
+    "supplementaryAllFormats": "All file formats are supported for supplementary files.",
     "maxFileSize": "Maximum file size: {{ size }} per file",
     "uploadForBook": "Upload an additional file for <strong>{{ title }}</strong>.",
     "thisBook": "this book",

--- a/booklore-ui/src/i18n/es/book.json
+++ b/booklore-ui/src/i18n/es/book.json
@@ -445,6 +445,7 @@
     "statusFailed": "Fallido",
     "dragDropText": "Arrastre y suelte un archivo aquí para subir.",
     "supportedFormats": "Formatos compatibles: <strong>.pdf</strong>, <strong>.epub</strong>, <strong>.cbz</strong>, <strong>.cbr</strong>, <strong>.cb7</strong>, <strong>.fb2</strong>, <strong>.mobi</strong>, <strong>.azw3</strong>, <strong>.m4b</strong>, <strong>.mp3</strong>",
+    "supplementaryAllFormats": "Todos los formatos de archivo son compatibles con archivos complementarios.",
     "maxFileSize": "Tamaño máximo de archivo: {{ size }} por archivo",
     "uploadForBook": "Subir un archivo adicional para <strong>{{ title }}</strong>.",
     "thisBook": "este libro",


### PR DESCRIPTION
The file picker for supplementary uploads was locked to the same book formats (pdf, epub, cbz, etc.) as alternative format uploads. Supplementary files should accept anything since Booklore just needs to store and serve them back, not actually parse them. Now the accept filter is only applied when "Alternative Format" is selected, and switches to unrestricted when "Supplementary File" is picked. Also clears any selected file when toggling between the two types so you don't accidentally upload a mismatched file.

Closes #2940