### PR TITLE
Clamp ebook gap on load to fix blank pages for v1 upgraders

### DIFF
--- a/booklore-ui/src/app/features/readers/ebook-reader/state/reader-state.service.ts
+++ b/booklore-ui/src/app/features/readers/ebook-reader/state/reader-state.service.ts
@@ -122,7 +122,7 @@ export class ReaderStateService {
           newState.fontFamily = `custom:${(settings as any).customFontId}`;
         }
 
-        if (settings.gap != null) newState.gap = settings.gap;
+        if (settings.gap != null) newState.gap = Math.min(settings.gap, 0.5);
         if (settings.hyphenate != null) newState.hyphenate = settings.hyphenate;
         if (settings.justify != null) newState.justify = settings.justify;
         if (settings.maxColumnCount != null) newState.maxColumnCount = settings.maxColumnCount;


### PR DESCRIPTION
Users who adjusted column gap in v1 had values stored as integers (5, 10, 15...) since the old +/- buttons incremented by 5. In v2 gap is a decimal fraction (0.05 = 5%), so those old values get interpreted as 500%+ which produces negative column gaps in the paginator math, collapsing the layout to blank pages. This just clamps the gap to the valid max of 0.5 when loading settings from the API.

Fixes #2863