### PR TITLE
Fix filter counts being cut off in book filters

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.component.scss
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.component.scss
@@ -45,10 +45,10 @@
 }
 
 .filter-type-label {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 0.25rem;
-  max-width: 100%;
+  min-width: 0;
   overflow: hidden;
 }
 
@@ -56,8 +56,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex-shrink: 1;
-  max-width: 175px;
+  flex: 1;
+  min-width: 0;
 }
 
 .active-filter-count {


### PR DESCRIPTION
## Issue
Filter counts were being cut off and hidden in some filters due to improper flex layout handling.

## Solution
Adjusted the flexbox properties in `.filter-type-label` and `.active-filter-count` to properly handle text truncation and width constraints:

- Changed `display: inline-flex` to `display: flex` for proper container sizing
- Added `min-width: 0` to both containers to allow flex items to shrink below their content size
- Simplified `.active-filter-count` flex properties from `flex-shrink: 1; max-width: 175px` to `flex: 1; min-width: 0` for better flexibility

These changes ensure the filter count badge displays properly without being clipped, while maintaining text truncation with ellipsis when needed.

Fixes #2910