### PR TITLE
Fix bookdrop notification Hibernate NPE

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/enums/PermissionType.java
+++ b/booklore-api/src/main/java/org/booklore/model/enums/PermissionType.java
@@ -1,23 +1,33 @@
 package org.booklore.model.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum PermissionType {
-    ADMIN,
-    UPLOAD,
-    DOWNLOAD,
-    EDIT_METADATA,
-    MANAGE_LIBRARY,
-    EMAIL_BOOK,
-    DELETE_BOOK,
-    SYNC_KOREADER,
-    SYNC_KOBO,
-    ACCESS_OPDS,
-    MANAGE_METADATA_CONFIG,
-    ACCESS_BOOKDROP,
-    ACCESS_LIBRARY_STATS,
-    ACCESS_USER_STATS,
-    ACCESS_TASK_MANAGER,
-    MANAGE_GLOBAL_PREFERENCES,
-    MANAGE_ICONS,
-    MANAGE_FONTS,
-    DEMO_USER
+
+    ADMIN("permissionAdmin"),
+    UPLOAD("permissionUpload"),
+    DOWNLOAD("permissionDownload"),
+    EDIT_METADATA("permissionEditMetadata"),
+    MANAGE_LIBRARY("permissionManageLibrary"),
+    EMAIL_BOOK("permissionEmailBook"),
+    DELETE_BOOK("permissionDeleteBook"),
+    SYNC_KOREADER("permissionSyncKoreader"),
+    SYNC_KOBO("permissionSyncKobo"),
+    ACCESS_OPDS("permissionAccessOpds"),
+    MANAGE_METADATA_CONFIG("permissionManageMetadataConfig"),
+    ACCESS_BOOKDROP("permissionAccessBookdrop"),
+    ACCESS_LIBRARY_STATS("permissionAccessLibraryStats"),
+    ACCESS_USER_STATS("permissionAccessUserStats"),
+    ACCESS_TASK_MANAGER("permissionAccessTaskManager"),
+    MANAGE_GLOBAL_PREFERENCES("permissionManageGlobalPreferences"),
+    MANAGE_ICONS("permissionManageIcons"),
+    MANAGE_FONTS("permissionManageFonts"),
+    DEMO_USER("permissionDemoUser");
+
+    private final String entityField;
+
+    PermissionType(String entityField) {
+        this.entityField = entityField;
+    }
 }


### PR DESCRIPTION
The bookdrop file processor thread was calling userRepository.findAll() to figure out which users to notify, which loaded the full BookLoreUserEntity graph (eager libraries, settings, permissions, etc). Hibernate 7.x chokes on that entity initialization from a background thread, throwing a "loadedState is null" NPE. Replaced it with a lightweight JPQL query that just selects usernames based on permission flags, so the entity graph never gets loaded.

Closes #2978