### PR TITLE
Fix attach file without move when source/target have different library paths

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/BookController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/BookController.java
@@ -12,6 +12,7 @@ import org.booklore.model.dto.request.PersonalRatingUpdateRequest;
 import org.booklore.model.dto.request.ReadProgressRequest;
 import org.booklore.model.dto.request.ReadStatusUpdateRequest;
 import org.booklore.model.dto.request.ShelvesAssignmentRequest;
+import org.booklore.model.dto.response.AttachBookFileResponse;
 import org.booklore.model.dto.response.BookDeletionResponse;
 import org.booklore.model.dto.response.BookStatusUpdateResponse;
 import org.booklore.model.dto.response.DuplicateGroup;
@@ -285,7 +286,7 @@ public class BookController {
     })
     @PostMapping("/{targetBookId}/attach-file")
     @PreAuthorize("@securityUtil.canManageLibrary() or @securityUtil.isAdmin()")
-    public ResponseEntity<Book> attachBookFiles(
+    public ResponseEntity<AttachBookFileResponse> attachBookFiles(
             @Parameter(description = "ID of the target book to attach the files to") @PathVariable Long targetBookId,
             @Parameter(description = "Request containing source book IDs and delete option") @RequestBody @Valid AttachBookFileRequest request) {
         return ResponseEntity.ok(bookFileAttachmentService.attachBookFiles(targetBookId, request.getSourceBookIds(), request.isMoveFiles()));

--- a/booklore-api/src/main/java/org/booklore/model/dto/response/AttachBookFileResponse.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/response/AttachBookFileResponse.java
@@ -1,0 +1,7 @@
+package org.booklore.model.dto.response;
+
+import org.booklore.model.dto.Book;
+
+import java.util.List;
+
+public record AttachBookFileResponse(Book updatedBook, List<Long> deletedSourceBookIds) {}

--- a/booklore-ui/src/app/features/book/service/book-file.service.ts
+++ b/booklore-ui/src/app/features/book/service/book-file.service.ts
@@ -212,17 +212,17 @@ export class BookFileService {
     return this.http.post<DuplicateGroup[]>(`${this.url}/duplicates`, request);
   }
 
-  attachBookFiles(targetBookId: number, sourceBookIds: number[], moveFiles: boolean): Observable<Book> {
-    return this.http.post<Book>(`${this.url}/${targetBookId}/attach-file`, {
+  attachBookFiles(targetBookId: number, sourceBookIds: number[], moveFiles: boolean): Observable<{updatedBook: Book, deletedSourceBookIds: number[]}> {
+    return this.http.post<{updatedBook: Book, deletedSourceBookIds: number[]}>(`${this.url}/${targetBookId}/attach-file`, {
       sourceBookIds,
       moveFiles
     }).pipe(
-      tap(updatedBook => {
+      tap(response => {
         const currentState = this.bookStateService.getCurrentBookState();
-        const sourceIdSet = new Set(sourceBookIds);
+        const deletedIdSet = new Set(response.deletedSourceBookIds);
         let updatedBooks = (currentState.books || []).map(book =>
-          book.id === targetBookId ? updatedBook : book
-        ).filter(book => !sourceIdSet.has(book.id));
+          book.id === targetBookId ? response.updatedBook : book
+        ).filter(book => !deletedIdSet.has(book.id));
 
         this.bookStateService.updateBookState({
           ...currentState,


### PR DESCRIPTION
When attaching a book file without moving it, if the source and target books live under different library paths within the same library, the file's computed path ends up wrong after reassignment. This auto-upgrades to a file move in that case so the path stays correct. Also, the frontend was removing all source books from state after attach even if the backend only deleted the ones with zero remaining files. Now the response includes which source books were actually deleted so the UI only removes those.