### PR TITLE
Fix cover preview overlay stuck after mobile back gesture (#2958)

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -72,6 +72,7 @@ export class MetadataViewerComponent implements OnInit, OnChanges, AfterViewChec
   otherItems$!: Observable<MenuItem[]>;
   downloadMenuItems$!: Observable<MenuItem[]>;
   bookInSeries: Book[] = [];
+  @ViewChild(Image) private coverImage?: Image;
   @ViewChild('descriptionContent') descriptionContentRef?: ElementRef<HTMLElement>;
   isExpanded = false;
   isOverflowing = false;
@@ -104,6 +105,12 @@ export class MetadataViewerComponent implements OnInit, OnChanges, AfterViewChec
   navigationState$ = this.bookNavigationService.getNavigationState();
 
   ngOnInit(): void {
+    this.destroyRef.onDestroy(() => this.coverImage?.closePreview());
+
+    const onPopState = () => this.coverImage?.closePreview();
+    window.addEventListener('popstate', onPopState);
+    this.destroyRef.onDestroy(() => window.removeEventListener('popstate', onPopState));
+
     this.readMenuItems$ = this.book$.pipe(
       filter((book): book is Book => book !== null),
       map((book): MenuItem[] => {


### PR DESCRIPTION
On mobile, swiping back while the cover image preview was expanded would collapse the image but leave the toolbar controls (rotate, zoom, close) floating on screen. PrimeNG's Image component doesn't clean up its body-appended overlay on destroy or on popstate. Added a ViewChild ref to call closePreview() on both component destroy and popstate events.

Fixes #2958