### PR TITLE
fix(http): enable restricted headers for DNS rebinding protection and improve host header handling

### DIFF
--- a/booklore-api/src/main/java/org/booklore/BookloreApplication.java
+++ b/booklore-api/src/main/java/org/booklore/BookloreApplication.java
@@ -14,6 +14,10 @@ import org.booklore.config.BookmarkProperties;
 @SpringBootApplication
 public class BookloreApplication {
 
+    static {
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+    }
+
     public static void main(String[] args) {
         SpringApplication.run(BookloreApplication.class, args);
     }

--- a/booklore-api/src/main/java/org/booklore/config/security/SecurityConfig.java
+++ b/booklore-api/src/main/java/org/booklore/config/security/SecurityConfig.java
@@ -262,8 +262,11 @@ public class SecurityConfig {
                     protected void prepareConnection(HttpURLConnection connection, String httpMethod) throws IOException {
                         super.prepareConnection(connection, httpMethod);
                         connection.setInstanceFollowRedirects(false);
+                        String targetHost = FileService.getTargetHost();
+                        if (targetHost != null) {
+                            connection.setRequestProperty("Host", targetHost);
+                        }
                         if (connection instanceof HttpsURLConnection httpsConnection) {
-                            String targetHost = FileService.getTargetHost();
                             if (targetHost != null) {
                                 // Set original host for SNI (even if connecting to IP)
                                 SSLSocketFactory defaultFactory = httpsConnection.getSSLSocketFactory();

--- a/booklore-api/src/main/java/org/booklore/util/FileService.java
+++ b/booklore-api/src/main/java/org/booklore/util/FileService.java
@@ -57,11 +57,6 @@ public class FileService {
         TARGET_HOST_THREAD_LOCAL.remove();
     }
 
-    static {
-        // Enable restricted headers to allow 'Host' header override for DNS rebinding protection
-        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
-    }
-
     private final AppProperties appProperties;
     private final RestTemplate restTemplate;
     private final AppSettingService appSettingService;


### PR DESCRIPTION
## 📝 Description


The Issue: Users were encountering intermittent 500 errors when downloading Amazon cover images. This happened because Java's HttpURLConnection was silently dropping our custom Host header.

We set sun.net.http.allowRestrictedHeaders=true in FileService's static initializer to allow custom headers. However, HttpURLConnection caches this property during its own static initialization. If HttpURLConnection happened to load before FileService, it cached the value as false. This stripped the Host: m.media-amazon.com header, leaving CloudFront with the raw IP address (e.g., 99.84.94.36) and triggering a 500 error.

This specifically happened only with Amazon other providers seem to be unaffected by the bug.


<!-- Why is this change needed? Explain in your own words. -->

**Linked Issue:** Fixes # (it was reported via Discord, so not GH ticket.) 
> **Required.** Every PR must reference an approved issue. If no issue exists, [open one](https://github.com/booklore-app/booklore/issues/new) and wait for maintainer approval before submitting a PR. Unsolicited PRs without a linked issue will be closed.

## 🏷️ Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor (no behavior change)
- [ ] Breaking change (existing functionality affected)
- [ ] Documentation update

## 🔧 Changes

<!-- List the specific modifications made -->

* Moved the setting of the system property `sun.net.http.allowRestrictedHeaders` from a static block in `FileService` to a static block in the `BookloreApplication` class, centralizing configuration at application startup.
* Updated the `noRedirectRestTemplate` method in `SecurityConfig` to always set the `Host` header if a `targetHost` is present, regardless of whether the connection is HTTP or HTTPS, ensuring correct header usage for all outgoing requests.

## 🧪 Testing (MANDATORY)

> **PRs without this section filled out will be closed.** "Tests pass" or "Tested locally" is not sufficient. You must provide specifics.

**Manual testing steps you performed:**
<!-- Walk through the exact steps you took to verify your change works. Be specific. -->
1. Tested several covers with Amazon cover search
2.
3.

**Regression testing:**
<!-- How did you verify that existing related features still work after your change? -->
-

**Edge cases covered:**
<!-- What boundary conditions or unusual inputs did you test? -->
-

**Test output:**
<!-- Paste the actual terminal output from running tests. Not "all pass", the real output. -->

<details>
<summary>Backend test output (<code>./gradlew test</code>)</summary>

```
bszuc@brios:~/booklore/booklore-api$ ./gradlew clean test

> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
Management of bidirectional association persistent attributes is deprecated and will be removed. Set the value to 'false' to get rid of this warning

> Task :compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction (file:/home/bszuc/.gradle/caches/modules-2/files-2.1/net.bytebuddy/byte-buddy/1.17.8/af5735f63d00ca47a9375fae5c7471a36331c6ed/byte-buddy-1.17.8.jar)
WARNING: Please consider reporting this to the maintainers of class net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
2026-02-26T15:14:37.845+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.s.m.s.b.SimpleBrokerMessageHandler     : Stopping...
2026-02-26T15:14:37.846+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.s.m.s.b.SimpleBrokerMessageHandler     : BrokerAvailabilityEvent[available=false, SimpleBrokerMessageHandler [org.springframework.messaging.simp.broker.DefaultSubscriptionRegistry@16d924cf]]
2026-02-26T15:14:37.846+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.s.m.s.b.SimpleBrokerMessageHandler     : Stopped.
2026-02-26T15:14:37.859+01:00  INFO 353279 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-26T15:14:37.860+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-26T15:14:38.371+01:00  INFO 353279 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-26T15:14:38.373+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-26T15:14:38.373+01:00  WARN 353279 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-26T15:14:38.373+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-26T15:14:38.384+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-26T15:14:38.408+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-26T15:14:38.409+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-26T15:14:38.414+01:00  INFO 353279 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-26T15:14:38.414+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-26T15:14:38.414+01:00  INFO 353279 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-26T15:14:38.416+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-26T15:14:38.416+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-26T15:14:38.416+01:00  WARN 353279 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-26T15:14:38.423+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-26T15:14:38.425+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-26T15:14:38.426+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-26T15:14:38.431+01:00  INFO 353279 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-26T15:14:38.431+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-26T15:14:38.432+01:00  INFO 353279 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-26T15:14:38.433+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-26T15:14:38.433+01:00  WARN 353279 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-26T15:14:38.433+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-26T15:14:38.439+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-26T15:14:38.452+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-26T15:14:38.453+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-26T15:14:38.458+01:00  INFO 353279 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-26T15:14:38.458+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-26T15:14:38.458+01:00  INFO 353279 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-26T15:14:38.459+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-26T15:14:38.460+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-26T15:14:38.460+01:00  WARN 353279 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-26T15:14:38.467+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-26T15:14:38.477+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-26T15:14:38.478+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-26T15:14:38.482+01:00  INFO 353279 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-26T15:14:38.482+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-26T15:14:38.483+01:00  INFO 353279 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-26T15:14:38.483+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-26T15:14:38.484+01:00  WARN 353279 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-26T15:14:38.484+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-26T15:14:38.491+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-26T15:14:38.501+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-26T15:14:38.501+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-26T15:14:38.506+01:00  INFO 353279 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-26T15:14:38.506+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-26T15:14:38.507+01:00  INFO 353279 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-26T15:14:38.508+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-26T15:14:38.508+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-26T15:14:38.508+01:00  WARN 353279 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-26T15:14:38.514+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-26T15:14:38.525+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-26T15:14:38.525+01:00  INFO 353279 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.

[Incubating] Problems report is available at: file:///home/bszuc/booklore/booklore-api/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 2m 26s
7 actionable tasks: 7 executed
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.3.1/userguide/configuration_cache_enabling.html
bszuc@brios:~/booklore/booklore-api$ 
```

</details>

<details>
<summary>Frontend test output (<code>ng test</code>)</summary>

```
bszuc@brios:~/booklore/booklore-ui$ npm run test

> booklore@0.0.0 test
> ng test

Using Vitest configuration file: /home/bszuc/booklore/booklore-ui/vitest-base.config.ts
Initial chunk files                                                            | Names                                                                       |  Raw size
spec-app-features-magic-shelf-component-magic-shelf-component.js               | spec-app-features-magic-shelf-component-magic-shelf-component               |   1.09 MB | 
spec-app-features-magic-shelf-service-book-rule-evaluator.service.js           | spec-app-features-magic-shelf-service-book-rule-evaluator.service           |  65.08 kB | 
spec-app-app.component.js                                                      | spec-app-app.component                                                      |  58.63 kB | 
chunk-AD2BXOLH.js                                                              | -                                                                           |  53.30 kB | 
styles.css                                                                     | styles                                                                      |  30.99 kB | 
chunk-NM2JNTGJ.js                                                              | -                                                                           |  24.50 kB | 
spec-app-features-magic-shelf-service-book-rule-evaluator-metadata-presence.js | spec-app-features-magic-shelf-service-book-rule-evaluator-metadata-presence |  23.21 kB | 
chunk-ZRYX4BS5.js                                                              | -                                                                           |  15.97 kB | 
spec-app-features-magic-shelf-service-magic-shelf-utils.js                     | spec-app-features-magic-shelf-service-magic-shelf-utils                     |  11.36 kB | 
spec-app-core-security-auth-initializer.js                                     | spec-app-core-security-auth-initializer                                     |   8.69 kB | 
chunk-PUIDBMXW.js                                                              | -                                                                           |   6.10 kB | 
chunk-Y7BNZHZM.js                                                              | -                                                                           |   4.86 kB | 
chunk-3J3QIHZF.js                                                              | -                                                                           |   2.19 kB | 
chunk-HPNCK62B.js                                                              | -                                                                           |   1.33 kB | 
init-testbed.js                                                                | init-testbed                                                                |   1.27 kB | 
spec-app-app.js                                                                | spec-app-app                                                                | 202 bytes | 
polyfills.js                                                                   | polyfills                                                                   | 121 bytes | 

                                                                               | Initial total                                                               |   1.40 MB

Application bundle generation complete. [9.043 seconds] - 2026-02-26T14:12:22.854Z

Watch mode enabled. Watching for file changes...

 DEV  v4.0.18 /home/bszuc/booklore/booklore-ui
```

</details>

## 📸 Screen Recording / Screenshots (MANDATORY)

> Every PR must include a **screen recording or screenshots** showing the change working end-to-end in a running local instance (both backend and frontend). This means you must have actually built, run, and tested the code yourself. PRs without visual proof will be closed without review.

<!-- Attach screen recording or screenshots here -->

---

## ✅ Pre-Submission Checklist

> **All boxes must be checked before requesting review.** Incomplete PRs will be closed without review. No exceptions.

- [X] This PR is linked to an approved issue
- [X] Code follows project style guidelines and conventions
- [X] Branch is up to date with `develop` (merge conflicts resolved)
- [X] I ran the full stack locally (backend + frontend + database) and verified the change works
- [X] Automated tests added or updated to cover changes (backend **and** frontend)
- [X] All tests pass locally and output is pasted above
- [X] Screen recording or screenshots are attached above proving the change works
- [X] PR is a single focused change (one bug fix OR one feature, not multiple unrelated changes)
- [X] PR is reasonably scoped (PRs over 1000+ changed lines will be closed, split into smaller PRs)
- [X] No unsolicited refactors, cleanups, or "improvements" are bundled in
- [ ] Flyway migration versioning is correct _(if schema was modified)_
- [ ] Documentation PR submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(if user-facing changes)_

### 🤖 AI-Assisted Contributions

> **If any part of this PR was generated or assisted by AI tools (Copilot, Claude, ChatGPT, etc.), all items below are mandatory.** You are fully responsible for every line you submit. "The AI wrote it" is not an excuse, and AI-generated PRs that clearly haven't been reviewed are the #1 reason PRs get closed.

- [ ] I have read and understand every line of this PR and can explain any part of it during review
- [ ] I personally ran the code and verified it works (not just trusted the AI's output)
- [ ] PR is scoped to a single logical change, not a dump of everything the AI suggested
- [ ] Tests validate actual behavior, not just coverage (AI-generated tests often assert nothing meaningful)
- [ ] No dead code, placeholder comments, `TODO`s, or unused scaffolding left behind by AI
- [ ] I did not submit refactors, style changes, or "improvements" the AI suggested beyond the scope of the issue

---

## 💬 Additional Context _(optional)_

<!-- Any extra information or discussion points for reviewers -->
