### PR TITLE
Fix trailing spaces in metadata fields (#1390)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/entity/BookMetadataEntity.java
+++ b/booklore-api/src/main/java/org/booklore/model/entity/BookMetadataEntity.java
@@ -322,7 +322,35 @@ public class BookMetadataEntity {
     @PrePersist
     @PreUpdate
     public void updateSearchText() {
+        trimStringFields();
         this.searchText = BookUtils.buildSearchText(this);
+    }
+
+    private void trimStringFields() {
+        this.title = trimOrNull(this.title);
+        this.subtitle = trimOrNull(this.subtitle);
+        this.publisher = trimOrNull(this.publisher);
+        this.seriesName = trimOrNull(this.seriesName);
+        this.language = trimOrNull(this.language);
+        this.isbn13 = trimOrNull(this.isbn13);
+        this.isbn10 = trimOrNull(this.isbn10);
+        this.asin = trimOrNull(this.asin);
+        this.goodreadsId = trimOrNull(this.goodreadsId);
+        this.hardcoverId = trimOrNull(this.hardcoverId);
+        this.hardcoverBookId = trimOrNull(this.hardcoverBookId);
+        this.googleId = trimOrNull(this.googleId);
+        this.comicvineId = trimOrNull(this.comicvineId);
+        this.lubimyczytacId = trimOrNull(this.lubimyczytacId);
+        this.ranobedbId = trimOrNull(this.ranobedbId);
+        this.audibleId = trimOrNull(this.audibleId);
+        this.contentRating = trimOrNull(this.contentRating);
+        this.narrator = trimOrNull(this.narrator);
+    }
+
+    private static String trimOrNull(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/booklore-api/src/main/resources/db/migration/V125__Trim_whitespace_in_book_metadata.sql
+++ b/booklore-api/src/main/resources/db/migration/V125__Trim_whitespace_in_book_metadata.sql
@@ -1,0 +1,21 @@
+-- Trim leading/trailing whitespace from string columns in book_metadata.
+-- Blank-after-trim values are set to NULL to avoid empty-string duplicates.
+
+UPDATE book_metadata SET title = NULLIF(TRIM(title), '') WHERE title IS NOT NULL AND title != TRIM(title);
+UPDATE book_metadata SET subtitle = NULLIF(TRIM(subtitle), '') WHERE subtitle IS NOT NULL AND subtitle != TRIM(subtitle);
+UPDATE book_metadata SET publisher = NULLIF(TRIM(publisher), '') WHERE publisher IS NOT NULL AND publisher != TRIM(publisher);
+UPDATE book_metadata SET series_name = NULLIF(TRIM(series_name), '') WHERE series_name IS NOT NULL AND series_name != TRIM(series_name);
+UPDATE book_metadata SET language = NULLIF(TRIM(language), '') WHERE language IS NOT NULL AND language != TRIM(language);
+UPDATE book_metadata SET isbn_13 = NULLIF(TRIM(isbn_13), '') WHERE isbn_13 IS NOT NULL AND isbn_13 != TRIM(isbn_13);
+UPDATE book_metadata SET isbn_10 = NULLIF(TRIM(isbn_10), '') WHERE isbn_10 IS NOT NULL AND isbn_10 != TRIM(isbn_10);
+UPDATE book_metadata SET asin = NULLIF(TRIM(asin), '') WHERE asin IS NOT NULL AND asin != TRIM(asin);
+UPDATE book_metadata SET goodreads_id = NULLIF(TRIM(goodreads_id), '') WHERE goodreads_id IS NOT NULL AND goodreads_id != TRIM(goodreads_id);
+UPDATE book_metadata SET hardcover_id = NULLIF(TRIM(hardcover_id), '') WHERE hardcover_id IS NOT NULL AND hardcover_id != TRIM(hardcover_id);
+UPDATE book_metadata SET hardcover_book_id = NULLIF(TRIM(hardcover_book_id), '') WHERE hardcover_book_id IS NOT NULL AND hardcover_book_id != TRIM(hardcover_book_id);
+UPDATE book_metadata SET google_id = NULLIF(TRIM(google_id), '') WHERE google_id IS NOT NULL AND google_id != TRIM(google_id);
+UPDATE book_metadata SET comicvine_id = NULLIF(TRIM(comicvine_id), '') WHERE comicvine_id IS NOT NULL AND comicvine_id != TRIM(comicvine_id);
+UPDATE book_metadata SET lubimyczytac_id = NULLIF(TRIM(lubimyczytac_id), '') WHERE lubimyczytac_id IS NOT NULL AND lubimyczytac_id != TRIM(lubimyczytac_id);
+UPDATE book_metadata SET ranobedb_id = NULLIF(TRIM(ranobedb_id), '') WHERE ranobedb_id IS NOT NULL AND ranobedb_id != TRIM(ranobedb_id);
+UPDATE book_metadata SET audible_id = NULLIF(TRIM(audible_id), '') WHERE audible_id IS NOT NULL AND audible_id != TRIM(audible_id);
+UPDATE book_metadata SET content_rating = NULLIF(TRIM(content_rating), '') WHERE content_rating IS NOT NULL AND content_rating != TRIM(content_rating);
+UPDATE book_metadata SET narrator = NULLIF(TRIM(narrator), '') WHERE narrator IS NOT NULL AND narrator != TRIM(narrator);

--- a/booklore-api/src/test/java/org/booklore/model/entity/BookMetadataEntityTest.java
+++ b/booklore-api/src/test/java/org/booklore/model/entity/BookMetadataEntityTest.java
@@ -68,6 +68,95 @@ class BookMetadataEntityTest {
     }
 
     @Test
+    void updateSearchText_trimsLeadingAndTrailingWhitespace() {
+        BookMetadataEntity metadata = new BookMetadataEntity();
+        metadata.setTitle("  The Snowman  ");
+        metadata.setSubtitle("  A Mystery  ");
+        metadata.setPublisher("  Harvill Secker  ");
+        metadata.setSeriesName("  Harry Hole  ");
+        metadata.setLanguage("  en  ");
+        metadata.setIsbn13("  9780099520276  ");
+        metadata.setIsbn10("  0099520273  ");
+        metadata.setAsin("  B003GK21A8  ");
+        metadata.setGoodreadsId("  12345  ");
+        metadata.setHardcoverId("  hc-1  ");
+        metadata.setHardcoverBookId("  hcb-1  ");
+        metadata.setGoogleId("  g-1  ");
+        metadata.setComicvineId("  cv-1  ");
+        metadata.setLubimyczytacId("  lub-1  ");
+        metadata.setRanobedbId("  ran-1  ");
+        metadata.setAudibleId("  aud-1  ");
+        metadata.setContentRating("  PG-13  ");
+        metadata.setNarrator("  John Smith  ");
+
+        metadata.updateSearchText();
+
+        assertEquals("The Snowman", metadata.getTitle());
+        assertEquals("A Mystery", metadata.getSubtitle());
+        assertEquals("Harvill Secker", metadata.getPublisher());
+        assertEquals("Harry Hole", metadata.getSeriesName());
+        assertEquals("en", metadata.getLanguage());
+        assertEquals("9780099520276", metadata.getIsbn13());
+        assertEquals("0099520273", metadata.getIsbn10());
+        assertEquals("B003GK21A8", metadata.getAsin());
+        assertEquals("12345", metadata.getGoodreadsId());
+        assertEquals("hc-1", metadata.getHardcoverId());
+        assertEquals("hcb-1", metadata.getHardcoverBookId());
+        assertEquals("g-1", metadata.getGoogleId());
+        assertEquals("cv-1", metadata.getComicvineId());
+        assertEquals("lub-1", metadata.getLubimyczytacId());
+        assertEquals("ran-1", metadata.getRanobedbId());
+        assertEquals("aud-1", metadata.getAudibleId());
+        assertEquals("PG-13", metadata.getContentRating());
+        assertEquals("John Smith", metadata.getNarrator());
+    }
+
+    @Test
+    void updateSearchText_blanksAndWhitespaceOnlyBecomeNull() {
+        BookMetadataEntity metadata = new BookMetadataEntity();
+        metadata.setTitle("Valid Title");
+        metadata.setSubtitle("   ");
+        metadata.setPublisher("");
+        metadata.setSeriesName("  \t  ");
+        metadata.setLanguage("  ");
+        metadata.setNarrator("\t");
+
+        metadata.updateSearchText();
+
+        assertEquals("Valid Title", metadata.getTitle());
+        assertNull(metadata.getSubtitle());
+        assertNull(metadata.getPublisher());
+        assertNull(metadata.getSeriesName());
+        assertNull(metadata.getLanguage());
+        assertNull(metadata.getNarrator());
+    }
+
+    @Test
+    void updateSearchText_preservesNulls() {
+        BookMetadataEntity metadata = new BookMetadataEntity();
+        metadata.setTitle("Valid Title");
+
+        metadata.updateSearchText();
+
+        assertEquals("Valid Title", metadata.getTitle());
+        assertNull(metadata.getSubtitle());
+        assertNull(metadata.getPublisher());
+        assertNull(metadata.getSeriesName());
+        assertNull(metadata.getNarrator());
+    }
+
+    @Test
+    void updateSearchText_doesNotTrimDescription() {
+        BookMetadataEntity metadata = new BookMetadataEntity();
+        metadata.setTitle("Valid Title");
+        metadata.setDescription("  Some description with leading/trailing spaces  ");
+
+        metadata.updateSearchText();
+
+        assertEquals("  Some description with leading/trailing spaces  ", metadata.getDescription());
+    }
+
+    @Test
     void searchSimulation_withDiacritics() {
         BookMetadataEntity metadata = new BookMetadataEntity();
         metadata.setTitle("The Bat");


### PR DESCRIPTION
Metadata fields like language and series name could end up with trailing/leading whitespace from various import paths, causing duplicate entries in the metadata manager and merge failures. Instead of patching each extractor, this trims all string fields in BookMetadataEntity's @PrePersist/@PreUpdate hook so it catches everything regardless of how metadata gets in. Also includes a flyway migration to clean up existing rows.

Fixes #1390