### PR TITLE
Disable horizontal swipe navigation in CBX infinite/long strip scroll modes (#2977)

### DIFF
--- a/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -997,6 +997,8 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
   }
 
   private handleSwipeGesture() {
+    if (this.scrollMode === CbxScrollMode.INFINITE || this.scrollMode === CbxScrollMode.LONG_STRIP) return;
+
     const delta = this.touchEndX - this.touchStartX;
     if (Math.abs(delta) >= 50) {
       // In RTL mode, swipe directions are reversed


### PR DESCRIPTION
In the CBX reader, horizontal swipes were triggering nextPage()/previousPage() even in infinite and long strip scroll modes, which don't have discrete pages to navigate between. Now swipe gestures are skipped entirely in those modes.