### PR TITLE
use app-tag component with operation-based colors for audit log actions

### DIFF
--- a/booklore-ui/src/app/features/settings/audit-logs/audit-logs.component.html
+++ b/booklore-ui/src/app/features/settings/audit-logs/audit-logs.component.html
@@ -78,7 +78,7 @@
             <tr>
               <th style="width: 120px">{{ t('columns.timestamp') }}</th>
               <th style="width: 100px">{{ t('columns.user') }}</th>
-              <th style="width: 140px">{{ t('columns.action') }}</th>
+              <th style="width: 200px">{{ t('columns.action') }}</th>
               <th>{{ t('columns.description') }}</th>
               <th style="width: 160px">{{ t('columns.ip') }}</th>
             </tr>
@@ -91,9 +91,9 @@
               </td>
               <td>{{ log.username }}</td>
               <td>
-                <span class="action-badge" [ngClass]="getActionClass(log.action)">
+                <app-tag [color]="getActionColor(log.action)" size="2xs" [rounded]="true">
                   {{ formatAction(log.action) }}
-                </span>
+                </app-tag>
               </td>
               <td class="description-cell"
                   [class.expanded]="expandedRows.has(log.id)"

--- a/booklore-ui/src/app/features/settings/audit-logs/audit-logs.component.scss
+++ b/booklore-ui/src/app/features/settings/audit-logs/audit-logs.component.scss
@@ -86,35 +86,6 @@
   table-layout: fixed;
 }
 
-.action-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.125rem 0.5rem;
-  border-radius: 12px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  white-space: nowrap;
-
-  &.action-danger {
-    background: color-mix(in srgb, var(--p-red-500) 15%, transparent);
-    color: var(--p-red-400);
-  }
-
-  &.action-success {
-    background: color-mix(in srgb, var(--p-green-500) 15%, transparent);
-    color: var(--p-green-400);
-  }
-
-  &.action-info {
-    background: color-mix(in srgb, var(--p-primary-color) 15%, transparent);
-    color: var(--p-primary-color);
-  }
-
-  &.action-warning {
-    background: color-mix(in srgb, var(--p-orange-500) 15%, transparent);
-    color: var(--p-orange-400);
-  }
-}
 
 .timestamp-cell {
   white-space: nowrap;

--- a/booklore-ui/src/app/features/settings/audit-logs/audit-logs.component.ts
+++ b/booklore-ui/src/app/features/settings/audit-logs/audit-logs.component.ts
@@ -8,6 +8,24 @@ import {FormsModule} from '@angular/forms';
 import {TranslocoDirective} from '@jsverse/transloco';
 import {Subscription, interval} from 'rxjs';
 import {AuditLog, AuditLogService} from './audit-log.service';
+import {TagColor, TagComponent} from '../../../shared/components/tag/tag.component';
+
+const ACTION_COLOR_GROUPS: [TagColor, string[]][] = [
+  ['red', ['USER_DELETED', 'LIBRARY_DELETED', 'BOOK_DELETED', 'SHELF_DELETED', 'MAGIC_SHELF_DELETED', 'EMAIL_PROVIDER_DELETED', 'OPDS_USER_DELETED', 'AUTHOR_DELETED']],
+  ['green', ['USER_CREATED', 'LIBRARY_CREATED', 'BOOK_UPLOADED', 'SHELF_CREATED', 'MAGIC_SHELF_CREATED', 'EMAIL_PROVIDER_CREATED', 'OPDS_USER_CREATED', 'LOGIN_SUCCESS']],
+  ['blue', ['USER_UPDATED', 'LIBRARY_UPDATED', 'SHELF_UPDATED', 'MAGIC_SHELF_UPDATED', 'EMAIL_PROVIDER_UPDATED', 'OPDS_USER_UPDATED']],
+  ['purple', ['METADATA_UPDATED', 'AUTHOR_METADATA_UPDATED']],
+  ['orange', ['SETTINGS_UPDATED', 'OIDC_CONFIG_CHANGED', 'NAMING_PATTERN_CHANGED']],
+  ['amber', ['PASSWORD_CHANGED', 'PERMISSIONS_CHANGED']],
+  ['fuchsia', ['LOGIN_FAILED']],
+  ['pink', ['LOGIN_RATE_LIMITED', 'REFRESH_RATE_LIMITED']],
+  ['teal', ['LIBRARY_SCANNED', 'BOOK_SENT', 'BOOK_FILE_DETACHED', 'DUPLICATE_BOOKS_MERGED']],
+  ['indigo', ['TASK_EXECUTED']],
+];
+
+const ACTION_COLOR_MAP = new Map<string, TagColor>(
+  ACTION_COLOR_GROUPS.flatMap(([color, actions]) => actions.map(a => [a, color]))
+);
 
 interface ActionOption {
   label: string;
@@ -22,7 +40,7 @@ interface UsernameOption {
 @Component({
   selector: 'app-audit-logs',
   standalone: true,
-  imports: [CommonModule, TableModule, Select, DatePicker, FormsModule, TranslocoDirective],
+  imports: [CommonModule, TableModule, Select, DatePicker, FormsModule, TranslocoDirective, TagComponent],
   templateUrl: './audit-logs.component.html',
   styleUrl: './audit-logs.component.scss'
 })
@@ -77,6 +95,12 @@ export class AuditLogsComponent implements OnInit, OnDestroy {
     {label: 'OPDS User Deleted', value: 'OPDS_USER_DELETED'},
     {label: 'OPDS User Updated', value: 'OPDS_USER_UPDATED'},
     {label: 'Naming Pattern Changed', value: 'NAMING_PATTERN_CHANGED'},
+    {label: 'Login Rate Limited', value: 'LOGIN_RATE_LIMITED'},
+    {label: 'Refresh Rate Limited', value: 'REFRESH_RATE_LIMITED'},
+    {label: 'Duplicate Books Merged', value: 'DUPLICATE_BOOKS_MERGED'},
+    {label: 'Book File Detached', value: 'BOOK_FILE_DETACHED'},
+    {label: 'Author Metadata Updated', value: 'AUTHOR_METADATA_UPDATED'},
+    {label: 'Author Deleted', value: 'AUTHOR_DELETED'},
   ];
 
   currentPage = 0;
@@ -199,11 +223,8 @@ export class AuditLogsComponent implements OnInit, OnDestroy {
     return action.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()).replace(/\B\w+/g, c => c.toLowerCase());
   }
 
-  getActionClass(action: string): string {
-    if (action.includes('FAILED') || action.includes('DELETED')) return 'action-danger';
-    if (action.includes('CREATED') || action.includes('SUCCESS') || action.includes('UPLOADED')) return 'action-success';
-    if (action.includes('OIDC') || action.includes('PERMISSIONS')) return 'action-warning';
-    return 'action-info';
+  getActionColor(action: string): TagColor {
+    return ACTION_COLOR_MAP.get(action) ?? 'gray';
   }
 
   private restoreFromQueryParams(): void {


### PR DESCRIPTION
Swaps the old CSS-class badges in the audit log table for the shared app-tag component and remaps colors by operation type instead of domain. Deletes are red, creates are green, updates are blue, metadata is purple, etc. Also widens the action column a bit and adds the missing action filter options (rate limited, author deleted, book file detached, etc.).