### PR TITLE
Fix sort resetting to default when toggling series collapse (#2991)

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser-query-params.service.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser-query-params.service.ts
@@ -287,7 +287,7 @@ export class BookBrowserQueryParamsService {
     }
 
     const currentParams = this.activatedRoute.snapshot.queryParams;
-    const changed = Object.keys(queryParams).some(k => currentParams[k] !== queryParams[k]);
+    const changed = Object.keys(queryParams).some(k => (queryParams[k] ?? undefined) !== (currentParams[k] ?? undefined));
 
     if (changed) {
       const mergedParams = {...currentParams, ...queryParams};

--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -470,8 +470,13 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
       this.visibleSortOptions = visibleFields.map(f => sortOptionsByField.get(f)).filter((o): o is SortOption => !!o);
 
 
-      // Only update sort criteria if they actually changed to avoid resetting popover/CDK state
-      if (!this.areSortCriteriaEqual(this.bookSorter.selectedSortCriteria, parseResult.sortCriteria)) {
+      // Only update sort criteria if they actually changed to avoid resetting popover/CDK state.
+      // Skip preference-based sort re-derivation when sort is already established (prevents
+      // userState$ emissions from non-sort preference changes like seriesCollapsed from
+      // resetting the sort during the race window before syncQueryParams writes to URL).
+      const sortFromUrl = !!queryParamMap.get('sort');
+      const sortNotYetEstablished = this.bookSorter.selectedSortCriteria.length === 0;
+      if ((sortFromUrl || sortNotYetEstablished) && !this.areSortCriteriaEqual(this.bookSorter.selectedSortCriteria, parseResult.sortCriteria)) {
         this.bookSorter.setSortCriteria(parseResult.sortCriteria);
       }
       this.currentViewMode = parseResult.viewMode;


### PR DESCRIPTION
Toggling series collapse was firing a userState$ emission that re-derived the sort from preferences before the current sort had been written to the URL, so it'd snap back to the default. Now the sort criteria only get updated from preferences on initial load, after that it's driven by the URL.

Fixes #2991