### PR TITLE
Fix bookdrop metadata picker bugs

### DIFF
--- a/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
+++ b/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
@@ -2,41 +2,41 @@
 @if (fetchedMetadata && fetchedMetadata.title) {
   <form [formGroup]="metadataForm" class="metapicker">
     <div class="form-scroll">
-      <div class="metaheader">
-        <label class="field-label"></label>
-        <div class="header-fields-row">
-          <p class="header-column">{{ t('fileData') }}</p>
-          <div class="midbuttons">
-            <p-button
-              size="small"
-              icon="pi pi-angle-left"
-              class="btn-margin"
-              [outlined]="true"
-              [pTooltip]="t('copyMissingTooltip')"
-              tooltipPosition="bottom"
-              (onClick)="copyMissing()"
-            ></p-button>
-            <p-button
-              size="small"
-              icon="pi pi-angle-double-left"
-              class="btn-margin"
-              [outlined]="true"
-              [pTooltip]="t('overwriteAllTooltip')"
-              tooltipPosition="bottom"
-              (onClick)="copyAll()"
-            ></p-button>
-            <p-button
-              size="small"
-              severity="warn"
-              icon="pi pi-refresh"
-              class="btn-margin"
-              [outlined]="true"
-              [pTooltip]="t('resetAllTooltip')"
-              tooltipPosition="bottom"
-              (onClick)="confirmReset()"
-            ></p-button>
-          </div>
-          <p class="header-column">{{ t('fetchedData') }}</p>
+      <div class="column-headers">
+        <div class="column-label current">
+          <span>{{ t('fileData') }}</span>
+        </div>
+        <div class="column-actions">
+          <button
+            type="button"
+            class="p-button p-button-outlined p-button-sm p-button-icon-only"
+            [pTooltip]="t('copyMissingTooltip')"
+            tooltipPosition="bottom"
+            (click)="copyMissing()"
+          >
+            <span class="p-button-icon pi pi-angle-left"></span>
+          </button>
+          <button
+            type="button"
+            class="p-button p-button-outlined p-button-sm p-button-icon-only"
+            [pTooltip]="t('overwriteAllTooltip')"
+            tooltipPosition="bottom"
+            (click)="copyAll()"
+          >
+            <span class="p-button-icon pi pi-angle-double-left"></span>
+          </button>
+          <button
+            type="button"
+            class="p-button p-button-outlined p-button-sm p-button-icon-only p-button-warn"
+            [pTooltip]="t('resetAllTooltip')"
+            tooltipPosition="bottom"
+            (click)="confirmReset()"
+          >
+            <span class="p-button-icon pi pi-refresh"></span>
+          </button>
+        </div>
+        <div class="column-label fetched">
+          <span>{{ t('fetchedData') }}</span>
         </div>
       </div>
       <div class="metacontent">

--- a/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.scss
+++ b/booklore-ui/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.scss
@@ -93,18 +93,45 @@ textarea.changed,
   width: 8rem;
 }
 
-.header-fields-row {
+.column-headers {
   display: flex;
-  width: 100%;
   align-items: center;
-}
+  padding: 1rem;
+  border-bottom: 1px dotted var(--border-color);
 
-.header-column {
-  width: 50%;
-}
+  @media (min-width: 768px) {
+    &::before {
+      content: '';
+      min-width: 8rem;
+      flex-shrink: 0;
+    }
+  }
 
-.btn-margin {
-  margin: 0 0.5rem;
+  .column-label {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    color: var(--text-color-secondary);
+    font-size: 0.875rem;
+
+    &.current {
+      justify-content: flex-end;
+      padding-right: 1rem;
+    }
+
+    &.fetched {
+      justify-content: flex-start;
+      padding-left: 1rem;
+    }
+  }
+
+  .column-actions {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
 }
 
 .thumbnail-row {
@@ -217,25 +244,13 @@ textarea.changed,
   }
 }
 
+
 .metaheader {
-  position: relative;
   display: flex;
   align-items: center;
   border-bottom: 1px dotted var(--border-color);
   padding: 1rem;
   justify-content: space-between;
-
-  p {
-    text-align: center;
-
-    @media (max-width: 768px) {
-      font-size: 0.875rem;
-    }
-  }
-}
-
-.metaheader .midbuttons {
-  white-space: nowrap;
 }
 
 .metacontent {
@@ -294,7 +309,6 @@ textarea.changed,
 }
 
 @media (min-width: 768px) {
-  .metaheader,
   .metapicker .metacontent,
   .metaeditor .metabody {
     padding-left: 3.25rem;


### PR DESCRIPTION
The copy missing / overwrite all / reset buttons in the bookdrop metadata picker header weren't showing up on initial render. Turns out PrimeNG's p-button component has a Bind host directive that applies CSS classes via signals and effects, and when the picker is created inside an if block, the effect doesn't fire on the first render cycle. Replaced those three buttons with plain HTML buttons using PrimeNG CSS classes directly.

Also fixed disabled provider-specific fields (like Ranobedb, Lubimyczytac, etc.) still appearing in the bookdrop picker even when toggled off in the "Enabled Fields in Metadata Editor & Picker" settings.