### PR TITLE
fix prev/next book navigation arrows not showing in metadata viewer (#2969)

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.html
@@ -34,7 +34,7 @@
     @if (_isSeriesViewActive) {
       <p-button [rounded]="true" icon="pi pi-info" class="info-btn" (click)="openSeriesInfo()" [ariaLabel]="'book.card.alt.viewSeriesInfo' | transloco"></p-button>
     } @else {
-      <a [routerLink]="urlHelper.getBookUrl(book)"><p-button [rounded]="true" icon="pi pi-info" class="info-btn" [ariaLabel]="'book.card.alt.viewDetails' | transloco">
+      <a [routerLink]="urlHelper.getBookUrl(book)" (click)="prepareNavigation(book)"><p-button [rounded]="true" icon="pi pi-info" class="info-btn" [ariaLabel]="'book.card.alt.viewDetails' | transloco">
       </p-button></a>
     }
 

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -636,6 +636,13 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 
+  prepareNavigation(book: Book): void {
+    const allBookIds = this.bookNavigationService.getAvailableBookIds();
+    if (allBookIds.length > 0) {
+      this.bookNavigationService.setNavigationContext(allBookIds, book.id);
+    }
+  }
+
   openBookInfo(book: Book): void {
     const allBookIds = this.bookNavigationService.getAvailableBookIds();
     if (allBookIds.length > 0) {


### PR DESCRIPTION
The routerLink change from #2500 bypassed the openBookInfo() call that was responsible for setting navigation context. Without that context, navigationState$ stays null and the @if block in the metadata viewer never renders the prev/next arrows. Added a click handler on the anchor that sets navigation context before routerLink fires.

Fixes #2969