### PR TITLE
Save cover and fetch metadata by ISBN for physical books (#3035)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/MetadataController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/MetadataController.java
@@ -6,6 +6,7 @@ import org.booklore.mapper.BookMetadataMapper;
 import org.booklore.model.MetadataUpdateContext;
 import org.booklore.model.MetadataUpdateWrapper;
 import org.booklore.model.dto.BookMetadata;
+import org.booklore.model.dto.request.IsbnLookupRequest;
 import org.booklore.model.dto.request.*;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.enums.MetadataProvider;
@@ -140,6 +141,19 @@ public class MetadataController {
     public ResponseEntity<Void> deleteMetadata(@Parameter(description = "Delete metadata request") @Validated @RequestBody DeleteMetadataRequest request) {
         metadataManagementService.deleteMetadata(request.getMetadataType(), request.getValuesToDelete());
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Lookup metadata by ISBN", description = "Fetch metadata for a book by ISBN. Requires library management permission or admin.")
+    @ApiResponse(responseCode = "200", description = "Metadata found")
+    @ApiResponse(responseCode = "404", description = "No metadata found for the given ISBN")
+    @PostMapping("/metadata/isbn-lookup")
+    @PreAuthorize("@securityUtil.canManageLibrary() or @securityUtil.isAdmin()")
+    public ResponseEntity<BookMetadata> lookupByIsbn(@RequestBody IsbnLookupRequest request) {
+        BookMetadata metadata = bookMetadataService.lookupByIsbn(request);
+        if (metadata == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(metadata);
     }
 
     @Operation(summary = "Get detailed metadata from provider", description = "Fetch full metadata details for a specific item from a provider. Requires metadata edit permission or admin.")

--- a/booklore-api/src/main/java/org/booklore/model/dto/request/CreatePhysicalBookRequest.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/request/CreatePhysicalBookRequest.java
@@ -27,4 +27,5 @@ public class CreatePhysicalBookRequest {
     private String language;
     private Integer pageCount;
     private List<String> categories;
+    private String thumbnailUrl;
 }

--- a/booklore-api/src/main/java/org/booklore/model/dto/request/IsbnLookupRequest.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/request/IsbnLookupRequest.java
@@ -1,0 +1,14 @@
+package org.booklore.model.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class IsbnLookupRequest {
+    private String isbn;
+}

--- a/booklore-api/src/main/java/org/booklore/util/FileService.java
+++ b/booklore-api/src/main/java/org/booklore/util/FileService.java
@@ -323,8 +323,9 @@ public class FileService {
                 String requestUrl = uri.getScheme() + "://" + hostInUrl + portSuffix + path + (query != null ? "?" + query : "");
 
                 HttpHeaders headers = new HttpHeaders();
-                // Set original 'Host' header for server-side virtual hosting
-                headers.set(HttpHeaders.HOST, host);
+                // Host header is set in prepareConnection via setRequestProperty.
+                // Do NOT set it here: Spring's addRequestProperty would add a duplicate,
+                // and duplicate Host headers cause 400 on strict CDNs like CloudFront.
                 headers.set(HttpHeaders.USER_AGENT, "BookLore/1.0 (Book and Comic Metadata Fetcher; +https://github.com/booklore-app/booklore)");
                 headers.set(HttpHeaders.ACCEPT, "image/*");
 

--- a/booklore-ui/src/app/features/book/components/add-physical-book-dialog/add-physical-book-dialog.component.html
+++ b/booklore-ui/src/app/features/book/components/add-physical-book-dialog/add-physical-book-dialog.component.html
@@ -38,63 +38,81 @@
 
     <div class="gradient-divider"></div>
 
-    <div class="form-row">
-      <div class="form-group highlight-group flex-2">
-        <label for="title" class="form-label">
-          <i class="pi pi-tag label-icon"></i>
-          {{ t('titleLabel') }}
-        </label>
-        <div class="input-wrapper">
-          <input
-            id="title"
-            type="text"
-            pInputText
-            [(ngModel)]="title"
-            class="input-full"
-            [placeholder]="t('titlePlaceholder')"
-            [class.filled]="title.trim()"/>
+    <div class="top-section">
+      @if (coverUrl) {
+        <div class="cover-preview">
+          <img [src]="coverUrl" alt="Book cover"/>
         </div>
-      </div>
+      }
 
-      <div class="form-group highlight-group flex-1">
-        <label for="isbn" class="form-label">
-          <i class="pi pi-barcode label-icon"></i>
-          {{ t('isbnLabel') }}
-        </label>
-        <div class="input-wrapper">
-          <input
-            id="isbn"
-            type="text"
-            pInputText
-            [(ngModel)]="isbn"
-            class="input-full"
-            [placeholder]="t('isbnPlaceholder')"/>
+      <div class="top-fields">
+        <div class="form-row">
+          <div class="form-group highlight-group flex-2">
+            <label for="title" class="form-label">
+              <i class="pi pi-tag label-icon"></i>
+              {{ t('titleLabel') }}
+            </label>
+            <div class="input-wrapper">
+              <input
+                id="title"
+                type="text"
+                pInputText
+                [(ngModel)]="title"
+                class="input-full"
+                [placeholder]="t('titlePlaceholder')"
+                [class.filled]="title.trim()"/>
+            </div>
+          </div>
+
+          <div class="form-group highlight-group flex-1">
+            <label for="isbn" class="form-label">
+              <i class="pi pi-barcode label-icon"></i>
+              {{ t('isbnLabel') }}
+            </label>
+            <div class="isbn-input-row">
+              <input
+                id="isbn"
+                type="text"
+                pInputText
+                [(ngModel)]="isbn"
+                class="input-full"
+                [placeholder]="t('isbnPlaceholder')"/>
+              <p-button
+                icon="pi pi-search"
+                [rounded]="true"
+                [text]="true"
+                severity="info"
+                (onClick)="fetchMetadataByIsbn()"
+                [disabled]="!isbn.trim() || isFetchingMetadata"
+                [loading]="isFetchingMetadata"
+                [pTooltip]="t('fetchMetadataTooltip')"
+                tooltipPosition="top"/>
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
 
-    <div class="gradient-divider"></div>
-
-    <div class="form-group highlight-group">
-      <label for="authors" class="form-label">
-        <i class="pi pi-user label-icon"></i>
-        {{ t('authorsLabel') }}
-      </label>
-      <div class="autocomplete-wrapper">
-        <p-autoComplete
-          appendTo="body"
-          [(ngModel)]="authors"
-          [multiple]="true"
-          [fluid]="true"
-          [dropdown]="false"
-          [suggestions]="filteredAuthors"
-          [forceSelection]="false"
-          [showClear]="false"
-          [placeholder]="t('authorsPlaceholder')"
-          (completeMethod)="filterAuthors($event)"
-          (onKeyUp)="onAutoCompleteKeyUp('authors', $event)"
-          (onSelect)="onAutoCompleteSelect('authors', $event)">
-        </p-autoComplete>
+        <div class="form-group highlight-group">
+          <label for="authors" class="form-label">
+            <i class="pi pi-user label-icon"></i>
+            {{ t('authorsLabel') }}
+          </label>
+          <div class="autocomplete-wrapper">
+            <p-autoComplete
+              appendTo="body"
+              [(ngModel)]="authors"
+              [multiple]="true"
+              [fluid]="true"
+              [dropdown]="false"
+              [suggestions]="filteredAuthors"
+              [forceSelection]="false"
+              [showClear]="false"
+              [placeholder]="t('authorsPlaceholder')"
+              (completeMethod)="filterAuthors($event)"
+              (onKeyUp)="onAutoCompleteKeyUp('authors', $event)"
+              (onSelect)="onAutoCompleteSelect('authors', $event)">
+            </p-autoComplete>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/booklore-ui/src/app/features/book/components/add-physical-book-dialog/add-physical-book-dialog.component.scss
+++ b/booklore-ui/src/app/features/book/components/add-physical-book-dialog/add-physical-book-dialog.component.scss
@@ -106,6 +106,54 @@
   box-sizing: border-box;
 }
 
+.isbn-input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+
+  .input-full {
+    flex: 1;
+  }
+}
+
+.top-section {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+
+  @media (max-width: 640px) {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+.top-fields {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cover-preview {
+  flex-shrink: 0;
+  padding: 0.5rem;
+
+  img {
+    height: 180px;
+    border-radius: 4px;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+    object-fit: contain;
+  }
+
+  @media (max-width: 640px) {
+    img {
+      height: 150px;
+    }
+  }
+}
+
 .autocomplete-wrapper {
   width: 100%;
 

--- a/booklore-ui/src/app/features/book/model/book.model.ts
+++ b/booklore-ui/src/app/features/book/model/book.model.ts
@@ -413,6 +413,7 @@ export interface CreatePhysicalBookRequest {
   language?: string;
   pageCount?: number;
   categories?: string[];
+  thumbnailUrl?: string;
 }
 
 export interface BookStatusUpdateResponse {

--- a/booklore-ui/src/app/features/book/service/book-metadata.service.ts
+++ b/booklore-ui/src/app/features/book/service/book-metadata.service.ts
@@ -57,4 +57,8 @@ export class BookMetadataService {
   fetchMetadataDetail(provider: string, providerItemId: string): Observable<BookMetadata> {
     return this.http.get<BookMetadata>(`${this.url}/metadata/detail/${provider}/${providerItemId}`);
   }
+
+  lookupByIsbn(isbn: string): Observable<BookMetadata> {
+    return this.http.post<BookMetadata>(`${this.url}/metadata/isbn-lookup`, {isbn});
+  }
 }

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
@@ -593,9 +593,8 @@
                   <p-button
                     icon="pi pi-chevron-left"
                     [disabled]="!canNavigatePrevious()"
-                    (onClick)="navigatePrevious()"
-                    rounded
-                    text
+                    (onClick)="navigatePrevious()"`
+                    outlined
                     severity="secondary"
                     [pTooltip]="t('goToPreviousBook')"
                     tooltipPosition="bottom">
@@ -609,8 +608,7 @@
                     [disabled]="!canNavigateNext()"
                     (onClick)="navigateNext()"
                     severity="secondary"
-                    rounded
-                    text
+                    outlined
                     [pTooltip]="t('goToNextBook')"
                     tooltipPosition="bottom">
                   </p-button>

--- a/booklore-ui/src/i18n/en/book.json
+++ b/booklore-ui/src/i18n/en/book.json
@@ -429,7 +429,8 @@
     "validationTitleOrIsbn": "Title or ISBN is required",
     "validationReady": "Ready to create",
     "cancelButton": "Cancel",
-    "addButton": "Add Physical Book"
+    "addButton": "Add Physical Book",
+    "fetchMetadataTooltip": "Fetch metadata by ISBN"
   },
   "fileUploader": {
     "title": "Upload Additional File",

--- a/booklore-ui/src/i18n/es/book.json
+++ b/booklore-ui/src/i18n/es/book.json
@@ -429,7 +429,8 @@
     "validationTitleOrIsbn": "Se requiere un título o ISBN",
     "validationReady": "Listo para crear",
     "cancelButton": "Cancelar",
-    "addButton": "Agregar libro físico"
+    "addButton": "Agregar libro físico",
+    "fetchMetadataTooltip": "Obtener metadatos por ISBN"
   },
   "fileUploader": {
     "title": "Subir archivo adicional",


### PR DESCRIPTION
When adding a physical book via ISBN lookup, the cover URL from the metadata provider was being fetched and shown in the dialog but never actually saved to disk. The thumbnailUrl now gets passed through to the backend, which downloads it after saving the book. Also moved the cover preview to the left of the title/authors/ISBN section in the dialog so it looks nicer.

Fixed a bug in FileService where the Host header was being set in both prepareConnection and the HttpEntity, causing duplicate Host headers that strict CDNs like CloudFront reject with a 400.

Fixes #3035