### PR TITLE
fix series page blank for names with trailing whitespace (#3040)

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.config.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.config.ts
@@ -202,7 +202,7 @@ const findExactAgeRating = (ageRating: number | null | undefined): FilterValue[]
 export const FILTER_EXTRACTORS: Readonly<Record<Exclude<FilterType, 'library'>, (book: Book) => FilterValue[]>> = {
   author: (book) => extractStringsAsFilters(book.metadata?.authors),
   category: (book) => extractStringsAsFilters(book.metadata?.categories),
-  series: (book) => extractSingleString(book.metadata?.seriesName),
+  series: (book) => extractSingleString(book.metadata?.seriesName?.trim()),
   bookType: (book) => extractSingleString(book.primaryFile?.bookType),
   readStatus: (book) => {
     const status = book.readStatus ?? ReadStatus.UNSET;

--- a/booklore-ui/src/app/features/book/components/book-browser/filters/sidebar-filter.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/filters/sidebar-filter.ts
@@ -71,8 +71,8 @@ export function doesBookMatchFilter(
         : filterValues.every(val => book.metadata?.categories?.includes(val as string));
     case 'series':
       return mode === 'or'
-        ? filterValues.some(val => book.metadata?.seriesName === val)
-        : filterValues.every(val => book.metadata?.seriesName === val);
+        ? filterValues.some(val => book.metadata?.seriesName?.trim() === val)
+        : filterValues.every(val => book.metadata?.seriesName?.trim() === val);
     case 'bookType':
       return filterValues.includes(book.primaryFile?.bookType);
     case 'readStatus':

--- a/booklore-ui/src/app/features/book/components/series-page/series-page.component.ts
+++ b/booklore-ui/src/app/features/book/components/series-page/series-page.component.ts
@@ -155,7 +155,7 @@ export class SeriesPageComponent implements OnDestroy, AfterViewChecked {
   ]).pipe(
     map(([seriesName, books]) => {
       const inSeries = books.filter(
-        (b) => b.metadata?.seriesName?.toLowerCase() === seriesName
+        (b) => b.metadata?.seriesName?.trim().toLowerCase() === seriesName
       );
       return inSeries.sort((a, b) => {
         const aNum = a.metadata?.seriesNumber ?? Number.MAX_SAFE_INTEGER;

--- a/booklore-ui/src/app/features/series-browser/service/series-data.service.ts
+++ b/booklore-ui/src/app/features/series-browser/service/series-data.service.ts
@@ -25,7 +25,7 @@ export class SeriesDataService {
       const seriesName = book.metadata?.seriesName;
       if (!seriesName) continue;
 
-      const key = seriesName.toLowerCase();
+      const key = seriesName.trim().toLowerCase();
       if (!seriesMap.has(key)) {
         seriesMap.set(key, []);
       }
@@ -41,7 +41,7 @@ export class SeriesDataService {
         return aNum - bNum;
       });
 
-      const displayName = sorted[0].metadata?.seriesName || '';
+      const displayName = sorted[0].metadata?.seriesName?.trim() || '';
       const authorSet = new Set<string>();
       const categorySet = new Set<string>();
 


### PR DESCRIPTION
series names with trailing spaces (from metadata fetches or older versions) caused the series page to load blank since the URL param gets trimmed but the book metadata comparison didn't. now trimming series names on the frontend side in the series page matching, series browser grouping, and sidebar filter extraction/matching. backend already trims on persist so new data is fine, this just handles any existing dirty data.

Fixes #3040