### PR TITLE
fix auto-save on navigation not working in multi-book metadata editor (#3019)

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.ts
@@ -1064,11 +1064,19 @@ export class MetadataEditorComponent implements OnInit {
   }
 
   onNext() {
-    this.nextBookClicked.emit();
+    if (this.autoSaveEnabled && this.metadataForm.dirty) {
+      this.saveMetadata().pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.nextBookClicked.emit());
+    } else {
+      this.nextBookClicked.emit();
+    }
   }
 
   onPrevious() {
-    this.previousBookClicked.emit();
+    if (this.autoSaveEnabled && this.metadataForm.dirty) {
+      this.saveMetadata().pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.previousBookClicked.emit());
+    } else {
+      this.previousBookClicked.emit();
+    }
   }
 
   closeDialog() {


### PR DESCRIPTION
The multi-book metadata editor's prev/next buttons were bypassing the auto-save check entirely. Single-book navigation had the right logic but the multi-book path just emitted the navigation event without saving first. Now both paths save dirty forms before navigating when auto-save is enabled.

Fixes #3019