### PR TITLE
show friendly error when email send fails and warn on large attachments (#3008)

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -415,23 +415,40 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
             label: this.t.translate('book.card.menu.quickSend'),
             icon: 'pi pi-envelope',
             command: () => {
-              this.emailService.emailBookQuick(this.book.id).subscribe({
-                next: () => {
-                  this.messageService.add({
-                    severity: 'info',
-                    summary: this.t.translate('common.success'),
-                    detail: this.t.translate('book.card.toast.quickSendSuccessDetail'),
-                  });
-                },
-                error: (err) => {
-                  const errorMessage = err?.error?.message || this.t.translate('book.card.toast.quickSendErrorDetail');
-                  this.messageService.add({
-                    severity: 'error',
-                    summary: this.t.translate('common.error'),
-                    detail: errorMessage,
-                  });
-                },
-              });
+              const doSend = () => {
+                this.emailService.emailBookQuick(this.book.id).subscribe({
+                  next: () => {
+                    this.messageService.add({
+                      severity: 'info',
+                      summary: this.t.translate('common.success'),
+                      detail: this.t.translate('book.card.toast.quickSendSuccessDetail'),
+                    });
+                  },
+                  error: (err) => {
+                    const errorMessage = err?.error?.message || this.t.translate('book.card.toast.quickSendErrorDetail');
+                    this.messageService.add({
+                      severity: 'error',
+                      summary: this.t.translate('common.error'),
+                      detail: errorMessage,
+                    });
+                  },
+                });
+              };
+
+              if (this.book.primaryFile?.fileSizeKb && this.book.primaryFile.fileSizeKb > 25 * 1024) {
+                this.confirmationService.confirm({
+                  message: this.t.translate('book.card.confirm.largeFileMessage'),
+                  header: this.t.translate('book.card.confirm.largeFileHeader'),
+                  icon: 'pi pi-exclamation-triangle',
+                  acceptLabel: this.t.translate('book.card.confirm.sendAnyway'),
+                  rejectLabel: this.t.translate('common.cancel'),
+                  acceptButtonProps: { severity: 'warn' },
+                  rejectButtonProps: { severity: 'secondary' },
+                  accept: doSend,
+                });
+              } else {
+                doSend();
+              }
             }
           },
             {

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -268,7 +268,7 @@ export class MetadataViewerComponent implements OnInit, OnChanges, AfterViewChec
                   {
                     label: this.t.translate('metadata.viewer.menuQuickSend'),
                     icon: 'pi pi-bolt',
-                    command: () => this.quickSend(book.id)
+                    command: () => this.quickSend(book)
                   },
                   {
                     label: this.t.translate('metadata.viewer.menuCustomSend'),
@@ -646,19 +646,36 @@ export class MetadataViewerComponent implements OnInit, OnChanges, AfterViewChec
     }, 15000);
   }
 
-  quickSend(bookId: number) {
-    this.emailService.emailBookQuick(bookId).subscribe({
-      next: () => this.messageService.add({
-        severity: 'info',
-        summary: this.t.translate('metadata.viewer.toast.quickSendSuccessSummary'),
-        detail: this.t.translate('metadata.viewer.toast.quickSendSuccessDetail'),
-      }),
-      error: (err) => this.messageService.add({
-        severity: 'error',
-        summary: this.t.translate('metadata.viewer.toast.quickSendErrorSummary'),
-        detail: err?.error?.message || this.t.translate('metadata.viewer.toast.quickSendErrorDetail'),
-      })
-    });
+  quickSend(book: Book) {
+    const doSend = () => {
+      this.emailService.emailBookQuick(book.id).subscribe({
+        next: () => this.messageService.add({
+          severity: 'info',
+          summary: this.t.translate('metadata.viewer.toast.quickSendSuccessSummary'),
+          detail: this.t.translate('metadata.viewer.toast.quickSendSuccessDetail'),
+        }),
+        error: (err) => this.messageService.add({
+          severity: 'error',
+          summary: this.t.translate('metadata.viewer.toast.quickSendErrorSummary'),
+          detail: err?.error?.message || this.t.translate('metadata.viewer.toast.quickSendErrorDetail'),
+        })
+      });
+    };
+
+    if (book.primaryFile?.fileSizeKb && book.primaryFile.fileSizeKb > 25 * 1024) {
+      this.confirmationService.confirm({
+        message: this.t.translate('metadata.viewer.confirm.largeFileMessage'),
+        header: this.t.translate('metadata.viewer.confirm.largeFileHeader'),
+        icon: 'pi pi-exclamation-triangle',
+        acceptLabel: this.t.translate('metadata.viewer.confirm.sendAnyway'),
+        rejectLabel: this.t.translate('common.cancel'),
+        acceptButtonProps: { severity: 'warn' },
+        rejectButtonProps: { severity: 'secondary' },
+        accept: doSend,
+      });
+    } else {
+      doSend();
+    }
   }
 
   assignShelf(bookId: number) {

--- a/booklore-ui/src/i18n/en/book.json
+++ b/booklore-ui/src/i18n/en/book.json
@@ -101,7 +101,10 @@
       "deleteBookMessage": "Are you sure you want to delete \"{{ title }}\"?\n\nThis will permanently remove the book file from your filesystem.\n\nThis action cannot be undone.",
       "deleteBookHeader": "Confirm Deletion",
       "deleteFileMessage": "Are you sure you want to delete the additional file \"{{ fileName }}\"?",
-      "deleteFileHeader": "Confirm File Deletion"
+      "deleteFileHeader": "Confirm File Deletion",
+      "largeFileMessage": "This file exceeds 25MB. Some email providers may reject large attachments.\n\nDo you want to send it anyway?",
+      "largeFileHeader": "Large File Warning",
+      "sendAnyway": "Send Anyway"
     },
     "toast": {
       "quickSendSuccessDetail": "The book sending has been scheduled.",

--- a/booklore-ui/src/i18n/en/metadata.json
+++ b/booklore-ui/src/i18n/en/metadata.json
@@ -383,7 +383,10 @@
       "detachFileBtn": "Detach",
       "deleteBookMessage": "Are you sure you want to delete \"{{ title }}\"?\n\nThis will permanently remove the book record from your library.\n\nThis action cannot be undone.",
       "deleteBookAllFilesMessage": "Are you sure you want to delete \"{{ title }}\"?\n\nThis will permanently remove the book record AND all associated files from your filesystem.\n\nThis action cannot be undone.",
-      "deleteEverythingBtn": "Delete Everything"
+      "deleteEverythingBtn": "Delete Everything",
+      "largeFileMessage": "This file exceeds 25MB. Some email providers may reject large attachments.\n\nDo you want to send it anyway?",
+      "largeFileHeader": "Large File Warning",
+      "sendAnyway": "Send Anyway"
     }
   },
   "sidecar": {

--- a/booklore-ui/src/i18n/es/book.json
+++ b/booklore-ui/src/i18n/es/book.json
@@ -101,7 +101,10 @@
       "deleteBookMessage": "¿Estás seguro de que deseas eliminar \"{{ title }}\"?\n\nEsto eliminará permanentemente el archivo del libro de tu sistema de archivos.\n\nEsta acción no se puede deshacer.",
       "deleteBookHeader": "Confirmar eliminación",
       "deleteFileMessage": "¿Estás seguro de que deseas eliminar el archivo adicional \"{{ fileName }}\"?",
-      "deleteFileHeader": "Confirmar eliminación de archivo"
+      "deleteFileHeader": "Confirmar eliminación de archivo",
+      "largeFileMessage": "Este archivo supera los 25 MB. Algunos proveedores de correo pueden rechazar archivos adjuntos grandes.\n\n¿Deseas enviarlo de todos modos?",
+      "largeFileHeader": "Advertencia de archivo grande",
+      "sendAnyway": "Enviar de todos modos"
     },
     "toast": {
       "quickSendSuccessDetail": "El envío del libro ha sido programado.",

--- a/booklore-ui/src/i18n/es/metadata.json
+++ b/booklore-ui/src/i18n/es/metadata.json
@@ -383,7 +383,10 @@
       "detachFileBtn": "Separar",
       "deleteBookMessage": "¿Estás seguro de que deseas eliminar \"{{ title }}\"?\n\nEsto eliminará permanentemente el registro del libro de tu biblioteca.\n\nEsta acción no se puede deshacer.",
       "deleteBookAllFilesMessage": "¿Estás seguro de que deseas eliminar \"{{ title }}\"?\n\nEsto eliminará permanentemente el registro del libro Y todos los archivos asociados de tu sistema de archivos.\n\nEsta acción no se puede deshacer.",
-      "deleteEverythingBtn": "Eliminar todo"
+      "deleteEverythingBtn": "Eliminar todo",
+      "largeFileMessage": "Este archivo supera los 25 MB. Algunos proveedores de correo pueden rechazar archivos adjuntos grandes.\n\n¿Deseas enviarlo de todos modos?",
+      "largeFileHeader": "Advertencia de archivo grande",
+      "sendAnyway": "Enviar de todos modos"
     }
   },
   "sidecar": {


### PR DESCRIPTION
Instead of showing raw java exceptions like `SocketException: Broken pipe` when an email provider drops the connection mid-transfer, the backend now surfaces a user-friendly message about the provider rejecting the transfer (with a hint about size limits). On the frontend, quick send now shows a confirmation dialog when the file is over 25MB so users know it might not go through before they commit to sending.

Fixes #3008