### PR TITLE
fix NPE when re-attaching a book file to a physical book after deleting the previous one

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/upload/FileUploadService.java
+++ b/booklore-api/src/main/java/org/booklore/service/upload/FileUploadService.java
@@ -116,11 +116,13 @@ public class FileUploadService {
             final String fileSubPath;
             final BookFileType effectiveBookType;
 
-            // Handle physical books that are getting their first file
-            if (wasPhysicalBook) {
-                // Physical book - determine library path and subpath
-                LibraryPathEntity libraryPath = determineLibraryPathForPhysicalBook(book);
-                book.setLibraryPath(libraryPath);
+            // Handle physical books or books that lost all their files
+            if (wasPhysicalBook || book.getPrimaryBookFile() == null) {
+                LibraryPathEntity libraryPath = book.getLibraryPath();
+                if (libraryPath == null) {
+                    libraryPath = determineLibraryPathForPhysicalBook(book);
+                    book.setLibraryPath(libraryPath);
+                }
 
                 String pattern = fileMovingHelper.getFileNamingPattern(book.getLibrary());
                 String resolvedRelativePath = PathPatternResolver.resolvePattern(book.getMetadata(), pattern, sanitizedFileName);

--- a/booklore-api/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
@@ -6,6 +6,7 @@ import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookFileEntity;
 import org.booklore.model.entity.LibraryPathEntity;
 import org.booklore.repository.BookAdditionalFileRepository;
+import org.booklore.repository.BookRepository;
 import org.booklore.service.file.AdditionalFileService;
 import org.booklore.service.monitoring.MonitoringRegistrationService;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,9 @@ class AdditionalFileServiceTest {
 
     @Mock
     private BookAdditionalFileRepository additionalFileRepository;
+
+    @Mock
+    private BookRepository bookRepository;
 
     @Mock
     private AdditionalFileMapper additionalFileMapper;
@@ -175,6 +179,8 @@ class AdditionalFileServiceTest {
             verify(monitoringRegistrationService).unregisterSpecificPath(parentPath);
             filesMock.verify(() -> Files.deleteIfExists(fileEntity.getFullFilePath()));
             verify(additionalFileRepository).delete(fileEntity);
+            verify(bookRepository).save(bookEntity);
+            assertTrue(bookEntity.getIsPhysical());
         }
     }
 
@@ -194,6 +200,8 @@ class AdditionalFileServiceTest {
             verify(monitoringRegistrationService).unregisterSpecificPath(parentPath);
             filesMock.verify(() -> Files.deleteIfExists(fileEntity.getFullFilePath()));
             verify(additionalFileRepository).delete(fileEntity);
+            verify(bookRepository).save(bookEntity);
+            assertTrue(bookEntity.getIsPhysical());
         }
     }
 


### PR DESCRIPTION
When you attach a book file to a physical book, then delete it, trying to attach again would crash with an NPE because the book's isPhysical flag wasn't getting restored after the last file was removed. Now deleting the last book file reverts the book back to physical, and the upload path also handles the edge case defensively.