### PR TITLE
fix medium severity security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /angular-app
 
 COPY ./booklore-ui/package.json ./booklore-ui/package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm \
-    npm config set registry http://registry.npmjs.org/ \
+    npm config set registry https://registry.npmjs.org/ \
     && npm ci --force
 
 COPY ./booklore-ui /angular-app/

--- a/booklore-api/src/main/java/org/booklore/config/security/SecurityConfig.java
+++ b/booklore-api/src/main/java/org/booklore/config/security/SecurityConfig.java
@@ -222,6 +222,7 @@ public class SecurityConfig {
                 .headers(headers -> headers
                         .referrerPolicy(referrer -> referrer.policy(
                                 ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+                        .contentTypeOptions(contentType -> {})
                 )
                 .authorizeHttpRequests(auth -> auth
                         .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
@@ -242,6 +243,7 @@ public class SecurityConfig {
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
                         .referrerPolicy(referrer -> referrer.policy(
                                 ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+                        .contentTypeOptions(contentType -> {})
                 )
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         return http.build();

--- a/booklore-api/src/main/java/org/booklore/controller/AuthorController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/AuthorController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -69,7 +70,7 @@ public class AuthorController {
     @PutMapping("/{authorId}")
     public ResponseEntity<AuthorDetails> updateAuthor(
             @Parameter(description = "ID of the author") @PathVariable long authorId,
-            @RequestBody AuthorUpdateRequest request) {
+            @RequestBody @Valid AuthorUpdateRequest request) {
         return ResponseEntity.ok(authorMetadataService.updateAuthor(authorId, request));
     }
 
@@ -101,7 +102,7 @@ public class AuthorController {
     @PostMapping("/{authorId}/match")
     public ResponseEntity<AuthorDetails> matchAuthor(
             @Parameter(description = "ID of the author") @PathVariable long authorId,
-            @RequestBody AuthorMatchRequest request) {
+            @RequestBody @Valid AuthorMatchRequest request) {
         return ResponseEntity.ok(authorMetadataService.matchAuthor(authorId, request));
     }
 

--- a/booklore-api/src/main/java/org/booklore/controller/BookController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/BookController.java
@@ -36,10 +36,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -47,6 +49,7 @@ import java.util.Set;
 
 @Tag(name = "Books", description = "Endpoints for managing books, their metadata, progress, and recommendations")
 @RequestMapping("/api/v1/books")
+@Validated
 @RestController
 @AllArgsConstructor
 public class BookController {
@@ -190,7 +193,7 @@ public class BookController {
     @PutMapping("/{bookId}/viewer-setting")
     @CheckBookAccess(bookIdParam = "bookId")
     public ResponseEntity<Void> updateBookViewerSettings(
-            @Parameter(description = "Viewer settings to update") @RequestBody BookViewerSettings bookViewerSettings,
+            @Parameter(description = "Viewer settings to update") @RequestBody @Valid BookViewerSettings bookViewerSettings,
             @Parameter(description = "ID of the book") @PathVariable long bookId) {
         bookService.updateBookViewerSetting(bookId, bookViewerSettings);
         return ResponseEntity.noContent().build();
@@ -237,7 +240,7 @@ public class BookController {
     })
     @PostMapping("/reset-progress")
     public ResponseEntity<List<BookStatusUpdateResponse>> resetProgress(
-            @Parameter(description = "List of book IDs to reset progress for") @RequestBody List<Long> bookIds,
+            @Parameter(description = "List of book IDs to reset progress for") @RequestBody @Size(max = 500) List<Long> bookIds,
             @Parameter(description = "Type of progress reset") @RequestParam ResetProgressType type) {
         if (bookIds == null || bookIds.isEmpty()) {
             throw ApiError.GENERIC_BAD_REQUEST.createException("No book IDs provided");
@@ -260,7 +263,7 @@ public class BookController {
     })
     @PostMapping("/reset-personal-rating")
     public ResponseEntity<List<PersonalRatingUpdateResponse>> resetPersonalRating(
-            @Parameter(description = "List of book IDs to reset personal rating for") @RequestBody List<Long> bookIds) {
+            @Parameter(description = "List of book IDs to reset personal rating for") @RequestBody @Size(max = 500) List<Long> bookIds) {
         if (bookIds == null || bookIds.isEmpty()) {
             throw ApiError.GENERIC_BAD_REQUEST.createException("No book IDs provided");
         }

--- a/booklore-api/src/main/java/org/booklore/controller/EmailProviderV2Controller.java
+++ b/booklore-api/src/main/java/org/booklore/controller/EmailProviderV2Controller.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -44,7 +45,7 @@ public class EmailProviderV2Controller {
     @PreAuthorize("@securityUtil.isAdmin() or @securityUtil.canEmailBook()")
     @PostMapping
     public ResponseEntity<EmailProviderV2> createEmailProvider(
-            @Parameter(description = "Email provider creation request") @RequestBody CreateEmailProviderRequest createEmailProviderRequest) {
+            @Parameter(description = "Email provider creation request") @RequestBody @Valid CreateEmailProviderRequest createEmailProviderRequest) {
         return ResponseEntity.ok(service.createEmailProvider(createEmailProviderRequest));
     }
 
@@ -54,7 +55,7 @@ public class EmailProviderV2Controller {
     @PutMapping("/{id}")
     public ResponseEntity<EmailProviderV2> updateEmailProvider(
             @Parameter(description = "ID of the email provider") @PathVariable Long id,
-            @Parameter(description = "Email provider update request") @RequestBody CreateEmailProviderRequest updateRequest) {
+            @Parameter(description = "Email provider update request") @RequestBody @Valid CreateEmailProviderRequest updateRequest) {
         return ResponseEntity.ok(service.updateEmailProvider(id, updateRequest));
     }
 

--- a/booklore-api/src/main/java/org/booklore/controller/EmailRecipientV2Controller.java
+++ b/booklore-api/src/main/java/org/booklore/controller/EmailRecipientV2Controller.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -44,7 +45,7 @@ public class EmailRecipientV2Controller {
     @PreAuthorize("@securityUtil.isAdmin() or @securityUtil.canEmailBook()")
     @PostMapping
     public ResponseEntity<EmailRecipientV2> createEmailRecipient(
-            @Parameter(description = "Email recipient creation request") @RequestBody CreateEmailRecipientRequest createEmailRecipientRequest) {
+            @Parameter(description = "Email recipient creation request") @RequestBody @Valid CreateEmailRecipientRequest createEmailRecipientRequest) {
         return ResponseEntity.ok(service.createEmailRecipient(createEmailRecipientRequest));
     }
 
@@ -54,7 +55,7 @@ public class EmailRecipientV2Controller {
     @PutMapping("/{id}")
     public ResponseEntity<EmailRecipientV2> updateEmailRecipient(
             @Parameter(description = "ID of the email recipient") @PathVariable Long id,
-            @Parameter(description = "Email recipient update request") @RequestBody CreateEmailRecipientRequest updateRequest) {
+            @Parameter(description = "Email recipient update request") @RequestBody @Valid CreateEmailRecipientRequest updateRequest) {
         return ResponseEntity.ok(service.updateEmailRecipient(id, updateRequest));
     }
 

--- a/booklore-api/src/main/java/org/booklore/controller/FileMoveController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/FileMoveController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,7 +27,7 @@ public class FileMoveController {
     @ApiResponse(responseCode = "200", description = "Files moved successfully")
     @PostMapping("/move")
     @PreAuthorize("@securityUtil.canManageLibrary() or @securityUtil.isAdmin()")
-    public ResponseEntity<?> moveFiles(@Parameter(description = "File move request") @RequestBody FileMoveRequest request) {
+    public ResponseEntity<?> moveFiles(@Parameter(description = "File move request") @RequestBody @Valid FileMoveRequest request) {
         fileMoveService.bulkMoveFiles(request);
         return ResponseEntity.ok().build();
     }

--- a/booklore-api/src/main/java/org/booklore/controller/HardcoverSyncSettingsController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/HardcoverSyncSettingsController.java
@@ -5,6 +5,7 @@ import org.booklore.service.hardcover.HardcoverSyncSettingsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -35,7 +36,7 @@ public class HardcoverSyncSettingsController {
     @ApiResponse(responseCode = "200", description = "Settings updated successfully")
     @PutMapping
     @PreAuthorize("@securityUtil.canSyncKobo() or @securityUtil.canSyncKoReader() or @securityUtil.isAdmin()")
-    public ResponseEntity<HardcoverSyncSettings> updateSettings(@RequestBody HardcoverSyncSettings settings) {
+    public ResponseEntity<HardcoverSyncSettings> updateSettings(@RequestBody @Valid HardcoverSyncSettings settings) {
         HardcoverSyncSettings updated = hardcoverSyncSettingsService.updateCurrentUserSettings(settings);
         return ResponseEntity.ok(updated);
     }

--- a/booklore-api/src/main/java/org/booklore/controller/KoboSettingsController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/KoboSettingsController.java
@@ -5,6 +5,7 @@ import org.booklore.service.kobo.KoboSettingsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -41,7 +42,7 @@ public class KoboSettingsController {
     @ApiResponse(responseCode = "200", description = "Settings updated successfully")
     @PutMapping
     @PreAuthorize("@securityUtil.canSyncKobo() or @securityUtil.isAdmin()")
-    public ResponseEntity<KoboSyncSettings> updateSettings(@RequestBody KoboSyncSettings settings) {
+    public ResponseEntity<KoboSyncSettings> updateSettings(@RequestBody @Valid KoboSyncSettings settings) {
         KoboSyncSettings updated = koboService.updateSettings(settings);
         return ResponseEntity.ok(updated);
     }

--- a/booklore-api/src/main/java/org/booklore/controller/OpdsUserV2Controller.java
+++ b/booklore-api/src/main/java/org/booklore/controller/OpdsUserV2Controller.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -35,7 +36,7 @@ public class OpdsUserV2Controller {
     @PostMapping
     @PreAuthorize("@securityUtil.isAdmin() or @securityUtil.canAccessOpds()")
     public OpdsUserV2 createUser(
-            @Parameter(description = "OPDS user creation request") @RequestBody OpdsUserV2CreateRequest createRequest) {
+            @Parameter(description = "OPDS user creation request") @RequestBody @Valid OpdsUserV2CreateRequest createRequest) {
         return service.createOpdsUser(createRequest);
     }
 
@@ -54,6 +55,6 @@ public class OpdsUserV2Controller {
     @PreAuthorize("@securityUtil.isAdmin() or @securityUtil.canAccessOpds()")
     public OpdsUserV2 updateUser(
             @Parameter(description = "ID of the OPDS user to update") @PathVariable Long id,
-            @Parameter(description = "OPDS user update request") @RequestBody OpdsUserV2UpdateRequest updateRequest) {
+            @Parameter(description = "OPDS user update request") @RequestBody @Valid OpdsUserV2UpdateRequest updateRequest) {
         return service.updateOpdsUser(id, updateRequest);
     }}

--- a/booklore-api/src/main/java/org/booklore/controller/ReadingSessionController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/ReadingSessionController.java
@@ -7,11 +7,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Validated
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/v1/reading-sessions")
@@ -39,8 +43,8 @@ public class ReadingSessionController {
     @GetMapping("/book/{bookId}")
     public ResponseEntity<Page<ReadingSessionResponse>> getReadingSessionsForBook(
             @PathVariable Long bookId, 
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int size) {
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "5") @Min(1) @Max(100) int size) {
         Page<ReadingSessionResponse> sessions = readingSessionService.getReadingSessionsForBook(bookId, page, size);
         return ResponseEntity.ok(sessions);
     }

--- a/booklore-api/src/main/java/org/booklore/controller/UserController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/UserController.java
@@ -75,7 +75,7 @@ public class UserController {
     @Operation(summary = "Change password", description = "Change the password for the current user.")
     @ApiResponse(responseCode = "200", description = "Password changed successfully")
     @PutMapping("/change-password")
-    public ResponseEntity<?> changePassword(@Parameter(description = "Change password request") @RequestBody ChangePasswordRequest request) {
+    public ResponseEntity<?> changePassword(@Parameter(description = "Change password request") @RequestBody @Valid ChangePasswordRequest request) {
         userService.changePassword(request);
         return ResponseEntity.ok().build();
     }
@@ -84,7 +84,7 @@ public class UserController {
     @ApiResponse(responseCode = "200", description = "Password changed successfully")
     @PutMapping("/change-user-password")
     @PreAuthorize("@securityUtil.isAdmin()")
-    public ResponseEntity<?> changeUserPassword(@Parameter(description = "Change user password request") @RequestBody ChangeUserPasswordRequest request) {
+    public ResponseEntity<?> changeUserPassword(@Parameter(description = "Change user password request") @RequestBody @Valid ChangeUserPasswordRequest request) {
         userService.changeUserPassword(request);
         return ResponseEntity.ok().build();
     }
@@ -95,7 +95,7 @@ public class UserController {
     @PreAuthorize("@securityUtil.isSelf(#id)")
     public void updateUserSetting(
             @Parameter(description = "ID of the user") @PathVariable Long id,
-            @Parameter(description = "Update user setting request") @RequestBody UpdateUserSettingRequest request) {
+            @Parameter(description = "Update user setting request") @RequestBody @Valid UpdateUserSettingRequest request) {
         userService.updateUserSetting(id, request);
     }
 }

--- a/booklore-api/src/main/java/org/booklore/model/dto/request/PersonalRatingUpdateRequest.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/request/PersonalRatingUpdateRequest.java
@@ -1,6 +1,8 @@
 package org.booklore.model.dto.request;
 
+import jakarta.validation.constraints.Size;
+
 import java.util.List;
 
-public record PersonalRatingUpdateRequest(List<Long> ids, Integer rating) {
+public record PersonalRatingUpdateRequest(@Size(max = 500) List<Long> ids, Integer rating) {
 }

--- a/booklore-api/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -376,6 +376,7 @@ class BookServiceTest {
 
         doNothing().when(bookRepository).deleteAll(anyList());
         when(bookQueryService.findAllWithMetadataByIds(Set.of(11L))).thenReturn(List.of(entity));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);
 
         BookDeletionResponse response = bookService.deleteBooks(Set.of(11L)).getBody();
 
@@ -403,6 +404,7 @@ class BookServiceTest {
         entity.setBookFiles(List.of(primaryFile));
 
         when(bookQueryService.findAllWithMetadataByIds(Set.of(13L))).thenReturn(List.of(entity));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);
         doNothing().when(bookRepository).deleteAll(anyList());
 
         BookDeletionResponse response = bookService.deleteBooks(Set.of(13L)).getBody();


### PR DESCRIPTION
Addresses several medium-severity findings from the security audit: blocks browsing sensitive system directories in the path browser, adds @Valid to controller endpoints that were missing it so Jakarta validation annotations actually get enforced, caps bulk operation list sizes to prevent DoS via unbounded ID lists, fixes the npm registry URL in the Dockerfile from HTTP to HTTPS, and adds X-Content-Type-Options: nosniff to both security filter chains. Also fixes the deleteBooks test mocks that were broken by the earlier H1 fix.