### PR TITLE
fix medium and high severity security vulnerabilities

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/AudiobookReaderController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/AudiobookReaderController.java
@@ -46,6 +46,7 @@ public class AudiobookReaderController {
     @ApiResponse(responseCode = "200", description = "Full audio file returned")
     @ApiResponse(responseCode = "206", description = "Partial content returned (range request)")
     @ApiResponse(responseCode = "416", description = "Range not satisfiable")
+    @CheckBookAccess(bookIdParam = "bookId")
     @GetMapping("/{bookId}/stream")
     public void streamAudiobook(
             @Parameter(description = "ID of the book") @PathVariable Long bookId,
@@ -62,6 +63,7 @@ public class AudiobookReaderController {
     @ApiResponse(responseCode = "200", description = "Full track file returned")
     @ApiResponse(responseCode = "206", description = "Partial content returned (range request)")
     @ApiResponse(responseCode = "416", description = "Range not satisfiable")
+    @CheckBookAccess(bookIdParam = "bookId")
     @GetMapping("/{bookId}/track/{trackIndex}/stream")
     public void streamTrack(
             @Parameter(description = "ID of the book") @PathVariable Long bookId,
@@ -79,6 +81,7 @@ public class AudiobookReaderController {
                     "Uses token query parameter for authentication.")
     @ApiResponse(responseCode = "200", description = "Cover art returned successfully")
     @ApiResponse(responseCode = "404", description = "No embedded cover art found")
+    @CheckBookAccess(bookIdParam = "bookId")
     @GetMapping("/{bookId}/cover")
     public ResponseEntity<byte[]> getEmbeddedCover(
             @Parameter(description = "ID of the book") @PathVariable Long bookId,

--- a/booklore-api/src/main/java/org/booklore/controller/BookMarkController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/BookMarkController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/bookmarks")
+@PreAuthorize("isAuthenticated()")
 @Tag(name = "Bookmarks", description = "Endpoints for managing book bookmarks")
 public class BookMarkController {
 

--- a/booklore-api/src/main/java/org/booklore/controller/EpubReaderController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/EpubReaderController.java
@@ -1,5 +1,6 @@
 package org.booklore.controller;
 
+import org.booklore.config.security.annotation.CheckBookAccess;
 import org.booklore.model.dto.response.EpubBookInfo;
 import org.booklore.service.reader.EpubReaderService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +31,7 @@ public class EpubReaderController {
     @Operation(summary = "Get EPUB book info",
             description = "Retrieve parsed metadata, spine, manifest, and TOC for an EPUB book.")
     @ApiResponse(responseCode = "200", description = "Book info returned successfully")
+    @CheckBookAccess(bookIdParam = "bookId")
     @GetMapping("/{bookId}/info")
     public ResponseEntity<EpubBookInfo> getBookInfo(
             @Parameter(description = "ID of the book") @PathVariable Long bookId,
@@ -39,6 +41,7 @@ public class EpubReaderController {
 
     @Operation(summary = "Get file from EPUB", description = "Retrieve a specific file from within the EPUB archive (HTML, CSS, images, fonts, etc.).")
     @ApiResponse(responseCode = "200", description = "File content returned successfully")
+    @CheckBookAccess(bookIdParam = "bookId")
     @GetMapping("/{bookId}/file/**")
     public void getFile(
             @Parameter(description = "ID of the book") @PathVariable Long bookId,

--- a/booklore-api/src/main/java/org/booklore/mobile/service/MobileBookService.java
+++ b/booklore-api/src/main/java/org/booklore/mobile/service/MobileBookService.java
@@ -32,6 +32,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Tuple;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -263,7 +264,7 @@ public class MobileBookService {
         }
 
         long maxOffset = Math.max(0, totalElements - pageSize);
-        int randomOffset = (int) (Math.random() * (maxOffset + 1));
+        int randomOffset = ThreadLocalRandom.current().nextInt((int) maxOffset + 1);
 
         Pageable pageable = PageRequest.of(randomOffset / pageSize, pageSize);
         Page<BookEntity> bookPage = bookRepository.findAll(spec, pageable);

--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
@@ -96,7 +96,7 @@ public class GoodReadsParser implements BookParser, DetailedMetadataProvider {
     public List<BookMetadata> fetchMetadata(Book book, FetchMetadataRequest fetchMetadataRequest) {
         String isbn = ParserUtils.cleanIsbn(fetchMetadataRequest.getIsbn());
         if (isbn != null && !isbn.isBlank()) {
-            log.info("Goodreads Query URL (ISBN): " + BASE_ISBN_URL + "{}", isbn);
+            log.info("Goodreads Query URL (ISBN): {}{}", BASE_ISBN_URL, isbn);
             Document doc = fetchDoc(BASE_ISBN_URL + isbn);
             String ogUrl = Optional.ofNullable(doc.selectFirst("meta[property=og:url]"))
                     .map(e -> e.attr("content"))

--- a/booklore-api/src/main/java/org/booklore/service/opds/OpdsFeedService.java
+++ b/booklore-api/src/main/java/org/booklore/service/opds/OpdsFeedService.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.exception.ApiError;
 import org.booklore.config.security.userdetails.OpdsUserDetails;
 import org.booklore.model.dto.Book;
 import org.booklore.model.dto.BookFile;
@@ -747,9 +748,10 @@ public class OpdsFeedService {
 
     private Long getUserId() {
         OpdsUserDetails details = authenticationService.getOpdsUser();
-        return details != null && details.getOpdsUserV2() != null
-                ? details.getOpdsUserV2().getUserId()
-                : null;
+        if (details == null || details.getOpdsUserV2() == null) {
+            throw ApiError.FORBIDDEN.createException("OPDS authentication required");
+        }
+        return details.getOpdsUserV2().getUserId();
     }
 
     private OpdsSortOrder getSortOrder() {

--- a/booklore-api/src/main/resources/application.yaml
+++ b/booklore-api/src/main/resources/application.yaml
@@ -46,6 +46,10 @@ spring:
       request-timeout: 600000
   application:
     name: booklore-api
+  data:
+    web:
+      pageable:
+        max-page-size: 100
   datasource:
     url: ${DATABASE_URL:jdbc:mariadb://${DATABASE_HOST:${DB_HOST:mariadb}}:${DATABASE_PORT:3306}/${DATABASE_NAME:booklore}?createDatabaseIfNotExist=true}
     username: ${DATABASE_USERNAME:root}

--- a/booklore-api/src/test/java/org/booklore/service/opds/OpdsFeedServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/opds/OpdsFeedServiceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 class OpdsFeedServiceTest {
@@ -115,10 +116,11 @@ class OpdsFeedServiceTest {
     }
 
     @Test
-    void generateShelvesNavigation_shouldHandleNullUserDetails() {
+    void generateShelvesNavigation_shouldThrowWhenNotAuthenticated() {
         when(authenticationService.getOpdsUser()).thenReturn(null);
-        String xml = opdsFeedService.generateShelvesNavigation(request);
-        assertThat(xml).contains("</feed>");
+        assertThatThrownBy(() -> opdsFeedService.generateShelvesNavigation(request))
+                .isInstanceOf(org.booklore.exception.APIException.class)
+                .hasMessageContaining("OPDS authentication required");
         verify(opdsBookService, never()).getUserShelves(any());
     }
 
@@ -300,14 +302,14 @@ class OpdsFeedServiceTest {
     }
 
     @Test
-    void getUserId_shouldReturnNullWhenNotAuthenticated() throws Exception {
+    void getUserId_shouldThrowWhenNotAuthenticated() throws Exception {
         when(authenticationService.getOpdsUser()).thenReturn(null);
 
         var method = OpdsFeedService.class.getDeclaredMethod("getUserId");
         method.setAccessible(true);
-        Long userId = (Long) method.invoke(opdsFeedService);
-
-        assertThat(userId).isNull();
+        assertThatThrownBy(() -> method.invoke(opdsFeedService))
+                .hasCauseInstanceOf(org.booklore.exception.APIException.class)
+                .hasRootCauseMessage("OPDS authentication required");
     }
 
     @Test


### PR DESCRIPTION
Fixes a batch of security audit findings: adds @CheckBookAccess to EPUB/audiobook streaming endpoints (C2), makes OPDS fail closed on null user instead of returning null (H3), cleans up string concat in a log statement (H8), swaps Math.random() for ThreadLocalRandom (M7), adds a global max page size of 100 for Spring Pageable (M8), and adds @PreAuthorize("isAuthenticated()") to BookMarkController as defense-in-depth (M10).