### PR TITLE
tune jvm flags for containerized deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ LABEL org.opencontainers.image.title="BookLore" \
       org.opencontainers.image.licenses="GPL-3.0" \
       org.opencontainers.image.base.name="docker.io/library/eclipse-temurin:25-jre-alpine"
 
-ENV JAVA_TOOL_OPTIONS="-XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=75.0"
+ENV JAVA_TOOL_OPTIONS="-XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:+UseStringDeduplication -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
 
 ARG TARGETARCH
 RUN apk update && apk add --no-cache su-exec libstdc++ libgcc && \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -16,7 +16,7 @@ LABEL org.opencontainers.image.title="BookLore" \
       org.opencontainers.image.licenses="GPL-3.0" \
       org.opencontainers.image.base.name="docker.io/library/eclipse-temurin:25-jre-alpine"
 
-ENV JAVA_TOOL_OPTIONS="-XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=75.0"
+ENV JAVA_TOOL_OPTIONS="-XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:+UseStringDeduplication -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
 
 ARG TARGETARCH
 RUN apk update && apk add --no-cache su-exec libstdc++ libgcc

--- a/example-docker/docker-compose.yml
+++ b/example-docker/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - SWAGGER_ENABLED=false                               # Enable or disable Swagger UI (API docs). Set to 'true' to allow access; 'false' to block access (recommended for production).
       - FORCE_DISABLE_OIDC=false                            # Set to 'true' to force-disable OIDC and allow internal login, regardless of UI config
       # ALLOWED_ORIGINS=                                    # Comma-separated list of allowed cross-origin URLs for CORS (e.g. https://app.example.com). Defaults to '*' (allow all) if unset. Leave empty to restrict to same-origin.
+      # JAVA_TOOL_OPTIONS=-XX:+UseSerialGC -Xmx256m -XX:+UseCompactObjectHeaders -XX:+ExitOnOutOfMemoryError  # For very constrained hardware (RPi 3, 512MB RAM). Uncomment and adjust as needed.
     depends_on:
       mariadb:
         condition: service_healthy


### PR DESCRIPTION
Cleans up the default JAVA_TOOL_OPTIONS in both Dockerfiles. Drops redundant flags (MaxGCPauseMillis=200 is already G1's default, UseContainerSupport has been on since JDK 10), adds ExitOnOutOfMemoryError so the container restarts cleanly instead of leaving a zombie JVM on OOM. Also adds a commented-out override in the example docker-compose for users on constrained hardware like Raspberry Pis.