### PR TITLE
fix magic shelf audiobook duration filter (#3059)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/book/BookQueryService.java
+++ b/booklore-api/src/main/java/org/booklore/service/book/BookQueryService.java
@@ -150,7 +150,9 @@ public class BookQueryService {
             m.setExternalUrl(null);
             m.setThumbnailUrl(null);
             m.setProvider(null);
-            m.setAudiobookMetadata(null);
+            if (m.getAudiobookMetadata() != null) {
+                m.getAudiobookMetadata().setChapters(null);
+            }
             m.setBookReviews(null);
 
             // Strip unused ratings

--- a/booklore-ui/src/app/features/magic-shelf/component/magic-shelf-component.ts
+++ b/booklore-ui/src/app/features/magic-shelf/component/magic-shelf-component.ts
@@ -279,7 +279,10 @@ export class MagicShelfComponent implements OnInit {
     {label: 'CB7', value: 'cb7'},
     {label: 'FB2', value: 'fb2'},
     {label: 'MOBI', value: 'mobi'},
-    {label: 'AZW3', value: 'azw3'}
+    {label: 'AZW3', value: 'azw3'},
+    {label: 'M4B', value: 'm4b'},
+    {label: 'M4A', value: 'm4a'},
+    {label: 'MP3', value: 'mp3'}
   ];
 
   get readStatusOptions() {


### PR DESCRIPTION
the list endpoint was stripping audiobookMetadata entirely in the list view response, so the frontend magic shelf evaluator never had durationSeconds to work with. changed it to only strip the heavy chapters array instead of the whole object. also added m4b, m4a, mp3 to the file type dropdown since those were missing.

Fixes #3059