### PR TITLE
fix comic book deletion failing with transient entity error (#3000)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/book/BookService.java
+++ b/booklore-api/src/main/java/org/booklore/service/book/BookService.java
@@ -425,7 +425,7 @@ public class BookService {
             }
         }
 
-        bookRepository.deleteAll(books);
+        bookRepository.deleteAllInBatch(books);
         auditService.log(AuditAction.BOOK_DELETED, "Deleted " + ids.size() + " book(s)");
         BookDeletionResponse response = new BookDeletionResponse(ids, failedFileDeletions);
         return failedFileDeletions.isEmpty()

--- a/booklore-api/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -374,7 +374,7 @@ class BookServiceTest {
         Files.createDirectories(filePath.getParent());
         Files.write(filePath, "abc".getBytes());
 
-        doNothing().when(bookRepository).deleteAll(anyList());
+        doNothing().when(bookRepository).deleteAllInBatch(anyList());
         when(bookQueryService.findAllWithMetadataByIds(Set.of(11L))).thenReturn(List.of(entity));
         when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);
 
@@ -405,7 +405,7 @@ class BookServiceTest {
 
         when(bookQueryService.findAllWithMetadataByIds(Set.of(13L))).thenReturn(List.of(entity));
         when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);
-        doNothing().when(bookRepository).deleteAll(anyList());
+        doNothing().when(bookRepository).deleteAllInBatch(anyList());
 
         BookDeletionResponse response = bookService.deleteBooks(Set.of(13L)).getBody();
 


### PR DESCRIPTION
Deleting comics (cbz, cbx, etc.) was throwing a TransientPropertyValueException because Hibernate's persistence context still held the loaded ComicMetadataEntity referencing a now-removed BookMetadataEntity. Switched from deleteAll to deleteAllInBatch so the delete goes straight to SQL, letting the DB's ON DELETE CASCADE chain handle cleanup across book_metadata and comic_metadata.

Fixes #3000