### PR TITLE
fix: Add non-lowercased auth header to include list

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/kobo/KoboServerProxy.java
+++ b/booklore-api/src/main/java/org/booklore/service/kobo/KoboServerProxy.java
@@ -39,6 +39,7 @@ public class KoboServerProxy {
 
     private static final Set<String> HEADERS_OUT_INCLUDE = Set.of(
             HttpHeaders.AUTHORIZATION.toLowerCase(),
+            HttpHeaders.AUTHORIZATION,
             HttpHeaders.USER_AGENT,
             HttpHeaders.ACCEPT,
             HttpHeaders.ACCEPT_LANGUAGE


### PR DESCRIPTION
## 📝 Description

Kobo Sync proxy appears to be broken as mentioned on discord multiple times and also some github issues. I am experiencing this issue as well.

**Linked Issue:** Fixes #3009

> **Required.** Every PR must reference an approved issue. If no issue exists, [open one](https://github.com/booklore-app/booklore/issues/new) and wait for maintainer approval before submitting a PR. Unsolicited PRs without a linked issue will be closed.

## 🏷️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor (no behavior change)
- [ ] Breaking change (existing functionality affected)
- [ ] Documentation update

## 🔧 Changes

<!-- List the specific modifications made -->
- Added a non-lowercased version of the Authorization header to the headers to include list, as the header coming from my Kobo Clara HD starts with a capital A.

## 🧪 Testing (MANDATORY)

> **PRs without this section filled out will be closed.** "Tests pass" or "Tested locally" is not sufficient. You must provide specifics.

**Manual testing steps you performed:**
1. Connected my Kobo Clara HD to the local Booklore instance running in Intellij
2. Tried to access to Discover page
3. It loads successfully, browsed around in the store for a bit and tested the Kobo Plus and OverDrive pages as well. Previously this just led to the Network error popup on the device.

**Regression testing:**
- I left the lowercase version in the include list as I am assuming it was lowercased for a reason. Might be different casing in different firmware versions?

**Edge cases covered:**
- None

**Test output:**
<!-- Paste the actual terminal output from running tests. Not "all pass", the real output. -->

<details>
<summary>Backend test output (<code>./gradlew test</code>)</summary>

```
➜  booklore-api git:(fix/kobo-sync-auth) ✗ ./gradlew clean test

> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
Management of bidirectional association persistent attributes is deprecated and will be removed. Set the value to 'false' to get rid of this warning

> Task :compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction (file:/home/iszla/.gradle/caches/modules-2/files-2.1/net.bytebuddy/byte-buddy/1.17.8/af5735f63d00ca47a9375fae5c7471a36331c6ed/byte-buddy-1.17.8.jar)
WARNING: Please consider reporting this to the maintainers of class net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
2026-02-27T17:13:20.122+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.s.m.s.b.SimpleBrokerMessageHandler     : Stopping...
2026-02-27T17:13:20.122+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.s.m.s.b.SimpleBrokerMessageHandler     : BrokerAvailabilityEvent[available=false, SimpleBrokerMessageHandler [org.springframework.messaging.simp.broker.DefaultSubscriptionRegistry@591b8ed3]]
2026-02-27T17:13:20.122+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.s.m.s.b.SimpleBrokerMessageHandler     : Stopped.
2026-02-27T17:13:20.135+01:00  INFO 25339 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-27T17:13:20.136+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-27T17:13:20.290+01:00  INFO 25339 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-27T17:13:20.291+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-27T17:13:20.291+01:00  WARN 25339 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-27T17:13:20.291+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-27T17:13:20.296+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-27T17:13:20.308+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-27T17:13:20.308+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-27T17:13:20.312+01:00  INFO 25339 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-27T17:13:20.312+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-27T17:13:20.312+01:00  INFO 25339 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-27T17:13:20.313+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-27T17:13:20.313+01:00  WARN 25339 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-27T17:13:20.313+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-27T17:13:20.318+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-27T17:13:20.319+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-27T17:13:20.320+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-27T17:13:20.323+01:00  INFO 25339 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-27T17:13:20.323+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-27T17:13:20.323+01:00  INFO 25339 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-27T17:13:20.324+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-27T17:13:20.324+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-27T17:13:20.324+01:00  WARN 25339 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-27T17:13:20.329+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-27T17:13:20.334+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-27T17:13:20.335+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-27T17:13:20.339+01:00  INFO 25339 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-27T17:13:20.339+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-27T17:13:20.339+01:00  INFO 25339 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-27T17:13:20.340+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-27T17:13:20.340+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-27T17:13:20.340+01:00  WARN 25339 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-27T17:13:20.345+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-27T17:13:20.350+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-27T17:13:20.350+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-27T17:13:20.354+01:00  INFO 25339 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-27T17:13:20.354+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-27T17:13:20.354+01:00  INFO 25339 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-27T17:13:20.355+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-27T17:13:20.355+01:00  WARN 25339 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-27T17:13:20.355+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-27T17:13:20.360+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-27T17:13:20.365+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-27T17:13:20.365+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.
2026-02-27T17:13:20.368+01:00  INFO 25339 --- [booklore-api] [opFolderWatcher] o.b.s.b.BookdropMonitoringService        : Bookdrop monitor thread interrupted
2026-02-27T17:13:20.369+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.b.BookdropMonitoringService        : Stopped bookdrop folder monitor
2026-02-27T17:13:20.370+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.monitoring.MonitoringService       : Shutting down monitoring service...
2026-02-27T17:13:20.370+01:00  WARN 25339 --- [booklore-api] [        async-0] o.b.service.monitoring.MonitoringTask    : WatchService has been closed. Stopping monitoring.
2026-02-27T17:13:20.370+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] o.b.s.watcher.LibraryFileEventProcessor  : Shutting down LibraryFileEventProcessor...
2026-02-27T17:13:20.370+01:00  INFO 25339 --- [booklore-api] [opFileProcessor] o.b.s.b.BookdropEventHandlerService      : File processing thread interrupted, shutting down.
2026-02-27T17:13:20.375+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2026-02-27T17:13:20.379+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown initiated...
2026-02-27T17:13:20.379+01:00  INFO 25339 --- [booklore-api] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : BookloreHikariPool - Shutdown completed.

[Incubating] Problems report is available at: file:///home/iszla/code/booklore/booklore-api/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 1m 12s
7 actionable tasks: 7 executed
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.3.1/userguide/configuration_cache_enabling.html
```

</details>

<details>
<summary>Frontend test output (<code>ng test</code>)</summary>

```
PASTE OUTPUT HERE
```

</details>

## 📸 Screen Recording / Screenshots (MANDATORY)

> Every PR must include a **screen recording or screenshots** showing the change working end-to-end in a running local instance (both backend and frontend). This means you must have actually built, run, and tested the code yourself. PRs without visual proof will be closed without review.

<!-- Attach screen recording or screenshots here -->

---

## ✅ Pre-Submission Checklist

> **All boxes must be checked before requesting review.** Incomplete PRs will be closed without review. No exceptions.

- [ ] This PR is linked to an approved issue
- [ ] Code follows project style guidelines and conventions
- [ ] Branch is up to date with `develop` (merge conflicts resolved)
- [ ] I ran the full stack locally (backend + frontend + database) and verified the change works
- [ ] Automated tests added or updated to cover changes (backend **and** frontend)
- [ ] All tests pass locally and output is pasted above
- [ ] Screen recording or screenshots are attached above proving the change works
- [ ] PR is a single focused change (one bug fix OR one feature, not multiple unrelated changes)
- [ ] PR is reasonably scoped (PRs over 1000+ changed lines will be closed, split into smaller PRs)
- [ ] No unsolicited refactors, cleanups, or "improvements" are bundled in
- [ ] Flyway migration versioning is correct _(if schema was modified)_
- [ ] Documentation PR submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(if user-facing changes)_

### 🤖 AI-Assisted Contributions

> **If any part of this PR was generated or assisted by AI tools (Copilot, Claude, ChatGPT, etc.), all items below are mandatory.** You are fully responsible for every line you submit. "The AI wrote it" is not an excuse, and AI-generated PRs that clearly haven't been reviewed are the #1 reason PRs get closed.

- [ ] I have read and understand every line of this PR and can explain any part of it during review
- [ ] I personally ran the code and verified it works (not just trusted the AI's output)
- [ ] PR is scoped to a single logical change, not a dump of everything the AI suggested
- [ ] Tests validate actual behavior, not just coverage (AI-generated tests often assert nothing meaningful)
- [ ] No dead code, placeholder comments, `TODO`s, or unused scaffolding left behind by AI
- [ ] I did not submit refactors, style changes, or "improvements" the AI suggested beyond the scope of the issue

---

## 💬 Additional Context _(optional)_

<!-- Any extra information or discussion points for reviewers -->
