### PR TITLE
add backend and frontend conventions to contributing docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -72,7 +72,7 @@ PASTE OUTPUT HERE
 > **All boxes must be checked before requesting review.** Incomplete PRs will be closed without review. No exceptions.
 
 - [ ] This PR is linked to an approved issue
-- [ ] Code follows project style guidelines and conventions
+- [ ] Code follows project [backend and frontend conventions](../CONTRIBUTING.md#backend-conventions)
 - [ ] Branch is up to date with `develop` (merge conflicts resolved)
 - [ ] I ran the full stack locally (backend + frontend + database) and verified the change works
 - [ ] Automated tests added or updated to cover changes (backend **and** frontend)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ volumes:
 | 💬 **Come hang out** | [Discord Server](https://discord.gg/Ee5hd458Uz) |
 
 > [!WARNING]
-> **Before opening a PR:** Open an issue first and get maintainer approval. PRs without a linked issue, without screenshots/video proof, or without pasted test output will be closed. AI-assisted contributions are welcome, but you must run, test, and understand every line you submit. See the [Contributing Guide](CONTRIBUTING.md) for full details.
+> **Before opening a PR:** Open an issue first and get maintainer approval. PRs without a linked issue, without screenshots/video proof, or without pasted test output will be closed. All code must follow project [backend](CONTRIBUTING.md#backend-conventions) and [frontend](CONTRIBUTING.md#frontend-conventions) conventions. AI-assisted contributions are welcome, but you must run, test, and understand every line you submit. See the [Contributing Guide](CONTRIBUTING.md) for full details.
 
 ---
 


### PR DESCRIPTION
Adds explicit backend and frontend convention sections to CONTRIBUTING.md so contributors (and their AI tools) know the standards before submitting code. Updates the README warning to link to the new sections, and swaps the vague 'follows project style' checklist item in the PR template for one that points directly at the conventions. Also bumps the Java version references from 21 to 25, fixes Node.js minimum to 20+, removes the stale roadmap link, folds the old Code Style table into the convention sections, and adds Flyway migration rules.