### PR TITLE
Clear book selection when navigating between libraries/shelves (#3073)

### DIFF
--- a/booklore-ui/src/app/core/custom-reuse-strategy.ts
+++ b/booklore-ui/src/app/core/custom-reuse-strategy.ts
@@ -1,6 +1,7 @@
 import {inject, Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, DetachedRouteHandle, RouteReuseStrategy} from '@angular/router';
 import {BookBrowserScrollService} from '../features/book/components/book-browser/book-browser-scroll.service';
+import {BookSelectionService} from '../features/book/components/book-browser/book-selection.service';
 
 @Injectable({
   providedIn: 'root',
@@ -8,6 +9,7 @@ import {BookBrowserScrollService} from '../features/book/components/book-browser
 export class CustomReuseStrategy implements RouteReuseStrategy {
   private storedRoutes = new Map<string, DetachedRouteHandle>();
   private scrollService = inject(BookBrowserScrollService);
+  private bookSelectionService = inject(BookSelectionService);
 
   private readonly BOOK_BROWSER_PATHS = [
     'all-books',
@@ -39,6 +41,7 @@ export class CustomReuseStrategy implements RouteReuseStrategy {
     if (handle && this.isBookBrowserRoute(route)) {
       const key = this.getRouteKey(route);
       this.storedRoutes.set(key, handle);
+      this.bookSelectionService.deselectAll();
     }
   }
 


### PR DESCRIPTION
The custom route reuse strategy was detaching and caching book browser components on navigation, but the BookSelectionService (a root singleton) kept the selected book IDs around. So if you selected books in one library and switched to another, those selections silently persisted in the background. Now selection gets cleared in the reuse strategy's store() hook whenever a book browser route is detached.

Fixes #3073