### PR TITLE
Add option to disable support button animation (#3075)

### DIFF
--- a/booklore-ui/src/app/features/settings/global-preferences/global-preferences.component.html
+++ b/booklore-ui/src/app/features/settings/global-preferences/global-preferences.component.html
@@ -14,6 +14,33 @@
     <div class="preferences-section">
       <div class="section-header">
         <h3 class="section-title">
+          <i class="pi pi-palette"></i>
+          {{ t('appearance.sectionTitle') }}
+        </h3>
+      </div>
+
+      <div class="settings-card">
+        <div class="setting-item">
+          <div class="setting-info">
+            <div class="setting-label-row">
+              <label class="setting-label">{{ t('appearance.supportButtonAnimation') }}</label>
+              <p-toggleswitch
+                [(ngModel)]="supportButtonAnimation"
+                (onChange)="onSupportAnimationChange($event.checked)">
+              </p-toggleswitch>
+            </div>
+            <p class="setting-description">
+              <i class="pi pi-info-circle"></i>
+              {{ t('appearance.supportButtonAnimationDesc') }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="preferences-section">
+      <div class="section-header">
+        <h3 class="section-title">
           <i class="pi pi-image"></i>
           {{ t('covers.sectionTitle') }}
         </h3>

--- a/booklore-ui/src/app/features/settings/global-preferences/global-preferences.component.ts
+++ b/booklore-ui/src/app/features/settings/global-preferences/global-preferences.component.ts
@@ -14,6 +14,8 @@ import {Slider} from 'primeng/slider';
 import {ExternalDocLinkComponent} from '../../../shared/components/external-doc-link/external-doc-link.component';
 import {TranslocoDirective, TranslocoPipe, TranslocoService} from '@jsverse/transloco';
 
+export const SUPPORT_ANIMATION_KEY = 'booklore-support-animation';
+
 @Component({
   selector: 'app-global-preferences',
   standalone: true,
@@ -37,6 +39,8 @@ export class GlobalPreferencesComponent implements OnInit {
     similarBookRecommendation: false,
     enableTelemetry: true,
   };
+
+  supportButtonAnimation = localStorage.getItem(SUPPORT_ANIMATION_KEY) !== 'false';
 
   coverCroppingSettings: CoverCroppingSettings = {
     verticalCroppingEnabled: false,
@@ -83,6 +87,12 @@ export class GlobalPreferencesComponent implements OnInit {
     } else {
       console.warn(`Unknown toggle key: ${settingKey}`);
     }
+  }
+
+  onSupportAnimationChange(checked: boolean): void {
+    this.supportButtonAnimation = checked;
+    localStorage.setItem(SUPPORT_ANIMATION_KEY, String(checked));
+    window.dispatchEvent(new StorageEvent('storage', {key: SUPPORT_ANIMATION_KEY, newValue: String(checked)}));
   }
 
   onCoverCroppingChange(): void {

--- a/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.html
+++ b/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.html
@@ -117,12 +117,16 @@
           </p-popover>
         </li>
 
-        <li class="topbar-item-relative heart-button topbar-item" (click)="openGithubSupportDialog()">
-          <span class="heart-ripple"></span>
-          <span class="heart-ripple heart-ripple-delayed"></span>
-          <span class="heart-orbit heart-orbit-1"></span>
-          <span class="heart-orbit heart-orbit-2"></span>
-          <span class="heart-orbit heart-orbit-3"></span>
+        <li class="topbar-item-relative heart-button topbar-item"
+            [class.heart-button-static]="!supportAnimationEnabled"
+            (click)="openGithubSupportDialog()">
+          @if (supportAnimationEnabled) {
+            <span class="heart-ripple"></span>
+            <span class="heart-ripple heart-ripple-delayed"></span>
+            <span class="heart-orbit heart-orbit-1"></span>
+            <span class="heart-orbit heart-orbit-2"></span>
+            <span class="heart-orbit heart-orbit-3"></span>
+          }
           <i class="pi pi-heart-fill heart-icon"></i>
         </li>
         <li class="topbar-item-relative">

--- a/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.scss
+++ b/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.scss
@@ -133,6 +133,18 @@
   transition: filter 0.3s;
 }
 
+.heart-button-static {
+  .heart-icon {
+    animation: none;
+    filter: none;
+  }
+
+  &:hover .heart-icon {
+    animation: none;
+    filter: none;
+  }
+}
+
 .mobile-trigger {
   display: none;
   position: relative;

--- a/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.ts
+++ b/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.ts
@@ -28,6 +28,7 @@ import {Menu} from 'primeng/menu';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {AVAILABLE_LANGS, LANG_LABELS} from '../../../../core/config/transloco-loader';
 import {LANG_STORAGE_KEY} from '../../../../core/config/language-initializer';
+import {SUPPORT_ANIMATION_KEY} from '../../../../features/settings/global-preferences/global-preferences.component';
 
 @Component({
   selector: 'app-topbar',
@@ -70,6 +71,7 @@ export class AppTopBarComponent implements OnDestroy {
   showPulse = false;
   hasAnyTasks = false;
   hasPendingBookdropFiles = false;
+  supportAnimationEnabled = localStorage.getItem(SUPPORT_ANIMATION_KEY) !== 'false';
 
   private eventTimer: number | undefined;
   private destroy$ = new Subject<void>();
@@ -101,6 +103,9 @@ export class AppTopBarComponent implements OnDestroy {
       icon: lang === this.activeLang ? 'pi pi-check' : undefined,
       command: () => this.switchLanguage(lang),
     }));
+    this.onStorageChange = this.onStorageChange.bind(this);
+    window.addEventListener('storage', this.onStorageChange);
+
     this.subscribeToMetadataProgress();
     this.subscribeToNotifications();
 
@@ -132,8 +137,15 @@ export class AppTopBarComponent implements OnDestroy {
   ngOnDestroy(): void {
     if (this.ref) this.ref.close();
     clearTimeout(this.eventTimer);
+    window.removeEventListener('storage', this.onStorageChange);
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  private onStorageChange(event: StorageEvent): void {
+    if (event.key === SUPPORT_ANIMATION_KEY) {
+      this.supportAnimationEnabled = event.newValue !== 'false';
+    }
   }
 
   toggleMenu() {

--- a/booklore-ui/src/i18n/en/settings-application.json
+++ b/booklore-ui/src/i18n/en/settings-application.json
@@ -34,6 +34,11 @@
     "invalidInput": "Invalid Input",
     "invalidInputDetail": "Please enter a valid max file upload size in MB."
   },
+  "appearance": {
+    "sectionTitle": "Appearance",
+    "supportButtonAnimation": "Support Button Animation",
+    "supportButtonAnimationDesc": "Show the animated heart effect on the support button in the top bar. Disabling this keeps the button visible but removes the animation."
+  },
   "telemetry": {
     "sectionTitle": "Telemetry",
     "enableTelemetry": "Enable Telemetry",

--- a/booklore-ui/src/i18n/es/settings-application.json
+++ b/booklore-ui/src/i18n/es/settings-application.json
@@ -34,6 +34,11 @@
     "invalidInput": "Entrada inválida",
     "invalidInputDetail": "Introduce un tamaño máximo de carga de archivo válido en MB."
   },
+  "appearance": {
+    "sectionTitle": "Apariencia",
+    "supportButtonAnimation": "Animación del botón de apoyo",
+    "supportButtonAnimationDesc": "Muestra el efecto animado de corazón en el botón de apoyo en la barra superior. Desactivar esto mantiene el botón visible pero elimina la animación."
+  },
   "telemetry": {
     "sectionTitle": "Telemetría",
     "enableTelemetry": "Habilitar telemetría",


### PR DESCRIPTION
Adds a toggle under a new Appearance section in Global Preferences to turn off the animated heart on the support button. Saves to localStorage so it's per-browser, no backend changes needed. The button stays, just the orbits/ripples/float animation go away.

Fixes #3075