### PR TITLE
Fix author endpoints leaking authors across library boundaries (#3077)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/repository/AuthorRepository.java
+++ b/booklore-api/src/main/java/org/booklore/repository/AuthorRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface AuthorRepository extends JpaRepository<AuthorEntity, Long> {
@@ -23,4 +24,10 @@ public interface AuthorRepository extends JpaRepository<AuthorEntity, Long> {
 
     @Query("SELECT a, COUNT(bm) FROM AuthorEntity a LEFT JOIN a.bookMetadataEntityList bm GROUP BY a ORDER BY a.name")
     List<Object[]> findAllWithBookCount();
+
+    @Query("SELECT a, COUNT(DISTINCT bm) FROM AuthorEntity a LEFT JOIN a.bookMetadataEntityList bm JOIN bm.book b WHERE b.library.id IN :libraryIds GROUP BY a ORDER BY a.name")
+    List<Object[]> findAllWithBookCountByLibraryIds(@Param("libraryIds") Set<Long> libraryIds);
+
+    @Query("SELECT COUNT(b) > 0 FROM AuthorEntity a JOIN a.bookMetadataEntityList bm JOIN bm.book b WHERE a.id = :authorId AND b.library.id IN :libraryIds")
+    boolean existsByIdAndLibraryIds(@Param("authorId") Long authorId, @Param("libraryIds") Set<Long> libraryIds);
 }

--- a/booklore-api/src/test/java/org/booklore/service/AuthorMetadataServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/AuthorMetadataServiceTest.java
@@ -1,8 +1,10 @@
 package org.booklore.service;
 
+import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.exception.APIException;
 import org.booklore.model.dto.AuthorDetails;
 import org.booklore.model.dto.AuthorSearchResult;
+import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.request.AuthorMatchRequest;
 import org.booklore.model.entity.AuthorEntity;
 import org.booklore.model.enums.AuditAction;
@@ -28,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class AuthorMetadataServiceTest {
@@ -37,6 +40,7 @@ class AuthorMetadataServiceTest {
     @Mock private AuditService auditService;
     @Mock private FileService fileService;
     @Mock private DuckDuckGoCoverService duckDuckGoCoverService;
+    @Mock private AuthenticationService authenticationService;
 
     private AuthorMetadataService service;
 
@@ -45,7 +49,12 @@ class AuthorMetadataServiceTest {
         Map<AuthorMetadataSource, AuthorParser> authorParserMap = Map.of(
                 AuthorMetadataSource.AUDNEXUS, authorParser
         );
-        service = new AuthorMetadataService(authorRepository, authorParserMap, auditService, fileService, duckDuckGoCoverService);
+        service = new AuthorMetadataService(authorRepository, authorParserMap, auditService, fileService, duckDuckGoCoverService, authenticationService);
+
+        BookLoreUser.UserPermissions adminPermissions = new BookLoreUser.UserPermissions();
+        adminPermissions.setAdmin(true);
+        BookLoreUser adminUser = BookLoreUser.builder().id(1L).permissions(adminPermissions).build();
+        lenient().when(authenticationService.getAuthenticatedUser()).thenReturn(adminUser);
     }
 
     @Test


### PR DESCRIPTION
Non-admin users could see all authors in the system, including ones from libraries they don't have access to. Now the author list and detail endpoints filter by the user's assigned libraries, same as the book endpoints already do. Admins still see everything.

Fixes #3077