### PR TITLE
fix title sort using series name instead of book title (#3070)

### DIFF
--- a/booklore-ui/src/app/features/book/service/sort.service.ts
+++ b/booklore-ui/src/app/features/book/service/sort.service.ts
@@ -61,9 +61,7 @@ export class SortService {
   };
 
   private readonly fieldExtractors: Record<string, (book: Book) => unknown> = {
-    title: (book) => book.metadata?.seriesName?.toLowerCase()
-      || book.metadata?.title?.toLowerCase()
-      || null,
+    title: (book) => book.metadata?.title?.toLowerCase() || null,
     author: (book) => book.metadata?.authors?.map(a => a.toLowerCase()).join(", ") || null,
     authorSurnameVorname: (book) => book.metadata?.authors?.map(a => {
       const parts = a.trim().split(/\s+/);


### PR DESCRIPTION
The title sort field extractor was prioritizing series name over the actual book title, so books in a series would sort by their series name instead of the book title. Now it just sorts by title like it should.

Fixes #3070