### PR TITLE
Fix metadata search save clearing age rating and content rating (#3069)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/MetadataController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/MetadataController.java
@@ -65,7 +65,8 @@ public class MetadataController {
     public ResponseEntity<BookMetadata> updateMetadata(
             @Parameter(description = "Metadata update wrapper") @RequestBody MetadataUpdateWrapper metadataUpdateWrapper,
             @Parameter(description = "ID of the book") @PathVariable long bookId,
-            @Parameter(description = "Merge categories") @RequestParam(defaultValue = "false") boolean mergeCategories) {
+            @Parameter(description = "Merge categories") @RequestParam(defaultValue = "false") boolean mergeCategories,
+            @Parameter(description = "Replace mode") @RequestParam(defaultValue = "REPLACE_ALL") MetadataReplaceMode replaceMode) {
         BookEntity bookEntity = bookRepository.findAllWithMetadataByIds(java.util.Collections.singleton(bookId)).stream()
                 .findFirst()
                 .orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
@@ -75,7 +76,7 @@ public class MetadataController {
                 .metadataUpdateWrapper(metadataUpdateWrapper)
                 .updateThumbnail(true)
                 .mergeCategories(mergeCategories)
-                .replaceMode(MetadataReplaceMode.REPLACE_ALL)
+                .replaceMode(replaceMode)
                 .mergeMoods(false)
                 .mergeTags(false)
                 .build();

--- a/booklore-api/src/test/java/org/booklore/service/metadata/BookMetadataUpdaterTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/BookMetadataUpdaterTest.java
@@ -554,4 +554,185 @@ class BookMetadataUpdaterTest {
         assertEquals("Existing Title", bookEntity.getMetadata().getTitle(),
                 "Title should NOT be replaced when using REPLACE_MISSING mode and title exists");
     }
+
+    @Test
+    void setBookMetadata_withReplaceWhenProvided_shouldPreserveExistingAgeRatingWhenIncomingIsNull() {
+        BookEntity bookEntity = createBookEntity();
+        bookEntity.getMetadata().setAgeRating(16);
+        bookEntity.getMetadata().setAgeRatingLocked(false);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setTitle("Some Title");
+
+        MetadataUpdateContext context = buildContext(bookEntity, newMetadata, MetadataReplaceMode.REPLACE_WHEN_PROVIDED);
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertEquals(16, bookEntity.getMetadata().getAgeRating(),
+                "ageRating should be preserved when incoming value is null and mode is REPLACE_WHEN_PROVIDED");
+    }
+
+    @Test
+    void setBookMetadata_withReplaceWhenProvided_shouldPreserveExistingContentRatingWhenIncomingIsNull() {
+        BookEntity bookEntity = createBookEntity();
+        bookEntity.getMetadata().setContentRating("Mature");
+        bookEntity.getMetadata().setContentRatingLocked(false);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setTitle("Some Title");
+
+        MetadataUpdateContext context = buildContext(bookEntity, newMetadata, MetadataReplaceMode.REPLACE_WHEN_PROVIDED);
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertEquals("Mature", bookEntity.getMetadata().getContentRating(),
+                "contentRating should be preserved when incoming value is null and mode is REPLACE_WHEN_PROVIDED");
+    }
+
+    @Test
+    void setBookMetadata_withReplaceAll_shouldClearAgeRatingWhenIncomingIsNull() {
+        BookEntity bookEntity = createBookEntity();
+        bookEntity.getMetadata().setAgeRating(16);
+        bookEntity.getMetadata().setAgeRatingLocked(false);
+
+        BookMetadata newMetadata = new BookMetadata();
+
+        MetadataUpdateContext context = buildContext(bookEntity, newMetadata, MetadataReplaceMode.REPLACE_ALL);
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertNull(bookEntity.getMetadata().getAgeRating(),
+                "ageRating should be cleared when incoming value is null and mode is REPLACE_ALL");
+    }
+
+    @Test
+    void setBookMetadata_withReplaceAll_shouldClearContentRatingWhenIncomingIsNull() {
+        BookEntity bookEntity = createBookEntity();
+        bookEntity.getMetadata().setContentRating("Mature");
+        bookEntity.getMetadata().setContentRatingLocked(false);
+
+        BookMetadata newMetadata = new BookMetadata();
+
+        MetadataUpdateContext context = buildContext(bookEntity, newMetadata, MetadataReplaceMode.REPLACE_ALL);
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertNull(bookEntity.getMetadata().getContentRating(),
+                "contentRating should be cleared when incoming value is null and mode is REPLACE_ALL");
+    }
+
+    @Test
+    void setBookMetadata_withReplaceWhenProvided_shouldUpdateAgeRatingWhenProvided() {
+        BookEntity bookEntity = createBookEntity();
+        bookEntity.getMetadata().setAgeRating(12);
+        bookEntity.getMetadata().setAgeRatingLocked(false);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setAgeRating(18);
+
+        MetadataUpdateContext context = buildContext(bookEntity, newMetadata, MetadataReplaceMode.REPLACE_WHEN_PROVIDED);
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertEquals(18, bookEntity.getMetadata().getAgeRating(),
+                "ageRating should be updated when a new value is provided");
+    }
+
+    @Test
+    void setBookMetadata_withReplaceWhenProvided_shouldUpdateContentRatingWhenProvided() {
+        BookEntity bookEntity = createBookEntity();
+        bookEntity.getMetadata().setContentRating("Teen");
+        bookEntity.getMetadata().setContentRatingLocked(false);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setContentRating("Mature");
+
+        MetadataUpdateContext context = buildContext(bookEntity, newMetadata, MetadataReplaceMode.REPLACE_WHEN_PROVIDED);
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertEquals("Mature", bookEntity.getMetadata().getContentRating(),
+                "contentRating should be updated when a new value is provided");
+    }
+
+    @Test
+    void setBookMetadata_withReplaceWhenProvided_shouldPreserveExistingTitleWhenIncomingIsNull() {
+        BookEntity bookEntity = createBookEntity();
+        bookEntity.getMetadata().setTitle("Existing Title");
+        bookEntity.getMetadata().setTitleLocked(false);
+
+        BookMetadata newMetadata = new BookMetadata();
+
+        MetadataUpdateContext context = buildContext(bookEntity, newMetadata, MetadataReplaceMode.REPLACE_WHEN_PROVIDED);
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertEquals("Existing Title", bookEntity.getMetadata().getTitle(),
+                "Title should be preserved when incoming value is null and mode is REPLACE_WHEN_PROVIDED");
+    }
+
+    @Test
+    void setBookMetadata_withReplaceWhenProvided_shouldPreserveAuthorsWhenIncomingIsEmpty() {
+        BookEntity bookEntity = createBookEntity();
+        Set<AuthorEntity> existingAuthors = new HashSet<>();
+        existingAuthors.add(AuthorEntity.builder().name("Author1").build());
+        bookEntity.getMetadata().setAuthors(existingAuthors);
+        bookEntity.getMetadata().setAuthorsLocked(false);
+
+        BookMetadata newMetadata = new BookMetadata();
+
+        MetadataUpdateContext context = buildContext(bookEntity, newMetadata, MetadataReplaceMode.REPLACE_WHEN_PROVIDED);
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertEquals(1, bookEntity.getMetadata().getAuthors().size(),
+                "Authors should be preserved when incoming is null/empty and mode is REPLACE_WHEN_PROVIDED");
+    }
+
+    @Test
+    void setBookMetadata_withReplaceWhenProvided_lockedFieldShouldNotBeUpdated() {
+        BookEntity bookEntity = createBookEntity();
+        bookEntity.getMetadata().setAgeRating(12);
+        bookEntity.getMetadata().setAgeRatingLocked(true);
+
+        BookMetadata newMetadata = new BookMetadata();
+        newMetadata.setAgeRating(18);
+
+        MetadataUpdateContext context = buildContext(bookEntity, newMetadata, MetadataReplaceMode.REPLACE_WHEN_PROVIDED);
+
+        bookMetadataUpdater.setBookMetadata(context);
+
+        assertEquals(12, bookEntity.getMetadata().getAgeRating(),
+                "Locked ageRating should not be updated even when a new value is provided");
+    }
+
+    private BookEntity createBookEntity() {
+        BookEntity bookEntity = new BookEntity();
+        bookEntity.setId(1L);
+        BookMetadataEntity metadataEntity = new BookMetadataEntity();
+        metadataEntity.setBook(bookEntity);
+        bookEntity.setMetadata(metadataEntity);
+
+        BookFileEntity primaryFile = new BookFileEntity();
+        primaryFile.setBook(bookEntity);
+        primaryFile.setBookType(BookFileType.EPUB);
+        primaryFile.setBookFormat(true);
+        primaryFile.setFileSubPath("sub");
+        primaryFile.setFileName("file.epub");
+        bookEntity.setBookFiles(List.of(primaryFile));
+
+        return bookEntity;
+    }
+
+    private MetadataUpdateContext buildContext(BookEntity bookEntity, BookMetadata newMetadata, MetadataReplaceMode replaceMode) {
+        MetadataUpdateWrapper wrapper = MetadataUpdateWrapper.builder()
+                .metadata(newMetadata)
+                .build();
+
+        return MetadataUpdateContext.builder()
+                .bookEntity(bookEntity)
+                .metadataUpdateWrapper(wrapper)
+                .replaceMode(replaceMode)
+                .build();
+    }
 }

--- a/booklore-ui/src/app/features/book/service/book-metadata-manage.service.ts
+++ b/booklore-ui/src/app/features/book/service/book-metadata-manage.service.ts
@@ -24,8 +24,8 @@ export class BookMetadataManageService {
   private bookService = inject(BookService);
   private readonly t = inject(TranslocoService);
 
-  updateBookMetadata(bookId: number | undefined, wrapper: MetadataUpdateWrapper, mergeCategories: boolean): Observable<BookMetadata> {
-    const params = new HttpParams().set('mergeCategories', mergeCategories.toString());
+  updateBookMetadata(bookId: number | undefined, wrapper: MetadataUpdateWrapper, mergeCategories: boolean, replaceMode: 'REPLACE_ALL' | 'REPLACE_WHEN_PROVIDED' = 'REPLACE_ALL'): Observable<BookMetadata> {
+    const params = new HttpParams().set('mergeCategories', mergeCategories.toString()).set('replaceMode', replaceMode);
     return this.http.put<BookMetadata>(`${this.url}/${bookId}/metadata`, wrapper, {params}).pipe(
       map(updatedMetadata => {
         this.bookSocketService.handleBookMetadataUpdate(bookId!, updatedMetadata);

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-picker/metadata-picker.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-picker/metadata-picker.component.ts
@@ -289,7 +289,7 @@ export class MetadataPickerComponent implements OnInit {
     const updatedBookMetadata = this.buildMetadataWrapper(undefined);
 
     const requests: Observable<unknown>[] = [
-      this.bookMetadataManageService.updateBookMetadata(this.currentBookId, updatedBookMetadata, false)
+      this.bookMetadataManageService.updateBookMetadata(this.currentBookId, updatedBookMetadata, false, 'REPLACE_WHEN_PROVIDED')
     ];
 
     // Handle audiobook cover upload when fetched from Audible provider
@@ -517,7 +517,7 @@ export class MetadataPickerComponent implements OnInit {
   }
 
   private updateMetadata(shouldLockAllFields: boolean | undefined): void {
-    this.bookMetadataManageService.updateBookMetadata(this.currentBookId, this.buildMetadataWrapper(shouldLockAllFields), false).subscribe({
+    this.bookMetadataManageService.updateBookMetadata(this.currentBookId, this.buildMetadataWrapper(shouldLockAllFields), false, 'REPLACE_WHEN_PROVIDED').subscribe({
       next: () => {
         if (shouldLockAllFields !== undefined) {
           this.messageService.add({


### PR DESCRIPTION
The metadata search/picker tab was using REPLACE_ALL mode when saving, which meant any fields the search provider didn't return (like age rating and content rating) got wiped to null. Switched the picker to use REPLACE_WHEN_PROVIDED so fields not present in the search result are left alone. The edit details tab still uses REPLACE_ALL since users explicitly control every field there.

Fixes #3069