### PR TITLE
Fix thumbnail missing-file test assertion

### DIFF
--- a/booklore-api/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -271,10 +271,10 @@ class BookServiceTest {
     }
 
     @Test
-    void getBookThumbnail_fileMissing_returnsDefault() throws Exception {
+    void getBookThumbnail_fileMissing_returnsDefault() {
         when(fileService.getThumbnailFile(1L)).thenReturn("/tmp/nonexistent.jpg");
         Resource res = bookService.getBookThumbnail(1L);
-        assertTrue(res instanceof UrlResource);
+        assertTrue(res instanceof ClassPathResource);
     }
 
     @Test


### PR DESCRIPTION
Test was asserting UrlResource for a missing thumbnail, but the implementation returns ClassPathResource (the default missing-cover fallback). Same pattern as the getBookCover test right below it.