### PR TITLE
Add folder structure docs hint to library creator

### DIFF
--- a/booklore-ui/src/app/features/library-creator/library-creator.component.html
+++ b/booklore-ui/src/app/features/library-creator/library-creator.component.html
@@ -82,6 +82,11 @@
         </div>
 
         <div class="folders-zone">
+          <div class="folder-structure-hint">
+            <i class="pi pi-exclamation-triangle"></i>
+            <span [innerHTML]="t('folderStructureHint')"></span>
+          </div>
+
           <button class="add-folder-trigger" (click)="openDirectoryPicker()" type="button">
             <i class="pi pi-plus-circle"></i>
             <span>{{ t('addFolder') }}</span>
@@ -102,11 +107,6 @@
                   </button>
                 </div>
               }
-            </div>
-          } @else {
-            <div class="empty-hint">
-              <i class="pi pi-info-circle"></i>
-              <span>{{ t('emptyFoldersHint') }}</span>
             </div>
           }
         </div>

--- a/booklore-ui/src/app/features/library-creator/library-creator.component.scss
+++ b/booklore-ui/src/app/features/library-creator/library-creator.component.scss
@@ -251,6 +251,35 @@
   }
 }
 
+.folder-structure-hint {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.625rem 0.75rem;
+  background: rgba(234, 179, 8, 0.08);
+  border: 1px solid rgba(234, 179, 8, 0.25);
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  color: var(--text-secondary-color);
+  line-height: 1.5;
+
+  i {
+    font-size: 0.9rem;
+    color: rgb(234, 179, 8);
+    flex-shrink: 0;
+  }
+
+  a {
+    color: var(--p-primary-color);
+    text-decoration: none;
+    font-weight: 500;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
 // Folders zone
 .folders-zone {
   display: flex;

--- a/booklore-ui/src/i18n/en/library-creator.json
+++ b/booklore-ui/src/i18n/en/library-creator.json
@@ -12,6 +12,7 @@
     "bookFolders": "Book Folders",
     "addFolder": "Add folder",
     "emptyFoldersHint": "Add folders containing your book files",
+    "folderStructureHint": "Make sure your folders follow the expected <a href='https://booklore.org/docs/library/folder-structure#-recommended-structures' target='_blank' rel='noopener'>directory structure</a> for books and audiobooks.",
     "options": "Options",
     "watchFolders": "Watch folders",
     "watchFoldersTooltip": "Automatically detect new books added to folders",

--- a/booklore-ui/src/i18n/es/library-creator.json
+++ b/booklore-ui/src/i18n/es/library-creator.json
@@ -12,6 +12,7 @@
         "bookFolders": "Carpetas de Libros",
         "addFolder": "Agregar carpeta",
         "emptyFoldersHint": "Agrega carpetas que contengan tus archivos de libros",
+        "folderStructureHint": "Asegurate de que tus carpetas sigan la <a href='https://booklore.org/docs/library/folder-structure#-recommended-structures' target='_blank' rel='noopener'>estructura de directorios</a> esperada para libros y audiolibros.",
         "options": "Opciones",
         "watchFolders": "Vigilar carpetas",
         "watchFoldersTooltip": "Detectar automaticamente nuevos libros agregados a las carpetas",


### PR DESCRIPTION
Adds a warning-style hint inside the Book Folders section of the library creator dialog that links to the recommended folder structure docs page. Should help new users set up their directories correctly before adding folders.