### PR TITLE
Turn off auto book search by default (#3117)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/booklore-api/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -149,7 +149,7 @@ public class AppSettingService {
                 true
             )
         );
-        builder.autoBookSearch(Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.AUTO_BOOK_SEARCH, "true")));
+        builder.autoBookSearch(Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.AUTO_BOOK_SEARCH, "false")));
         builder.uploadPattern(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.UPLOAD_FILE_PATTERN, "{authors}/<{series}/><{seriesIndex}. >/{title}/{title}< - {authors}>< ({year})>"));
         builder.similarBookRecommendation(Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.SIMILAR_BOOK_RECOMMENDATION, "true")));
         builder.opdsServerEnabled(Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OPDS_SERVER_ENABLED, "false")));

--- a/booklore-api/src/main/resources/db/migration/V126__Update_auto_book_search_default_false.sql
+++ b/booklore-api/src/main/resources/db/migration/V126__Update_auto_book_search_default_false.sql
@@ -1,0 +1,1 @@
+UPDATE app_settings SET val = 'false' WHERE name = 'auto_book_search';

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.html
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.html
@@ -60,7 +60,7 @@
       }
       @if (admin || canEditMetadata) {
         <p-tabpanel value="match">
-          <app-metadata-searcher [book$]="book$"></app-metadata-searcher>
+          <app-metadata-searcher [book$]="book$" [isActiveTab]="tab === 'match'"></app-metadata-searcher>
         </p-tabpanel>
       }
       @if ((admin || canEditMetadata) && !isPhysical) {

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, Input, OnChanges, OnDestroy, OnInit, SimpleChanges} from '@angular/core';
 import {FormBuilder, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Button} from 'primeng/button';
 import {InputText} from 'primeng/inputtext';
@@ -35,7 +35,7 @@ import {TranslocoDirective} from '@jsverse/transloco';
   ],
   standalone: true
 })
-export class MetadataSearcherComponent implements OnInit, OnDestroy {
+export class MetadataSearcherComponent implements OnInit, OnDestroy, OnChanges {
   form: FormGroup;
   providers: string[] = [];
   allFetchedMetadata: BookMetadata[] = [];
@@ -44,6 +44,7 @@ export class MetadataSearcherComponent implements OnInit, OnDestroy {
   searchTriggered = false;
 
   @Input() book$!: Observable<Book | null>;
+  @Input() isActiveTab: boolean = false;
 
   selectedFetchedMetadata$ = new BehaviorSubject<BookMetadata | null>(null);
   detailLoading = false;
@@ -66,6 +67,7 @@ export class MetadataSearcherComponent implements OnInit, OnDestroy {
 
   private metadataByProvider: Map<string, BookMetadata[]> = new Map();
   private providerCompletionStatus: Map<string, boolean> = new Map();
+  private pendingAutoSearch = false;
 
   constructor() {
     this.form = this.formBuilder.group({
@@ -74,6 +76,13 @@ export class MetadataSearcherComponent implements OnInit, OnDestroy {
       author: [''],
       isbn: ['']
     });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['isActiveTab']?.currentValue && this.pendingAutoSearch) {
+      this.pendingAutoSearch = false;
+      this.onSubmit();
+    }
   }
 
   ngOnInit() {
@@ -117,7 +126,11 @@ export class MetadataSearcherComponent implements OnInit, OnDestroy {
           if (bookChanged) {
             this.resetFormFromBook(book!);
             if (settings!.autoBookSearch) {
-              this.onSubmit();
+              if (this.isActiveTab) {
+                this.onSubmit();
+              } else {
+                this.pendingAutoSearch = true;
+              }
             }
           } else {
             this.updateFormFromBook(book!);


### PR DESCRIPTION
Flips the auto book search default to off so users don't hit API rate limits before they even know the setting exists. Also gates the auto-search to only fire when the Search Metadata tab is active, not on every book open.

Fixes #3117