### PR TITLE
Fix /app/data and /bookdrop ownership on fresh Docker installs (#3119)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,4 +12,8 @@ if ! getent passwd "$USER_ID" >/dev/null 2>&1; then
     adduser -u "$USER_ID" -G "$(getent group "$GROUP_ID" | cut -d: -f1)" -S -D booklore
 fi
 
+# Ensure data and bookdrop directories exist and are writable by the target user
+mkdir -p /app/data /bookdrop
+chown "$USER_ID:$GROUP_ID" /app/data /bookdrop 2>/dev/null || true
+
 exec su-exec "$USER_ID:$GROUP_ID" "$@"


### PR DESCRIPTION
On a fresh Docker install, the host ./data directory gets created by Docker as root. The entrypoint drops to USER_ID:GROUP_ID via su-exec but never ensures /app/data is writable by that user, so IconService (and anything else that writes there) blows up with AccessDeniedException. Same gap exists for /bookdrop. Now the entrypoint mkdir's and chown's both dirs before dropping privileges.

Fixes #3119