### PR TITLE
Fix flaky thisPeriod month test

### DIFF
--- a/booklore-api/src/test/java/org/booklore/service/BookRuleEvaluatorServiceIntegrationTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/BookRuleEvaluatorServiceIntegrationTest.java
@@ -624,7 +624,7 @@ class BookRuleEvaluatorServiceIntegrationTest {
         @Test
         void thisPeriod_month_matchesThisMonthBook() {
             BookEntity thisMonth = createBook("This Month Book");
-            thisMonth.setAddedOn(Instant.now().minus(1, ChronoUnit.DAYS));
+            thisMonth.setAddedOn(Instant.now().minus(1, ChronoUnit.HOURS));
             em.merge(thisMonth);
 
             BookEntity notThisMonth = createBook("Not This Month Book");


### PR DESCRIPTION
The thisPeriod month test was using minus(1, DAYS) which breaks on the 1st of every month since 'yesterday' falls in the previous month. Switched to minus(1, HOURS) so it always stays in the current month.