### PR TITLE
Add embeddable field indicators to metadata editor

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.html
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.html
@@ -168,7 +168,7 @@
 
           <div class="field-row">
             <div class="field-group title-field">
-              <label for="title">{{ t('title') }}</label>
+              <label for="title">{{ t('title') }} @if (isEmbeddable('title', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <input pInputText id="title" formControlName="title"/>
                 @if (!book.metadata!['titleLocked']) {
@@ -181,7 +181,7 @@
             </div>
 
             <div class="field-group subtitle-field">
-              <label for="subtitle">{{ t('subtitle') }}</label>
+              <label for="subtitle">{{ t('subtitle') }} @if (isEmbeddable('subtitle', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <input pInputText id="subtitle" formControlName="subtitle"/>
                 @if (!book.metadata!['subtitleLocked']) {
@@ -194,7 +194,7 @@
             </div>
 
             <div class="field-group language-field">
-              <label for="language">{{ t('language') }}</label>
+              <label for="language">{{ t('language') }} @if (isEmbeddable('language', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <input pInputText id="language" formControlName="language"/>
                 @if (!book.metadata!['languageLocked']) {
@@ -209,7 +209,7 @@
 
           <div class="field-row">
             <div class="field-group authors-field">
-              <label for="authors">{{ t('authors') }}</label>
+              <label for="authors">{{ t('authors') }} @if (isEmbeddable('authors', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <p-autoComplete
                   formControlName="authors"
@@ -232,7 +232,7 @@
               </div>
             </div>
             <div class="field-group publisher-field">
-              <label for="publisher">{{ t('publisher') }}</label>
+              <label for="publisher">{{ t('publisher') }} @if (isEmbeddable('publisher', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <p-autoComplete
                   [fluid]="true"
@@ -254,7 +254,7 @@
               </div>
             </div>
             <div class="field-group date-field">
-              <label for="publishedDate">{{ t('publishDate') }}</label>
+              <label for="publishedDate">{{ t('publishDate') }} @if (isEmbeddable('publishedDate', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <p-datepicker
                   formControlName="publishedDate"
@@ -279,7 +279,7 @@
 
           <div class="field-row">
             <div class="field-group full-width">
-              <label for="categories">{{ t('genres') }}</label>
+              <label for="categories">{{ t('genres') }} @if (isEmbeddable('categories', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <div class="autocomplete-wrapper">
                   <p-autoComplete
@@ -306,7 +306,7 @@
 
           <div class="field-row">
             <div class="field-group half-width">
-              <label for="moods">{{ t('moods') }}</label>
+              <label for="moods">{{ t('moods') }} @if (isEmbeddable('moods', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <div class="autocomplete-wrapper">
                   <p-autoComplete
@@ -330,7 +330,7 @@
               </div>
             </div>
             <div class="field-group half-width">
-              <label for="tags">{{ t('tags') }}</label>
+              <label for="tags">{{ t('tags') }} @if (isEmbeddable('tags', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <div class="autocomplete-wrapper">
                   <p-autoComplete
@@ -357,7 +357,7 @@
 
           <div class="field-row">
             <div class="field-group series-name-field">
-              <label for="seriesName">{{ t('seriesName') }}</label>
+              <label for="seriesName">{{ t('seriesName') }} @if (isEmbeddable('seriesName', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <p-autoComplete
                   [fluid]="true"
@@ -380,7 +380,7 @@
             </div>
 
             <div class="field-group small-field">
-              <label for="seriesNumber">{{ t('seriesNumber') }}</label>
+              <label for="seriesNumber">{{ t('seriesNumber') }} @if (isEmbeddable('seriesNumber', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <input pInputText id="seriesNumber" formControlName="seriesNumber"/>
                 @if (!book.metadata!['seriesNumberLocked']) {
@@ -393,7 +393,7 @@
             </div>
 
             <div class="field-group small-field">
-              <label for="seriesTotal">{{ t('seriesTotal') }}</label>
+              <label for="seriesTotal">{{ t('seriesTotal') }} @if (isEmbeddable('seriesTotal', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <input pInputText id="seriesTotal" formControlName="seriesTotal"/>
                 @if (!book.metadata!['seriesTotalLocked']) {
@@ -420,7 +420,7 @@
 
           <div class="field-row">
             <div class="field-group small-field">
-              <label for="isbn10">{{ t('isbn10') }}</label>
+              <label for="isbn10">{{ t('isbn10') }} @if (isEmbeddable('isbn10', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <input pInputText id="isbn10" formControlName="isbn10"/>
                 @if (!book.metadata!['isbn10Locked']) {
@@ -432,7 +432,7 @@
               </div>
             </div>
             <div class="field-group small-field">
-              <label for="isbn13">{{ t('isbn13') }}</label>
+              <label for="isbn13">{{ t('isbn13') }} @if (isEmbeddable('isbn13', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <input pInputText id="isbn13" formControlName="isbn13"/>
                 @if (!book.metadata!['isbn13Locked']) {
@@ -444,7 +444,7 @@
               </div>
             </div>
             <div class="field-group small-field">
-              <label for="ageRating">{{ t('ageRating') }}</label>
+              <label for="ageRating">{{ t('ageRating') }} @if (isEmbeddable('ageRating', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <p-select
                   id="ageRating"
@@ -465,7 +465,7 @@
               </div>
             </div>
             <div class="field-group small-field">
-              <label for="contentRating">{{ t('contentRating') }}</label>
+              <label for="contentRating">{{ t('contentRating') }} @if (isEmbeddable('contentRating', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <p-select
                   id="contentRating"
@@ -486,7 +486,7 @@
               </div>
             </div>
             <div class="field-group small-field">
-              <label for="pageCount">{{ t('pages') }}</label>
+              <label for="pageCount">{{ t('pages') }} @if (isEmbeddable('pageCount', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
               <div class="field-with-lock">
                 <input pInputText id="pageCount" formControlName="pageCount"/>
                 @if (!book.metadata!['pageCountLocked']) {
@@ -515,7 +515,7 @@
               <div class="field-row metadata-ids-row">
                 @for (field of audiobookMetadataFields; track field) {
                   <div class="field-group metadata-id-field">
-                    <label>{{ field.label }}</label>
+                    <label>{{ field.label }} @if (isEmbeddable(field.controlName, book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                     <div class="field-with-lock">
                       @if (field.type === 'boolean') {
                         <p-select [formControlName]="field.controlName" [options]="booleanOptions" optionLabel="label" optionValue="value" appendTo="body"></p-select>
@@ -551,7 +551,7 @@
               <div class="comic-text-grid">
                 @for (field of comicTextFields; track field) {
                   <div class="field-group">
-                    <label>{{ field.label }}</label>
+                    <label>{{ field.label }} @if (isEmbeddable(field.controlName, book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                     <div class="field-with-lock">
                       @if (field.type === 'boolean') {
                         <p-select [formControlName]="field.controlName" [options]="booleanOptions" optionLabel="label" optionValue="value" size="small" appendTo="body"></p-select>
@@ -573,7 +573,7 @@
               <div class="comic-array-grid">
                 @for (field of comicArrayFields; track field) {
                   <div class="field-group">
-                    <label>{{ field.label }}</label>
+                    <label>{{ field.label }} @if (isEmbeddable(field.controlName, book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                     <div class="field-with-lock">
                       <div class="autocomplete-wrapper">
                         <p-autoComplete
@@ -602,7 +602,7 @@
               @for (field of comicTextareaFields; track field) {
                 <div class="field-row comic-array-row">
                   <div class="field-group full-width">
-                    <label>{{ field.label }}</label>
+                    <label>{{ field.label }} @if (isEmbeddable(field.controlName, book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                     <div class="field-with-lock description-with-lock">
                       <textarea pTextarea [formControlName]="field.controlName" rows="4"></textarea>
                       @if (!metadataForm.get(field.lockedKey)?.value) {
@@ -632,7 +632,7 @@
             <div class="field-row metadata-ids-row">
               @if (isFieldVisible('asin')) {
                 <div class="field-group metadata-id-field">
-                  <label for="asin">{{ t('amazonAsin') }}</label>
+                  <label for="asin">{{ t('amazonAsin') }} @if (isEmbeddable('asin', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="asin" formControlName="asin"/>
                     @if (!book.metadata!['asinLocked']) {
@@ -646,7 +646,7 @@
               }
               @if (isFieldVisible('amazonRating')) {
                 <div class="field-group metadata-id-field">
-                  <label for="amazonRating">{{ t('amazonRating') }}</label>
+                  <label for="amazonRating">{{ t('amazonRating') }} @if (isEmbeddable('amazonRating', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="amazonRating" formControlName="amazonRating"/>
                     @if (!book.metadata!['amazonRatingLocked']) {
@@ -660,7 +660,7 @@
               }
               @if (isFieldVisible('amazonReviewCount')) {
                 <div class="field-group metadata-id-field">
-                  <label for="amazonRatingCount">{{ t('amazonReviewCount') }}</label>
+                  <label for="amazonRatingCount">{{ t('amazonReviewCount') }} @if (isEmbeddable('amazonReviewCount', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="amazonRatingCount" formControlName="amazonReviewCount"/>
                     @if (!book.metadata!['amazonReviewCountLocked']) {
@@ -674,7 +674,7 @@
               }
               @if (isFieldVisible('googleId')) {
                 <div class="field-group metadata-id-field">
-                  <label for="googleId">{{ t('googleBooksId') }}</label>
+                  <label for="googleId">{{ t('googleBooksId') }} @if (isEmbeddable('googleId', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="googleId" formControlName="googleId"/>
                     @if (!book.metadata!['googleIdLocked']) {
@@ -688,7 +688,7 @@
               }
               @if (isFieldVisible('goodreadsId')) {
                 <div class="field-group metadata-id-field">
-                  <label for="goodreadsId">{{ t('goodreadsId') }}</label>
+                  <label for="goodreadsId">{{ t('goodreadsId') }} @if (isEmbeddable('goodreadsId', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="goodreadsId" formControlName="goodreadsId"/>
                     @if (!book.metadata!['goodreadsIdLocked']) {
@@ -702,7 +702,7 @@
               }
               @if (isFieldVisible('goodreadsRating')) {
                 <div class="field-group metadata-id-field">
-                  <label for="goodreadsRating">{{ t('goodreadsRating') }}</label>
+                  <label for="goodreadsRating">{{ t('goodreadsRating') }} @if (isEmbeddable('goodreadsRating', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="goodreadsRating" formControlName="goodreadsRating"/>
                     @if (!book.metadata!['goodreadsRatingLocked']) {
@@ -716,7 +716,7 @@
               }
               @if (isFieldVisible('goodreadsReviewCount')) {
                 <div class="field-group metadata-id-field">
-                  <label for="goodreadsReviewCount">{{ t('goodreadsReviewCount') }}</label>
+                  <label for="goodreadsReviewCount">{{ t('goodreadsReviewCount') }} @if (isEmbeddable('goodreadsReviewCount', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="goodreadsReviewCount" formControlName="goodreadsReviewCount"/>
                     @if (!book.metadata!['goodreadsReviewCountLocked']) {
@@ -730,7 +730,7 @@
               }
               @if (isFieldVisible('hardcoverId')) {
                 <div class="field-group metadata-id-field">
-                  <label for="hardcoverId">{{ t('hardcoverId') }}</label>
+                  <label for="hardcoverId">{{ t('hardcoverId') }} @if (isEmbeddable('hardcoverId', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="hardcoverId" formControlName="hardcoverId"/>
                     @if (!book.metadata!['hardcoverIdLocked']) {
@@ -744,7 +744,7 @@
               }
               @if (isFieldVisible('hardcoverBookId')) {
                 <div class="field-group metadata-id-field">
-                  <label for="hardcoverBookId">{{ t('hardcoverBookId') }}</label>
+                  <label for="hardcoverBookId">{{ t('hardcoverBookId') }} @if (isEmbeddable('hardcoverBookId', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="hardcoverBookId" formControlName="hardcoverBookId"/>
                     @if (!book.metadata!['hardcoverBookIdLocked']) {
@@ -758,7 +758,7 @@
               }
               @if (isFieldVisible('hardcoverRating')) {
                 <div class="field-group metadata-id-field">
-                  <label for="hardcoverRating">{{ t('hardcoverRating') }}</label>
+                  <label for="hardcoverRating">{{ t('hardcoverRating') }} @if (isEmbeddable('hardcoverRating', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="hardcoverRating" formControlName="hardcoverRating"/>
                     @if (!book.metadata!['hardcoverRatingLocked']) {
@@ -772,7 +772,7 @@
               }
               @if (isFieldVisible('hardcoverReviewCount')) {
                 <div class="field-group metadata-id-field">
-                  <label for="hardcoverReviewCount">{{ t('hardcoverReviewCount') }}</label>
+                  <label for="hardcoverReviewCount">{{ t('hardcoverReviewCount') }} @if (isEmbeddable('hardcoverReviewCount', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="hardcoverReviewCount" formControlName="hardcoverReviewCount"/>
                     @if (!book.metadata!['hardcoverReviewCountLocked']) {
@@ -786,7 +786,7 @@
               }
               @if (isFieldVisible('lubimyczytacId')) {
                 <div class="field-group metadata-id-field">
-                  <label for="lubimyczytacId">{{ t('lubimyczytacId') }}</label>
+                  <label for="lubimyczytacId">{{ t('lubimyczytacId') }} @if (isEmbeddable('lubimyczytacId', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="lubimyczytacId" formControlName="lubimyczytacId"/>
                     @if (!book.metadata!['lubimyczytacIdLocked']) {
@@ -800,7 +800,7 @@
               }
               @if (isFieldVisible('lubimyczytacRating')) {
                 <div class="field-group metadata-id-field">
-                  <label for="lubimyczytacRating">{{ t('lubimyczytacRating') }}</label>
+                  <label for="lubimyczytacRating">{{ t('lubimyczytacRating') }} @if (isEmbeddable('lubimyczytacRating', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="lubimyczytacRating" formControlName="lubimyczytacRating"/>
                     @if (!book.metadata!['lubimyczytacRatingLocked']) {
@@ -814,7 +814,7 @@
               }
               @if (isFieldVisible('comicvineId')) {
                 <div class="field-group metadata-id-field">
-                  <label for="comicvineId">{{ t('comicvineId') }}</label>
+                  <label for="comicvineId">{{ t('comicvineId') }} @if (isEmbeddable('comicvineId', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="comicvineId" formControlName="comicvineId"/>
                     @if (!book.metadata!['comicvineIdLocked']) {
@@ -828,7 +828,7 @@
               }
               @if (isFieldVisible('ranobedbId')) {
                 <div class="field-group metadata-id-field">
-                  <label for="ranobedbId">{{ t('ranobedbId') }}</label>
+                  <label for="ranobedbId">{{ t('ranobedbId') }} @if (isEmbeddable('ranobedbId', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="ranobedbId" formControlName="ranobedbId"/>
                     @if (!book.metadata!['ranobedbIdLocked']) {
@@ -842,7 +842,7 @@
               }
               @if (isFieldVisible('ranobedbRating')) {
                 <div class="field-group metadata-id-field">
-                  <label for="ranobedbRating">{{ t('ranobedbRating') }}</label>
+                  <label for="ranobedbRating">{{ t('ranobedbRating') }} @if (isEmbeddable('ranobedbRating', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="ranobedbRating" formControlName="ranobedbRating"/>
                     @if (!book.metadata!['ranobedbRatingLocked']) {
@@ -856,7 +856,7 @@
               }
               @if (isFieldVisible('audibleId')) {
                 <div class="field-group metadata-id-field">
-                  <label for="audibleId">{{ t('audibleId') }}</label>
+                  <label for="audibleId">{{ t('audibleId') }} @if (isEmbeddable('audibleId', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="audibleId" formControlName="audibleId"/>
                     @if (!book.metadata!['audibleIdLocked']) {
@@ -870,7 +870,7 @@
               }
               @if (isFieldVisible('audibleRating')) {
                 <div class="field-group metadata-id-field">
-                  <label for="audibleRating">{{ t('audibleRating') }}</label>
+                  <label for="audibleRating">{{ t('audibleRating') }} @if (isEmbeddable('audibleRating', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="audibleRating" formControlName="audibleRating"/>
                     @if (!book.metadata!['audibleRatingLocked']) {
@@ -884,7 +884,7 @@
               }
               @if (isFieldVisible('audibleReviewCount')) {
                 <div class="field-group metadata-id-field">
-                  <label for="audibleReviewCount">{{ t('audibleReviewCount') }}</label>
+                  <label for="audibleReviewCount">{{ t('audibleReviewCount') }} @if (isEmbeddable('audibleReviewCount', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
                   <div class="field-with-lock">
                     <input pSize="small" pInputText id="audibleReviewCount" formControlName="audibleReviewCount"/>
                     @if (!book.metadata!['audibleReviewCountLocked']) {
@@ -903,7 +903,7 @@
 
       <div class="description-section">
         <div class="field-group description-field">
-          <label for="description">{{ t('description') }}</label>
+          <label for="description">{{ t('description') }} @if (isEmbeddable('description', book)) { <i class="pi pi-file-export embeddable-indicator" [pTooltip]="t('writtenToFileTooltip')" tooltipPosition="top"></i> }</label>
           <div class="field-with-lock description-with-lock">
                 <textarea
                   id="description"

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
@@ -509,6 +509,13 @@ label {
   gap: 1rem;
 }
 
+.embeddable-indicator {
+  font-size: 0.65rem;
+  color: var(--green-500);
+  margin-left: 0.25rem;
+  vertical-align: super;
+}
+
 .mobile-lock-actions {
   display: flex;
   gap: 1rem;

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.ts
@@ -8,7 +8,7 @@ import {AsyncPipe} from "@angular/common";
 import {MessageService} from "primeng/api";
 import {Book, BookMetadata, ComicMetadata, MetadataClearFlags, MetadataUpdateWrapper,} from "../../../../book/model/book.model";
 import {UrlHelperService} from "../../../../../shared/service/url-helper.service";
-import {ALL_COMIC_METADATA_FIELDS, AUDIOBOOK_METADATA_FIELDS, COMIC_FORM_TO_MODEL_LOCK, COMIC_TEXT_METADATA_FIELDS, COMIC_ARRAY_METADATA_FIELDS, COMIC_TEXTAREA_METADATA_FIELDS, MetadataFieldConfig} from '../../../../../shared/metadata';
+import {ALL_COMIC_METADATA_FIELDS, AUDIOBOOK_METADATA_FIELDS, COMIC_FORM_TO_MODEL_LOCK, COMIC_TEXT_METADATA_FIELDS, COMIC_ARRAY_METADATA_FIELDS, COMIC_TEXTAREA_METADATA_FIELDS, MetadataFieldConfig, isFieldEmbeddable, hasMetadataWriter} from '../../../../../shared/metadata';
 import {FileUpload, FileUploadErrorEvent, FileUploadEvent,} from "primeng/fileupload";
 import {HttpResponse} from "@angular/common/http";
 import {BookService} from "../../../../book/service/book.service";
@@ -1175,6 +1175,14 @@ export class MetadataEditorComponent implements OnInit {
 
   isAudiobook(book: Book): boolean {
     return book.primaryFile?.bookType === 'AUDIOBOOK';
+  }
+
+  isEmbeddable(controlName: string, book: Book): boolean {
+    return isFieldEmbeddable(book.primaryFile?.bookType, controlName);
+  }
+
+  hasWriter(book: Book): boolean {
+    return hasMetadataWriter(book.primaryFile?.bookType);
   }
 
   getUploadAudiobookCoverUrl(): string {

--- a/booklore-ui/src/app/shared/metadata/embeddable-fields.config.ts
+++ b/booklore-ui/src/app/shared/metadata/embeddable-fields.config.ts
@@ -1,0 +1,43 @@
+import {BookType} from '../../features/book/model/book.model';
+import {ALL_COMIC_METADATA_FIELDS} from './metadata-field.config';
+
+const EBOOK_EMBEDDABLE: ReadonlySet<string> = new Set([
+  'title', 'subtitle', 'authors', 'publisher', 'publishedDate', 'language',
+  'categories', 'description', 'seriesName', 'seriesNumber', 'seriesTotal',
+  'isbn10', 'isbn13', 'moods', 'tags', 'ageRating', 'contentRating', 'pageCount',
+  'asin', 'amazonRating', 'amazonReviewCount', 'googleId',
+  'goodreadsId', 'goodreadsRating', 'goodreadsReviewCount',
+  'hardcoverId', 'hardcoverBookId', 'hardcoverRating', 'hardcoverReviewCount',
+  'lubimyczytacId', 'lubimyczytacRating',
+  'comicvineId', 'ranobedbId', 'ranobedbRating',
+  'audibleId', 'audibleRating', 'audibleReviewCount',
+]);
+
+const CBX_EMBEDDABLE: ReadonlySet<string> = new Set([
+  'title', 'description', 'publisher', 'publishedDate', 'language',
+  'authors', 'categories', 'tags', 'seriesName', 'seriesNumber', 'seriesTotal',
+  'pageCount', 'isbn13', 'ageRating',
+  ...ALL_COMIC_METADATA_FIELDS.map(f => f.controlName),
+]);
+
+const AUDIOBOOK_EMBEDDABLE: ReadonlySet<string> = new Set([
+  'title', 'authors', 'narrator', 'description', 'publisher', 'publishedDate',
+  'categories', 'language', 'seriesName', 'seriesNumber', 'seriesTotal',
+]);
+
+const EMBEDDABLE_FIELDS: Partial<Record<BookType, ReadonlySet<string>>> = {
+  EPUB: EBOOK_EMBEDDABLE,
+  PDF: EBOOK_EMBEDDABLE,
+  CBX: CBX_EMBEDDABLE,
+  AUDIOBOOK: AUDIOBOOK_EMBEDDABLE,
+};
+
+export function isFieldEmbeddable(bookType: BookType | undefined, controlName: string): boolean {
+  if (!bookType) return false;
+  return EMBEDDABLE_FIELDS[bookType]?.has(controlName) ?? false;
+}
+
+export function hasMetadataWriter(bookType: BookType | undefined): boolean {
+  if (!bookType) return false;
+  return bookType in EMBEDDABLE_FIELDS;
+}

--- a/booklore-ui/src/app/shared/metadata/index.ts
+++ b/booklore-ui/src/app/shared/metadata/index.ts
@@ -1,3 +1,4 @@
 export * from './metadata-field.config';
 export * from './metadata-utils.service';
 export * from './metadata-form.builder';
+export * from './embeddable-fields.config';

--- a/booklore-ui/src/i18n/en/metadata.json
+++ b/booklore-ui/src/i18n/en/metadata.json
@@ -85,6 +85,7 @@
     "saveBtn": "Save",
     "fetchFromFileBtn": "From File",
     "fetchFromFileTooltip": "Load metadata embedded in the book file",
+    "writtenToFileTooltip": "This field is written to the physical file",
     "previousBookTooltip": "Go to previous book",
     "nextBookTooltip": "Go to next book",
     "autoFetchTooltip": "Automatically fetch metadata using default sources",

--- a/booklore-ui/src/i18n/es/metadata.json
+++ b/booklore-ui/src/i18n/es/metadata.json
@@ -85,6 +85,7 @@
         "saveBtn": "Guardar",
         "fetchFromFileBtn": "Del archivo",
         "fetchFromFileTooltip": "Cargar metadatos incrustados en el archivo del libro",
+        "writtenToFileTooltip": "Este campo se escribe en el archivo físico",
         "previousBookTooltip": "Ir al libro anterior",
         "nextBookTooltip": "Ir al libro siguiente",
         "autoFetchTooltip": "Obtener metadatos automáticamente usando fuentes predeterminadas",


### PR DESCRIPTION
Shows a small green icon next to field labels in the metadata editor for fields that get written back to the physical file. The icon only appears when the book's primary format has a metadata writer (EPUB, PDF, CBX, audiobook). For formats with no writer (MOBI, AZW3, FB2) no icons show up. Hovering the icon shows a tooltip explaining it. All the format-to-field mapping lives in a single config file so adding support for new formats is just one file change.