### PR TITLE
Fix embeddable indicator color

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
@@ -511,7 +511,7 @@ label {
 
 .embeddable-indicator {
   font-size: 0.65rem;
-  color: var(--green-500);
+  color: var(--p-green-500);
   margin-left: 0.25rem;
   vertical-align: super;
 }


### PR DESCRIPTION
Was using --green-500 instead of --p-green-500, so the icon showed up grey instead of green.