### PR TITLE
Replace decades covered with 3 new publication timeline insights

### DIFF
--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.html
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.html
@@ -48,9 +48,15 @@
               <span class="insight-detail" [title]="insights.newestBook.title">{{ insights.newestBook.title }}</span>
             </div>
           }
+
+          <div class="insight-item common-year">
+            <span class="insight-label">{{ t('insightMostCommonYear') }}</span>
+            <span class="insight-value">{{ insights.mostCommonYear.year }}</span>
+            <span class="insight-detail">{{ t('insightMostCommonYearBooks', { count: insights.mostCommonYear.count }) }}</span>
+          </div>
         </div>
 
-        <div class="insights-row secondary">
+        <div class="insights-row">
           <div class="insight-item timespan">
             <span class="insight-label">{{ t('insightTimeSpan') }}</span>
             <span class="insight-value">{{ insights.timeSpan }}</span>
@@ -63,10 +69,16 @@
             <span class="insight-detail">{{ t('insightPeakDecadeBooks', { count: insights.peakDecadeCount }) }}</span>
           </div>
 
-          <div class="insight-item decades">
-            <span class="insight-label">{{ t('insightDecadesCovered') }}</span>
-            <span class="insight-value">{{ insights.decadesCovered }}</span>
-            <span class="insight-detail">{{ t('insightDifferentEras') }}</span>
+          <div class="insight-item golden-era">
+            <span class="insight-label">{{ t('insightGoldenEra') }}</span>
+            <span class="insight-value">{{ insights.goldenEra.start }}-{{ insights.goldenEra.end }}</span>
+            <span class="insight-detail">{{ t('insightGoldenEraRange', { count: insights.goldenEra.count }) }}</span>
+          </div>
+
+          <div class="insight-item rarity">
+            <span class="insight-label">{{ t('insightRarityScore') }}</span>
+            <span class="insight-value">{{ insights.rarityScore }}%</span>
+            <span class="insight-detail">{{ t('insightRarePicks') }}</span>
           </div>
         </div>
       </div>

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.scss
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.scss
@@ -33,15 +33,12 @@
 }
 
 .insights-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
 }
 
 .insight-item {
-  flex: 1;
-  min-width: 120px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -105,14 +102,26 @@
     }
   }
 
-  &.decades {
+  &.golden-era {
     .insight-value {
       color: #fb923c;
     }
   }
+
+  &.common-year {
+    .insight-value {
+      color: #34d399;
+    }
+  }
+
+  &.rarity {
+    .insight-value {
+      color: #f87171;
+    }
+  }
 }
 
-.insights-row.secondary {
+.insights-row + .insights-row {
   margin-top: 0.75rem;
 }
 
@@ -123,6 +132,11 @@
 
   .insights-row {
     gap: 0.75rem;
+  }
+
+  .insights-row {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.5rem;
   }
 
   .insight-item {
@@ -148,8 +162,11 @@
     padding: 0.3rem 0.75rem;
   }
 
+  .insights-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
   .insight-item {
-    min-width: 90px;
     padding: 0.5rem;
 
     .insight-value {

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.ts
@@ -27,7 +27,9 @@ interface TimelineInsights {
   peakDecade: string;
   peakDecadeCount: number;
   centuryBreakdown: { c21: number; c20: number; older: number };
-  decadesCovered: number;
+  goldenEra: { start: number; end: number; count: number };
+  mostCommonYear: { year: number; count: number };
+  rarityScore: number;
 }
 
 type TimelineChartData = ChartData<'bar', number[], string>;
@@ -338,12 +340,44 @@ export class PublicationTimelineChartComponent implements OnInit, OnDestroy {
     let peakDecadeCount = 0;
     for (const [decade, count] of decadeCounts) {
       if (count > peakDecadeCount) {
-        peakDecade = decade === 'pre1900' ? 'Pre-1900' : decade.toUpperCase();
+        peakDecade = decade === 'pre1900' ? 'Pre-1900' : decade;
         peakDecadeCount = count;
       }
     }
 
     const timeSpan = oldest && newest ? newest.year - oldest.year : 0;
+
+    // Golden Era: best 20-year window
+    let goldenEra = {start: 0, end: 0, count: 0};
+    if (years.length > 0) {
+      for (let i = 0; i < years.length; i++) {
+        const windowStart = years[i];
+        const windowEnd = windowStart + 19;
+        const windowCount = years.filter(y => y >= windowStart && y <= windowEnd).length;
+        if (windowCount > goldenEra.count) {
+          goldenEra = {start: windowStart, end: windowEnd, count: windowCount};
+        }
+      }
+    }
+
+    // Most Common Year
+    const yearCounts = new Map<number, number>();
+    for (const y of years) {
+      yearCounts.set(y, (yearCounts.get(y) || 0) + 1);
+    }
+    let mostCommonYear = {year: 0, count: 0};
+    for (const [y, c] of yearCounts) {
+      if (c > mostCommonYear.count) {
+        mostCommonYear = {year: y, count: c};
+      }
+    }
+
+    // Rarity Score: % of books in decades with fewer than 3 books
+    let rareBooks = 0;
+    for (const [_, count] of decadeCounts) {
+      if (count < 3) rareBooks += count;
+    }
+    const rarityScore = years.length > 0 ? Math.round((rareBooks / years.length) * 100) : 0;
 
     return {
       oldestBook: oldest,
@@ -355,7 +389,9 @@ export class PublicationTimelineChartComponent implements OnInit, OnDestroy {
       peakDecade,
       peakDecadeCount,
       centuryBreakdown: {c21, c20, older},
-      decadesCovered: decadeCounts.size
+      goldenEra,
+      mostCommonYear,
+      rarityScore
     };
   }
 

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.scss
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.scss
@@ -57,13 +57,13 @@
   }
 
   .insight-value {
-    font-size: 1.4rem;
+    font-size: 1.5rem;
     font-weight: 600;
     color: var(--text-color, #ffffff);
   }
 
   .insight-detail {
-    font-size: 0.7rem;
+    font-size: 0.75rem;
     color: var(--text-secondary-color);
     margin-top: 0.25rem;
     white-space: nowrap;

--- a/booklore-ui/src/i18n/en/stats-library.json
+++ b/booklore-ui/src/i18n/en/stats-library.json
@@ -87,8 +87,12 @@
     "insightYearsOfLiterature": "years of literature",
     "insightPeakDecade": "Peak Decade",
     "insightPeakDecadeBooks": "{{ count }} books",
-    "insightDecadesCovered": "Decades Covered",
-    "insightDifferentEras": "different eras"
+    "insightGoldenEra": "Golden Era",
+    "insightGoldenEraRange": "{{ count }} books",
+    "insightMostCommonYear": "Most Common Year",
+    "insightMostCommonYearBooks": "{{ count }} books",
+    "insightRarityScore": "Rarity Score",
+    "insightRarePicks": "rare picks"
   },
   "publicationTrend": {
     "title": "Publication Trend",

--- a/booklore-ui/src/i18n/es/stats-library.json
+++ b/booklore-ui/src/i18n/es/stats-library.json
@@ -87,8 +87,12 @@
         "insightYearsOfLiterature": "anos de literatura",
         "insightPeakDecade": "Decada pico",
         "insightPeakDecadeBooks": "{{ count }} libros",
-        "insightDecadesCovered": "Decadas cubiertas",
-        "insightDifferentEras": "diferentes epocas"
+        "insightGoldenEra": "Epoca dorada",
+        "insightGoldenEraRange": "{{ count }} libros",
+        "insightMostCommonYear": "Ano mas comun",
+        "insightMostCommonYearBooks": "{{ count }} libros",
+        "insightRarityScore": "Puntuacion de rareza",
+        "insightRarePicks": "selecciones raras"
     },
     "publicationTrend": {
         "title": "Tendencia de publicacion",


### PR DESCRIPTION
Swapped out the "Decades Covered" insight on the Publication Timeline chart for three new ones: Golden Era (best 20-year window), Most Common Year, and Rarity Score. Now matches the Reading Journey layout with 8 insights in a 4x2 grid. Also bumped Reading Journey's insight text sizes to match.