### PR TITLE
fix(api): set Host header for image downloads to fix CloudFront 400 e…

### DIFF
--- a/booklore-api/src/main/java/org/booklore/util/FileService.java
+++ b/booklore-api/src/main/java/org/booklore/util/FileService.java
@@ -289,6 +289,7 @@ public class FileService {
             }
 
             HttpHeaders headers = new HttpHeaders();
+            headers.set(HttpHeaders.HOST, uri.getHost());
             headers.set(HttpHeaders.USER_AGENT, "BookLore/1.0 (Book and Comic Metadata Fetcher; +https://github.com/booklore-app/booklore)");
             headers.set(HttpHeaders.ACCEPT, "image/*");
 


### PR DESCRIPTION
📝 Description
---
When downloading book cover images, the SSRF protection in `FileService.downloadImageFromUrlInternal()` resolves the hostname to an IP address and uses that IP in the request URL. This causes the Host header to contain the resolved IP (e.g., `13.225.197.36`) instead of the original hostname (e.g.,`images-na.ssl-images-amazon.com`). CloudFront requires the Host header to match the distribution's origin hostname, so it rejects the request with `400 Bad Request`.

The fix explicitly sets the Host header to `uri.getHost()` before making the request, preserving the original hostname. Since uri is re-parsed from `currentUrl` on each iteration of the redirect-following loop, the correct host is preserved across redirects as well.

Linked Issue: Fixes #3104

🏷️ Type of Change
---

- [x] Bug fix


🔧 Changes
---

Added `headers.set(HttpHeaders.HOST, uri.getHost())` in `FileService.downloadImageFromUrlInternal()` to preserve the original hostname in the Host header when making image download requests

🧪 Testing (MANDATORY)
---
Manual testing steps you performed:
  1. Built custom image from patched source using docker compose build
  2. Deployed with docker compose up -d and confirmed healthy startup
  3. Searched for a book in the metadata search UI, selected a cover image hosted on Amazon CloudFront, and confirmed it downloaded successfully (previously returned `400 Bad Request`)

Regression testing:
 - Verified cover image downloads from non-CloudFront sources still work
 - Verified the SSRF protection still blocks internal/private IP addresses (the Host header change does not bypass the IP validation that occurs before the request is made)

Edge cases covered:
 - Redirect-following: uri is re-parsed from `currentUrl` each loop iteration, so the Host header stays correct across 3xx redirects to different hostnames
 - Non-CDN hosts: Setting the Host header explicitly to the original hostname is correct behavior for all HTTP requests, not just CloudFront

### Test Output:
<details>
<summary>Backend test output (<code>./gradlew test</code>)</summary>

```log
> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
Management of bidirectional association persistent attributes is deprecated and will be removed. Set the value to 'false' to get rid of this warning

> Task :processResources
> Task :classes

> Task :compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :processTestResources
> Task :testClasses
> Task :test
> Task :jacocoTestReport

BUILD SUCCESSFUL in 2m 15s
6 actionable tasks: 6 executed
```

</details>

<details>
<summary>Frontend test output (<code>ng test</code>)</summary>

```log
RUN  v4.0.18 /angular-app

   ✓  booklore  src/app/app.spec.ts (1 test) 3ms
   ✓  booklore  src/app/features/magic-shelf/service/book-rule-evaluator-metadata-presence.spec.ts (85 tests) 155ms
   ✓  booklore  src/app/features/magic-shelf/service/magic-shelf-utils.spec.ts (46 tests) 15ms
   ✓  booklore  src/app/core/security/auth-initializer.spec.ts (2 tests) 22ms
   ✓  booklore  src/app/features/book/service/library-health.service.spec.ts (6 tests) 26ms
   ✓  booklore  src/app/features/magic-shelf/service/book-rule-evaluator.service.spec.ts (199 tests) 239ms
   ✓  booklore  src/app/app.component.spec.ts (7 tests) 230ms
   ✓  booklore  src/app/features/magic-shelf/component/magic-shelf-component.spec.ts (73 tests) 422ms

   Test Files  8 passed (8)
        Tests  419 passed (419)
     Start at  13:36:22
     Duration  2.94s (transform 776ms, setup 3.08s, import 3.40s, tests 1.11s, environment 4.69s)
```

</details>

📸 Screen Recording / Screenshots (MANDATORY)
---


---

✅ Pre-Submission Checklist

- [x] This PR is linked to an approved issue
- [x] Code follows project ../CONTRIBUTING.md#backend-conventions
- [x] Branch is up to date with develop (merge conflicts resolved)
- [x] I ran the full stack locally (backend + frontend + database) and verified the change works
- [ ] Automated tests added or updated to cover changes (backend and frontend)
- [x] All tests pass locally and output is pasted above
- [x] Screen recording or screenshots are attached above proving the change works
- [x] PR is a single focused change (one bug fix OR one feature, not multiple unrelated changes)
- [x] PR is reasonably scoped (PRs over 1000+ changed lines will be closed, split into smaller PRs)
- [x] No unsolicited refactors, cleanups, or "improvements" are bundled in
- [ ] Flyway migration versioning is correct (if schema was modified)
- [ ] Documentation PR submitted to https://github.com/booklore-app/booklore-docs (if user-facing changes)


🤖 AI-Assisted Contributions

- [x] I have read and understand every line of this PR and can explain any part of it during review
- [x] I personally ran the code and verified it works (not just trusted the AI's output)
- [x] PR is scoped to a single logical change, not a dump of everything the AI suggested
- [x] Tests validate actual behavior, not just coverage (AI-generated tests often assert nothing meaningful)
- [x] No dead code, placeholder comments, TODOs, or unused scaffolding left behind by AI
- [x] I did not submit refactors, style changes, or "improvements" the AI suggested beyond the scope of the issue

---
💬 Additional Context (optional)

The error logs show requests going to a bare IP instead of the original hostname:
`400 Bad Request` on GET request for `"https://13.225.197.36/images/I/813LFn0X0JL._SL1500_.jpg"`

CloudFront uses the Host header for routing and rejects requests where it doesn't match a configured distribution. By explicitly setting the Host header to the original hostname, CloudFront receives the hostname it expects.
