### PR TITLE
Make read status icon clickable on book cards

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.html
@@ -87,14 +87,15 @@
 
   @if (!bottomBarHidden) {
     <div class="book-title-container">
-      @if (_shouldShowStatusIcon) {
-        <div class="read-status-indicator"
-             [ngClass]="_readStatusClass"
-             [pTooltip]="readStatusTooltip"
-             tooltipPosition="bottom">
-          <i [class]="_readStatusIcon" style="font-size: 0.9rem"></i>
-        </div>
-      }
+      <div class="read-status-indicator"
+           [ngClass]="_readStatusClass"
+           [pTooltip]="readStatusTooltip"
+           tooltipPosition="bottom"
+           (click)="toggleReadStatusMenu($event, readStatusMenu)"
+           [attr.aria-label]="'book.card.alt.readStatusMenu' | transloco">
+        <i [class]="_readStatusIcon" style="font-size: 0.9rem"></i>
+      </div>
+      <p-tieredmenu #readStatusMenu [model]="readStatusMenuItems" [popup]="true" appendTo="body"></p-tieredmenu>
       <h4 class="book-title"
           tooltipPosition="bottom"
           [pTooltip]="titleTooltip">

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.scss
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.scss
@@ -381,6 +381,13 @@
   justify-content: center;
   font-weight: bold;
   margin-left: 0.5rem;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: opacity 0.15s ease;
+
+  &:hover {
+    opacity: 0.7;
+  }
 }
 
 .status-read {
@@ -409,6 +416,10 @@
 
 .status-wont-read {
   color: #ec4899;
+}
+
+.status-unset {
+  color: var(--text-color-secondary);
 }
 
 ::ng-deep .progress-incomplete .p-progressbar-value {

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -58,6 +58,7 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
   @ViewChild('checkboxElem') checkboxElem!: ElementRef<HTMLInputElement>;
 
   items: MenuItem[] | undefined;
+  readStatusMenuItems: MenuItem[] = [];
   isImageLoaded: boolean = false;
   isSubMenuLoading = false;
   private additionalFilesLoaded = false;
@@ -238,6 +239,40 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
 
   get coverImageUrl(): string {
     return this._coverImageUrl;
+  }
+
+  private buildReadStatusMenuItems(): void {
+    this.readStatusMenuItems = Object.entries(readStatusLabels).map(([status, label]) => ({
+      label,
+      command: () => {
+        this.bookService.updateBookReadStatus(this.book.id, status as ReadStatus).subscribe({
+          next: () => {
+            this.messageService.add({
+              severity: 'success',
+              summary: this.t.translate('book.card.toast.readStatusUpdatedSummary'),
+              detail: this.t.translate('book.card.toast.readStatusUpdatedDetail', {label}),
+              life: 2000
+            });
+          },
+          error: () => {
+            this.messageService.add({
+              severity: 'error',
+              summary: this.t.translate('book.card.toast.readStatusFailedSummary'),
+              detail: this.t.translate('book.card.toast.readStatusFailedDetail'),
+              life: 3000
+            });
+          }
+        });
+      }
+    }));
+  }
+
+  toggleReadStatusMenu(event: Event, menu: TieredMenu): void {
+    event.stopPropagation();
+    if (this.readStatusMenuItems.length === 0) {
+      this.buildReadStatusMenuItems();
+    }
+    menu.toggle(event);
   }
 
   onImageLoad(): void {

--- a/booklore-ui/src/app/features/book/helpers/read-status.helper.ts
+++ b/booklore-ui/src/app/features/book/helpers/read-status.helper.ts
@@ -7,7 +7,7 @@ import {ReadStatus} from '../model/book.model';
 export class ReadStatusHelper {
 
   getReadStatusIcon(readStatus: ReadStatus | undefined): string {
-    if (!readStatus) return '';
+    if (!readStatus) return 'pi pi-book';
     switch (readStatus) {
       case ReadStatus.READ:
         return 'pi pi-check';
@@ -23,13 +23,15 @@ export class ReadStatusHelper {
         return 'pi pi-times';
       case ReadStatus.WONT_READ:
         return 'pi pi-ban';
+      case ReadStatus.UNREAD:
+      case ReadStatus.UNSET:
       default:
-        return '';
+        return 'pi pi-book';
     }
   }
 
   getReadStatusClass(readStatus: ReadStatus | undefined): string {
-    if (!readStatus) return '';
+    if (!readStatus) return 'status-unset';
     switch (readStatus) {
       case ReadStatus.READ:
         return 'status-read';
@@ -45,13 +47,15 @@ export class ReadStatusHelper {
         return 'status-abandoned';
       case ReadStatus.WONT_READ:
         return 'status-wont-read';
+      case ReadStatus.UNREAD:
+      case ReadStatus.UNSET:
       default:
-        return '';
+        return 'status-unset';
     }
   }
 
   getReadStatusTooltip(readStatus: ReadStatus | undefined): string {
-    if (!readStatus) return '';
+    if (!readStatus) return 'Unset';
     switch (readStatus) {
       case ReadStatus.READ:
         return 'Read';
@@ -67,13 +71,16 @@ export class ReadStatusHelper {
         return 'Abandoned';
       case ReadStatus.WONT_READ:
         return 'Won\'t Read';
+      case ReadStatus.UNREAD:
+        return 'Unread';
+      case ReadStatus.UNSET:
       default:
-        return '';
+        return 'Unset';
     }
   }
 
-  shouldShowStatusIcon(readStatus: ReadStatus | undefined): boolean {
-    return !!(readStatus && readStatus !== ReadStatus.UNREAD && readStatus !== ReadStatus.UNSET);
+  shouldShowStatusIcon(_readStatus: ReadStatus | undefined): boolean {
+    return true;
   }
 }
 

--- a/booklore-ui/src/i18n/en/book.json
+++ b/booklore-ui/src/i18n/en/book.json
@@ -137,7 +137,8 @@
       "readBook": "Read book",
       "playAudiobook": "Play audiobook",
       "bookMenu": "Book actions menu",
-      "continueReading": "Continue reading"
+      "continueReading": "Continue reading",
+      "readStatusMenu": "Change read status"
     }
   },
   "notes": {

--- a/booklore-ui/src/i18n/es/book.json
+++ b/booklore-ui/src/i18n/es/book.json
@@ -137,7 +137,8 @@
             "readBook": "Leer libro",
             "playAudiobook": "Reproducir audiolibro",
             "bookMenu": "Menú de acciones del libro",
-            "continueReading": "Continuar leyendo"
+            "continueReading": "Continuar leyendo",
+            "readStatusMenu": "Cambiar estado de lectura"
         }
     },
     "notes": {


### PR DESCRIPTION
The read status icon on book cards is now always visible and clickable. Clicking it opens a dropdown to change the status directly, cutting it from 4 clicks down to 2. Books with no status set show a muted icon so it's still discoverable without being noisy.