### PR TITLE
Fix Kobo sync failure from magic shelf rule evaluation (#3074)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
+++ b/booklore-api/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
@@ -682,7 +682,7 @@ public class BookRuleEvaluatorService {
             return buildArrayFieldPredicate(rule.getField(), ruleList, query, cb, root, false);
         }
 
-        return buildFieldInPredicate(rule.getField(), field -> field, ruleList, cb, progressJoin);
+        return buildFieldInPredicate(rule.getField(), field -> field, ruleList, cb, root, progressJoin);
     }
 
     private Predicate buildExcludesAll(Rule rule, CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
@@ -692,7 +692,7 @@ public class BookRuleEvaluatorService {
             return cb.not(buildArrayFieldPredicate(rule.getField(), ruleList, query, cb, root, false));
         }
 
-        Predicate negated = cb.not(buildFieldInPredicate(rule.getField(), field -> field, ruleList, cb, progressJoin));
+        Predicate negated = cb.not(buildFieldInPredicate(rule.getField(), field -> field, ruleList, cb, root, progressJoin));
         if (rule.getField() == RuleField.READ_STATUS && ruleList.stream().noneMatch("UNSET"::equals)) {
             return cb.or(cb.isNull(progressJoin.get("readStatus")), negated);
         }
@@ -706,15 +706,16 @@ public class BookRuleEvaluatorService {
             return buildArrayFieldPredicate(rule.getField(), ruleList, query, cb, root, true);
         }
 
-        return buildFieldInPredicate(rule.getField(), field -> field, ruleList, cb, progressJoin);
+        return buildFieldInPredicate(rule.getField(), field -> field, ruleList, cb, root, progressJoin);
     }
 
     private Predicate buildFieldInPredicate(RuleField ruleField,
                                             java.util.function.Function<Expression<?>, Expression<?>> fieldTransformer,
                                             List<String> ruleList,
                                             CriteriaBuilder cb,
+                                            Root<BookEntity> root,
                                             Join<BookEntity, UserBookProgressEntity> progressJoin) {
-        Expression<?> field = fieldTransformer.apply(getFieldExpression(ruleField, cb, null, progressJoin));
+        Expression<?> field = fieldTransformer.apply(getFieldExpression(ruleField, cb, root, progressJoin));
         if (field == null) return cb.conjunction();
 
         if (ruleField == RuleField.READ_STATUS) {

--- a/booklore-api/src/main/java/org/booklore/service/kobo/KoboEntitlementService.java
+++ b/booklore-api/src/main/java/org/booklore/service/kobo/KoboEntitlementService.java
@@ -128,14 +128,16 @@ public class KoboEntitlementService {
                 .forEach(tags::add);
 
         // Magic Shelves
-        magicShelfRepository.findAllByUserId(userId).stream()
-                .map(magicShelf -> {
-                    List<Long> bookIds = magicShelfBookService.getBookIdsByMagicShelfId(userId, magicShelf.getId(), MAX_MAGIC_SHELF_BOOKS_FOR_KOBO);
-                    return buildKoboTag("BL-MS-" + magicShelf.getId(), magicShelf.getName(),
-                            magicShelf.getCreatedAt().atOffset(ZoneOffset.UTC).toString(), magicShelf.getUpdatedAt().atOffset(ZoneOffset.UTC).toString(),
-                            bookIds, koboBookIDs);
-                })
-                .forEach(tags::add);
+        magicShelfRepository.findAllByUserId(userId).forEach(magicShelf -> {
+            try {
+                List<Long> bookIds = magicShelfBookService.getBookIdsByMagicShelfId(userId, magicShelf.getId(), MAX_MAGIC_SHELF_BOOKS_FOR_KOBO);
+                tags.add(buildKoboTag("BL-MS-" + magicShelf.getId(), magicShelf.getName(),
+                        magicShelf.getCreatedAt().atOffset(ZoneOffset.UTC).toString(), magicShelf.getUpdatedAt().atOffset(ZoneOffset.UTC).toString(),
+                        bookIds, koboBookIDs));
+            } catch (Exception e) {
+                log.warn("Skipping magic shelf '{}' during Kobo tag generation: {}", magicShelf.getName(), e.getMessage());
+            }
+        });
 
         log.info("Synced {} tags to Kobo", tags.size());
         return tags;

--- a/booklore-ui/package-lock.json
+++ b/booklore-ui/package-lock.json
@@ -7383,9 +7383,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -10117,9 +10117,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
buildFieldInPredicate was passing null as the root parameter to getFieldExpression, so any magic shelf rule using includes_any/excludes_all/includes_all with root-dependent fields (library, title, etc.) would NPE during Kobo sync. Passed root through properly, and also wrapped magic shelf tag generation in a try-catch so a single broken shelf can't take down the whole sync.

Also ran npm audit fix for the high-severity immutable and tar vulnerabilities.

Fixes #3074