### PR TITLE
align device settings access denied card styling with OPDS

### DIFF
--- a/booklore-ui/src/app/shared/styles/_settings-shared.scss
+++ b/booklore-ui/src/app/shared/styles/_settings-shared.scss
@@ -452,22 +452,17 @@ $settings-item-border-left-width: 3px;
   display: flex;
   align-items: center;
   gap: 1rem;
-  padding: 1rem;
+  padding: 1.5rem;
   border-radius: $settings-card-border-radius;
-  background: rgba(220, 38, 38, 0.1);
-  border: 1px solid rgba(220, 38, 38, 0.3);
-  color: var(--p-red-400);
+  background: color-mix(in srgb, var(--ground-background) 85%, var(--p-red-600) 15%);
+  border: 1px solid var(--p-content-border-color);
+  border-left: 3px solid var(--p-red-500);
   max-width: 500px;
-  margin: 0 1rem;
-
-  @media (max-width: 768px) {
-    margin: 0;
-  }
 
   .pi {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
     flex-shrink: 0;
-    color: var(--p-red-300);
+    color: var(--p-red-400);
   }
 }
 
@@ -483,7 +478,7 @@ $settings-item-border-left-width: 3px;
     margin: 0;
     font-size: $settings-section-description-size;
     line-height: 1.5;
-    color: var(--p-red-400);
+    color: var(--p-text-muted-color);
   }
 }
 


### PR DESCRIPTION
Updated the shared access-denied-card mixin so the device settings pages (KOReader, Hardcover, Kobo) render the restricted access box the same way OPDS does: subtle color-mix background, content border, red left accent, and muted paragraph text.