### PR TITLE
fix broken state when canceling OIDC logout at provider (#2082)

### DIFF
--- a/booklore-ui/src/app/shared/components/login/login.component.ts
+++ b/booklore-ui/src/app/shared/components/login/login.component.ts
@@ -54,6 +54,8 @@ export class LoginComponent implements OnInit {
   private static readonly MAX_REDIRECT_COUNT = 3;
 
   ngOnInit(): void {
+    this.authService.clearSessionOnLoginPage();
+
     this.route.queryParams.pipe(take(1)).subscribe(params => {
       if (params['reason'] === 'session_revoked') {
         this.infoMessage = this.translocoService.translate('auth.login.sessionRevoked');

--- a/booklore-ui/src/app/shared/service/auth.service.ts
+++ b/booklore-ui/src/app/shared/service/auth.service.ts
@@ -77,10 +77,10 @@ export class AuthService {
     const refreshToken = this.getInternalRefreshToken();
     this.http.post<{ logoutUrl: string | null }>(`${this.apiUrl}/logout`, {refreshToken}).subscribe({
       next: (response) => {
-        this.clearSession();
         if (response.logoutUrl) {
           window.location.href = response.logoutUrl;
         } else {
+          this.clearSession();
           this.router.navigate(['/login']).then(() => window.location.reload());
         }
       },
@@ -94,6 +94,10 @@ export class AuthService {
   forceLogout(reason: string): void {
     this.clearSession();
     this.router.navigate(['/login'], {queryParams: {reason}});
+  }
+
+  clearSessionOnLoginPage(): void {
+    this.clearSession();
   }
 
   private clearSession(): void {


### PR DESCRIPTION
Was seeing a broken UI state (0 books, partial sidebar) when a user canceled the OIDC provider's sign-out screen. The frontend was clearing the local session (JWT tokens, websocket) before redirecting to the provider, so canceling left the user with no tokens but still on the app. Now the session is only cleared on the non-OIDC path, and the login page clears any stale tokens when it loads (which is where the post-logout redirect lands).

Fixes #2082