### PR TITLE
Include physical books in the Book Type filter

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.config.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.config.ts
@@ -203,7 +203,7 @@ export const FILTER_EXTRACTORS: Readonly<Record<Exclude<FilterType, 'library'>, 
   author: (book) => extractStringsAsFilters(book.metadata?.authors),
   category: (book) => extractStringsAsFilters(book.metadata?.categories),
   series: (book) => extractSingleString(book.metadata?.seriesName?.trim()),
-  bookType: (book) => extractSingleString(book.primaryFile?.bookType),
+  bookType: (book) => book.isPhysical ? [{id: 'PHYSICAL', name: 'PHYSICAL'}] : extractSingleString(book.primaryFile?.bookType),
   readStatus: (book) => {
     const status = book.readStatus ?? ReadStatus.UNSET;
     const validStatus = status in READ_STATUS_LABELS ? status : ReadStatus.UNSET;
@@ -324,6 +324,7 @@ export const SHELF_STATUS_LABEL_KEYS: Readonly<Record<string, string>> = {
   'shelved': 'book.filter.shelfStatus.shelved',
   'unshelved': 'book.filter.shelfStatus.unshelved'
 };
+
 
 export const COMIC_ROLE_LABEL_KEYS: Readonly<Record<string, string>> = {
   penciller: 'book.filter.comicRoles.penciller',

--- a/booklore-ui/src/app/features/book/components/book-browser/filters/sidebar-filter.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/filters/sidebar-filter.ts
@@ -76,7 +76,7 @@ export function doesBookMatchFilter(
         ? filterValues.some(val => book.metadata?.seriesName?.trim() === val)
         : filterValues.every(val => book.metadata?.seriesName?.trim() === val);
     case 'bookType':
-      return filterValues.includes(book.primaryFile?.bookType);
+      return book.isPhysical ? filterValues.includes('PHYSICAL') : filterValues.includes(book.primaryFile?.bookType);
     case 'readStatus':
       return doesBookMatchReadStatus(book, filterValues);
     case 'personalRating':


### PR DESCRIPTION
Physical books now show up as PHYSICAL in the Book Type filter instead of being invisible. Both the extractor and the sidebar filter matching handle the isPhysical flag.