### PR TITLE
Increase minimum password length to 8 characters (#3185)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/user/UserService.java
+++ b/booklore-api/src/main/java/org/booklore/service/user/UserService.java
@@ -170,6 +170,6 @@ public class UserService {
     }
 
     private boolean meetsMinimumPasswordRequirements(String password) {
-        return password != null && password.length() >= 6;
+        return password != null && password.length() >= 8;
     }
 }

--- a/booklore-ui/src/app/features/settings/user-management/create-user-dialog/create-user-dialog.component.ts
+++ b/booklore-ui/src/app/features/settings/user-management/create-user-dialog/create-user-dialog.component.ts
@@ -47,7 +47,7 @@ export class CreateUserDialogComponent implements OnInit {
       name: ['', [Validators.required, Validators.minLength(3)]],
       email: ['', [Validators.required, Validators.email]],
       username: ['', Validators.required],
-      password: ['', [Validators.required, Validators.minLength(6)]],
+      password: ['', [Validators.required, Validators.minLength(8)]],
       confirmPassword: ['', Validators.required],
       selectedLibraries: [[], Validators.required],
       permissionUpload: [false],

--- a/booklore-ui/src/app/features/settings/user-profile-dialog/user-profile-dialog.component.ts
+++ b/booklore-ui/src/app/features/settings/user-profile-dialog/user-profile-dialog.component.ts
@@ -54,7 +54,7 @@ export class UserProfileDialogComponent implements OnInit, OnDestroy {
     this.changePasswordForm = this.fb.group(
       {
         currentPassword: ['', Validators.required],
-        newPassword: ['', [Validators.required, Validators.minLength(6)]],
+        newPassword: ['', [Validators.required, Validators.minLength(8)]],
         confirmNewPassword: ['', Validators.required]
       },
       {validators: passwordMatchValidator}

--- a/booklore-ui/src/app/shared/components/setup/setup.component.ts
+++ b/booklore-ui/src/app/shared/components/setup/setup.component.ts
@@ -37,7 +37,7 @@ export class SetupComponent {
       name: ['', [Validators.required]],
       username: ['', [Validators.required]],
       email: ['', [Validators.required, Validators.email]],
-      password: ['', [Validators.required, Validators.minLength(6)]],
+      password: ['', [Validators.required, Validators.minLength(8)]],
       confirmPassword: ['', [Validators.required]],
     }, {validators: [passwordMatchValidator('password', 'confirmPassword')]});
   }

--- a/booklore-ui/src/i18n/en/settings-device.json
+++ b/booklore-ui/src/i18n/en/settings-device.json
@@ -21,7 +21,7 @@
     "usernameRequired": "Username is required.",
     "password": "KOReader Password",
     "passwordDesc": "Your password for authenticating with the KOReader sync service.",
-    "passwordMinLength": "Password must be at least 6 characters.",
+    "passwordMinLength": "Password must be at least 8 characters.",
     "settingsManagement": "Settings Management",
     "settingsManagementDesc": "Save your credentials or edit existing settings.",
     "accessDenied": "Access to KOReader sync is restricted.",

--- a/booklore-ui/src/i18n/en/settings-profile.json
+++ b/booklore-ui/src/i18n/en/settings-profile.json
@@ -19,7 +19,7 @@
   "validation": {
     "currentPasswordRequired": "Current password is required.",
     "newPasswordRequired": "New password is required.",
-    "passwordMinLength": "Password must be at least 6 characters long.",
+    "passwordMinLength": "Password must be at least 8 characters long.",
     "confirmPasswordRequired": "Please confirm your new password.",
     "passwordMismatch": "Passwords do not match."
   },

--- a/booklore-ui/src/i18n/en/settings-users.json
+++ b/booklore-ui/src/i18n/en/settings-users.json
@@ -140,7 +140,7 @@
     "nameRequired": "Name is required and must be at least 3 characters.",
     "usernameRequired": "Username is required.",
     "emailInvalid": "Enter a valid email address.",
-    "passwordMinLength": "Password must be at least 6 characters long.",
+    "passwordMinLength": "Password must be at least 8 characters long.",
     "confirmRequired": "Password confirmation is required",
     "passwordMismatch": "Passwords do not match.",
     "libraryAccess": "Library Access",

--- a/booklore-ui/src/i18n/en/shared.json
+++ b/booklore-ui/src/i18n/en/shared.json
@@ -143,7 +143,7 @@
       "usernameRequired": "Username is required",
       "nameRequired": "Name is required",
       "emailRequired": "Valid email is required",
-      "passwordMinLength": "Minimum 6 characters required",
+      "passwordMinLength": "Minimum 8 characters required",
       "confirmPasswordRequired": "Password confirmation is required",
       "passwordsMismatch": "Passwords do not match"
     },

--- a/booklore-ui/src/i18n/es/settings-device.json
+++ b/booklore-ui/src/i18n/es/settings-device.json
@@ -21,7 +21,7 @@
         "usernameRequired": "El nombre de usuario es obligatorio.",
         "password": "Contraseña KOReader",
         "passwordDesc": "Tu contraseña para autenticarte con el servicio de sincronización KOReader.",
-        "passwordMinLength": "La contraseña debe tener al menos 6 caracteres.",
+        "passwordMinLength": "La contraseña debe tener al menos 8 caracteres.",
         "settingsManagement": "Gestión de ajustes",
         "settingsManagementDesc": "Guarda tus credenciales o edita los ajustes existentes.",
         "accessDenied": "El acceso a la sincronización KOReader está restringido.",

--- a/booklore-ui/src/i18n/es/settings-profile.json
+++ b/booklore-ui/src/i18n/es/settings-profile.json
@@ -19,7 +19,7 @@
     "validation": {
         "currentPasswordRequired": "La contraseña actual es obligatoria.",
         "newPasswordRequired": "La nueva contraseña es obligatoria.",
-        "passwordMinLength": "La contraseña debe tener al menos 6 caracteres.",
+        "passwordMinLength": "La contraseña debe tener al menos 8 caracteres.",
         "confirmPasswordRequired": "Por favor, confirma tu nueva contraseña.",
         "passwordMismatch": "Las contraseñas no coinciden."
     },

--- a/booklore-ui/src/i18n/es/settings-users.json
+++ b/booklore-ui/src/i18n/es/settings-users.json
@@ -140,7 +140,7 @@
         "nameRequired": "El nombre es obligatorio y debe tener al menos 3 caracteres.",
         "usernameRequired": "El nombre de usuario es obligatorio.",
         "emailInvalid": "Introduce una dirección de correo electrónico válida.",
-        "passwordMinLength": "La contraseña debe tener al menos 6 caracteres.",
+        "passwordMinLength": "La contraseña debe tener al menos 8 caracteres.",
         "confirmRequired": "La confirmación de contraseña es obligatoria",
         "passwordMismatch": "Las contraseñas no coinciden.",
         "libraryAccess": "Acceso a bibliotecas",

--- a/booklore-ui/src/i18n/es/shared.json
+++ b/booklore-ui/src/i18n/es/shared.json
@@ -143,7 +143,7 @@
             "usernameRequired": "El nombre de usuario es obligatorio",
             "nameRequired": "El nombre es obligatorio",
             "emailRequired": "Se requiere un correo electrónico válido",
-            "passwordMinLength": "Se requieren al menos 6 caracteres",
+            "passwordMinLength": "Se requieren al menos 8 caracteres",
             "confirmPasswordRequired": "La confirmación de contraseña es obligatoria",
             "passwordsMismatch": "Las contraseñas no coinciden"
         },


### PR DESCRIPTION
The backend DTOs already enforced a minimum of 8 characters via @Size(min = 8), but the manual validation in UserService and all the frontend Angular validators were still checking for 6. This mismatch meant 6-7 character passwords passed the UI but got rejected server-side with an unhelpful "Validation error" message. Aligned everything to 8 across the board.

Fixes #3185