### PR TITLE
Add magnifying glass to CBX reader (#3190)

### DIFF
--- a/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.html
+++ b/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.html
@@ -36,7 +36,10 @@
     <div class="slideshow-progress" [class.above-footer]="isFooterVisible" [style.animation-duration.ms]="slideshowInterval"></div>
   }
 
+  <div #magnifierLens class="magnifier-lens"></div>
+
   <div class="image-container"
+    [class.magnifier-active]="isMagnifierActive"
     [class.two-page-view]="isTwoPageView && scrollMode === CbxScrollMode.PAGINATED"
     [class.infinite-scroll]="scrollMode === CbxScrollMode.INFINITE"
     [class.long-strip]="scrollMode === CbxScrollMode.LONG_STRIP"

--- a/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.scss
+++ b/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.scss
@@ -50,6 +50,19 @@
     to { width: 100%; }
   }
 
+  .magnifier-lens {
+    position: fixed;
+    top: 0;
+    left: 0;
+    display: none;
+    border-radius: 50%;
+    border: 3px solid rgba(255, 255, 255, 0.8);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3), 0 8px 32px rgba(0, 0, 0, 0.5);
+    pointer-events: none;
+    z-index: 1000;
+    background-repeat: no-repeat;
+  }
+
   .bookmark-indicator {
     position: absolute;
     top: 0;
@@ -93,6 +106,10 @@
         flex: 0 0 auto;
         margin-top: 1rem;
       }
+    }
+
+    &.magnifier-active {
+      cursor: none;
     }
 
     &.bg-black {

--- a/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -1,4 +1,4 @@
-import {Component, HostListener, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, ElementRef, HostListener, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 import {CommonModule} from '@angular/common';
 import {forkJoin, Subject} from 'rxjs';
@@ -116,6 +116,12 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
 
   // Shortcuts help dialog
   showShortcutsHelp = false;
+
+  // Magnifier
+  isMagnifierActive = false;
+  @ViewChild('magnifierLens', {static: true}) private magnifierLensRef!: ElementRef<HTMLDivElement>;
+  private static readonly MAGNIFIER_SIZE = 200;
+  private static readonly MAGNIFIER_ZOOM = 3;
 
   // Double page detection
   private pageDimensionsCache = new Map<number, {width: number, height: number}>();
@@ -300,6 +306,16 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.toggleSlideshow();
+      });
+
+    this.headerService.toggleMagnifier$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.isMagnifierActive = !this.isMagnifierActive;
+        if (!this.isMagnifierActive) {
+          this.hideMagnifier();
+        }
+        this.headerService.updateState({isMagnifierActive: this.isMagnifierActive});
       });
 
     this.headerService.showShortcutsHelp$
@@ -945,12 +961,25 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
         event.preventDefault();
         this.toggleSlideshow();
         break;
+      case 'm':
+      case 'M':
+        event.preventDefault();
+        this.isMagnifierActive = !this.isMagnifierActive;
+        if (!this.isMagnifierActive) {
+          this.hideMagnifier();
+        }
+        this.headerService.updateState({isMagnifierActive: this.isMagnifierActive});
+        break;
       case '?':
         event.preventDefault();
         this.showShortcutsHelp = true;
         break;
       case 'Escape':
-        if (this.showShortcutsHelp) {
+        if (this.isMagnifierActive) {
+          this.isMagnifierActive = false;
+          this.hideMagnifier();
+          this.headerService.updateState({isMagnifierActive: false});
+        } else if (this.showShortcutsHelp) {
           this.showShortcutsHelp = false;
         } else if (this.showNoteDialog) {
           this.showNoteDialog = false;
@@ -989,11 +1018,17 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
   @HostListener('document:mousemove', ['$event'])
   onMouseMove(event: MouseEvent): void {
     this.visibilityManager.handleMouseMove(event.clientY);
+    if (this.isMagnifierActive) {
+      this.updateMagnifier(event);
+    }
   }
 
   @HostListener('document:mouseleave', ['$event'])
   onMouseLeave(event: MouseEvent): void {
     this.visibilityManager.handleMouseLeave();
+    if (this.isMagnifierActive) {
+      this.hideMagnifier();
+    }
   }
 
   private handleSwipeGesture() {
@@ -1222,6 +1257,60 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
 
   shouldShowSinglePage(pageIndex: number): boolean {
     return this.isTwoPageView && this.isSpreadPage(pageIndex);
+  }
+
+  private updateMagnifier(event: MouseEvent): void {
+    const el = this.magnifierLensRef?.nativeElement;
+    if (!el) return;
+
+    const lensSize = CbxReaderComponent.MAGNIFIER_SIZE;
+    const zoom = CbxReaderComponent.MAGNIFIER_ZOOM;
+
+    const target = document.elementFromPoint(event.clientX, event.clientY);
+    if (!(target instanceof HTMLImageElement) || !target.classList.contains('page-image')) {
+      el.style.display = 'none';
+      return;
+    }
+
+    if (!target.naturalWidth || !target.naturalHeight) {
+      el.style.display = 'none';
+      return;
+    }
+
+    const imgRect = target.getBoundingClientRect();
+    const scale = Math.min(imgRect.width / target.naturalWidth, imgRect.height / target.naturalHeight);
+    const renderedWidth = target.naturalWidth * scale;
+    const renderedHeight = target.naturalHeight * scale;
+    const imgOffsetX = (imgRect.width - renderedWidth) / 2;
+    const imgOffsetY = (imgRect.height - renderedHeight) / 2;
+
+    const relX = (event.clientX - imgRect.left - imgOffsetX) / renderedWidth;
+    const relY = (event.clientY - imgRect.top - imgOffsetY) / renderedHeight;
+
+    if (relX < 0 || relX > 1 || relY < 0 || relY > 1) {
+      el.style.display = 'none';
+      return;
+    }
+
+    const bgWidth = renderedWidth * zoom;
+    const bgHeight = renderedHeight * zoom;
+    const bgPosX = -(relX * bgWidth - lensSize / 2);
+    const bgPosY = -(relY * bgHeight - lensSize / 2);
+
+    el.style.display = 'block';
+    el.style.width = `${lensSize}px`;
+    el.style.height = `${lensSize}px`;
+    el.style.transform = `translate(${event.clientX - lensSize / 2}px, ${event.clientY - lensSize / 2}px)`;
+    el.style.backgroundImage = `url('${target.src}')`;
+    el.style.backgroundSize = `${bgWidth}px ${bgHeight}px`;
+    el.style.backgroundPosition = `${bgPosX}px ${bgPosY}px`;
+  }
+
+  private hideMagnifier(): void {
+    const el = this.magnifierLensRef?.nativeElement;
+    if (el) {
+      el.style.display = 'none';
+    }
   }
 
   // Shortcuts help dialog

--- a/booklore-ui/src/app/features/readers/cbx-reader/dialogs/cbx-shortcuts-help.component.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/dialogs/cbx-shortcuts-help.component.ts
@@ -46,7 +46,8 @@ export class CbxShortcutsHelpComponent {
           {keys: ['F'], description: this.t.translate('readerCbx.shortcutsHelp.toggleFullscreen')},
           {keys: ['D'], description: this.t.translate('readerCbx.shortcutsHelp.toggleReadingDirection')},
           {keys: ['Escape'], description: this.t.translate('readerCbx.shortcutsHelp.exitFullscreenCloseDialogs')},
-          {keys: ['Double-click'], description: this.t.translate('readerCbx.shortcutsHelp.toggleZoom'), mobileGesture: this.t.translate('readerCbx.shortcutsHelp.doubleTap')}
+          {keys: ['Double-click'], description: this.t.translate('readerCbx.shortcutsHelp.toggleZoom'), mobileGesture: this.t.translate('readerCbx.shortcutsHelp.doubleTap')},
+          {keys: ['M'], description: this.t.translate('readerCbx.shortcutsHelp.toggleMagnifier')}
         ]
       },
       {

--- a/booklore-ui/src/app/features/readers/cbx-reader/layout/header/cbx-header.component.html
+++ b/booklore-ui/src/app/features/readers/cbx-reader/layout/header/cbx-header.component.html
@@ -15,6 +15,9 @@
   </div>
   <span class="book-title">{{ bookTitle }}</span>
   <div class="header-right">
+    <button class="icon-btn desktop-only" (click)="onToggleMagnifier()" [title]="state.isMagnifierActive ? ('readerCbx.header.disableMagnifier' | transloco) : ('readerCbx.header.enableMagnifier' | transloco)" [class.active]="state.isMagnifierActive">
+      <app-reader-icon name="magnifier" [size]="20" />
+    </button>
     <button class="icon-btn desktop-only" (click)="onToggleSlideshow()" [title]="state.isSlideshowActive ? ('readerCbx.header.stopSlideshow' | transloco) : ('readerCbx.header.startSlideshow' | transloco)" [class.active]="state.isSlideshowActive">
       <app-reader-icon [name]="state.isSlideshowActive ? 'pause' : 'play'" [size]="20" />
     </button>

--- a/booklore-ui/src/app/features/readers/cbx-reader/layout/header/cbx-header.component.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/layout/header/cbx-header.component.ts
@@ -24,7 +24,8 @@ export class CbxHeaderComponent implements OnInit, OnDestroy {
   overflowOpen = false;
   state: CbxHeaderState = {
     isFullscreen: false,
-    isSlideshowActive: false
+    isSlideshowActive: false,
+    isMagnifierActive: false
   };
 
   get bookTitle(): string {
@@ -68,6 +69,10 @@ export class CbxHeaderComponent implements OnInit, OnDestroy {
 
   onToggleSlideshow(): void {
     this.headerService.toggleSlideshow();
+  }
+
+  onToggleMagnifier(): void {
+    this.headerService.toggleMagnifier();
   }
 
   onShowShortcutsHelp(): void {

--- a/booklore-ui/src/app/features/readers/cbx-reader/layout/header/cbx-header.service.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/layout/header/cbx-header.service.ts
@@ -6,6 +6,7 @@ import {CbxSidebarService} from '../sidebar/cbx-sidebar.service';
 export interface CbxHeaderState {
   isFullscreen: boolean;
   isSlideshowActive: boolean;
+  isMagnifierActive: boolean;
 }
 
 @Injectable()
@@ -22,7 +23,8 @@ export class CbxHeaderService {
 
   private _state = new BehaviorSubject<CbxHeaderState>({
     isFullscreen: false,
-    isSlideshowActive: false
+    isSlideshowActive: false,
+    isMagnifierActive: false
   });
   state$ = this._state.asObservable();
 
@@ -40,6 +42,9 @@ export class CbxHeaderService {
 
   private _toggleSlideshow = new Subject<void>();
   toggleSlideshow$ = this._toggleSlideshow.asObservable();
+
+  private _toggleMagnifier = new Subject<void>();
+  toggleMagnifier$ = this._toggleMagnifier.asObservable();
 
   private _showShortcutsHelp = new Subject<void>();
   showShortcutsHelp$ = this._showShortcutsHelp.asObservable();
@@ -94,6 +99,10 @@ export class CbxHeaderService {
     this._toggleSlideshow.next();
   }
 
+  toggleMagnifier(): void {
+    this._toggleMagnifier.next();
+  }
+
   showShortcutsHelp(): void {
     this._showShortcutsHelp.next();
   }
@@ -104,7 +113,7 @@ export class CbxHeaderService {
 
   reset(): void {
     this._forceVisible.next(true);
-    this._state.next({isFullscreen: false, isSlideshowActive: false});
+    this._state.next({isFullscreen: false, isSlideshowActive: false, isMagnifierActive: false});
     this.bookTitle = '';
   }
 }

--- a/booklore-ui/src/app/features/readers/ebook-reader/shared/icon.component.ts
+++ b/booklore-ui/src/app/features/readers/ebook-reader/shared/icon.component.ts
@@ -34,7 +34,8 @@ export type ReaderIconName =
   | 'help'
   | 'long-strip'
   | 'direction-ltr'
-  | 'direction-rtl';
+  | 'direction-rtl'
+  | 'magnifier';
 
 interface IconPath {
   d: string;
@@ -192,6 +193,12 @@ const ICONS: Record<ReaderIconName, IconPath[]> = {
   'direction-rtl': [
     {d: 'M19,12 L5,12', type: 'line'},
     {d: 'M9,8 L5,12 L9,16', type: 'polyline'}
+  ],
+  'magnifier': [
+    {d: 'M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0-14 0', type: 'path'},
+    {d: 'M21 21l-5-5'},
+    {d: 'M7,10 L13,10', type: 'line'},
+    {d: 'M10,7 L10,13', type: 'line'}
   ]
 };
 

--- a/booklore-ui/src/i18n/en/reader-cbx.json
+++ b/booklore-ui/src/i18n/en/reader-cbx.json
@@ -41,6 +41,7 @@
     "toggleZoom": "Toggle zoom (fit page / actual size)",
     "doubleTap": "Double-tap",
     "toggleSlideshow": "Toggle slideshow / auto-play",
+    "toggleMagnifier": "Toggle magnifying glass",
     "showHelpDialog": "Show this help dialog"
   },
   "footer": {
@@ -76,6 +77,8 @@
     "exitFullscreenLabel": "Exit Fullscreen",
     "fullscreenLabel": "Fullscreen",
     "keyboardShortcutsLabel": "Keyboard Shortcuts",
+    "enableMagnifier": "Magnifying Glass (M)",
+    "disableMagnifier": "Disable Magnifying Glass (M)",
     "settings": "Settings",
     "closeReader": "Close Reader"
   },

--- a/booklore-ui/src/i18n/es/reader-cbx.json
+++ b/booklore-ui/src/i18n/es/reader-cbx.json
@@ -41,6 +41,7 @@
         "toggleZoom": "Alternar zoom (ajustar página / tamaño real)",
         "doubleTap": "Doble toque",
         "toggleSlideshow": "Alternar presentación / reproducción automática",
+        "toggleMagnifier": "Alternar lupa",
         "showHelpDialog": "Mostrar este diálogo de ayuda"
     },
     "footer": {
@@ -76,6 +77,8 @@
         "exitFullscreenLabel": "Salir de pantalla completa",
         "fullscreenLabel": "Pantalla completa",
         "keyboardShortcutsLabel": "Atajos de teclado",
+        "enableMagnifier": "Lupa (M)",
+        "disableMagnifier": "Desactivar lupa (M)",
         "settings": "Ajustes",
         "closeReader": "Cerrar lector"
     },


### PR DESCRIPTION
Adds a magnifying glass (loupe) to the comic book reader. Press M or click the new toolbar button to toggle it on, then hover over a page to see a 3x zoomed circular lens following the cursor. Handy for reading speech bubbles without having to zoom the whole page in and out. Escape also dismisses it.

Closes #3190