### PR TITLE
Fall back to folder cover images when embedded cover extraction fails

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/AbstractFileProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/AbstractFileProcessor.java
@@ -6,6 +6,7 @@ import org.booklore.model.dto.Book;
 import org.booklore.model.dto.settings.LibraryFile;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.enums.FileProcessStatus;
+import org.booklore.model.enums.LibraryOrganizationMode;
 import org.booklore.repository.BookAdditionalFileRepository;
 import org.booklore.repository.BookRepository;
 import org.booklore.service.book.BookCreatorService;
@@ -13,11 +14,16 @@ import org.booklore.service.file.FileFingerprint;
 import org.booklore.service.metadata.MetadataMatchService;
 import org.booklore.service.metadata.sidecar.SidecarMetadataWriter;
 import org.booklore.util.FileService;
+import org.booklore.util.FileUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 @Slf4j
 public abstract class AbstractFileProcessor implements BookFileProcessor {
@@ -76,4 +82,48 @@ public abstract class AbstractFileProcessor implements BookFileProcessor {
     }
 
     protected abstract BookEntity processNewFile(LibraryFile libraryFile);
+
+    protected Path getBookFolderForCoverFallback(LibraryFile libraryFile) {
+        if (libraryFile.isFolderBased()) {
+            return libraryFile.getFullPath();
+        }
+        if (libraryFile.getLibraryEntity().getOrganizationMode() == LibraryOrganizationMode.BOOK_PER_FOLDER) {
+            return libraryFile.getFullPath().getParent();
+        }
+        return null;
+    }
+
+    protected boolean generateCoverFromFolderImage(BookEntity bookEntity, Path bookFolder) {
+        Optional<Path> coverImage = FileUtils.findCoverImageInFolder(bookFolder);
+        if (coverImage.isEmpty()) return false;
+        try {
+            BufferedImage image = ImageIO.read(coverImage.get().toFile());
+            if (image == null) return false;
+            try {
+                return fileService.saveCoverImages(image, bookEntity.getId());
+            } finally {
+                image.flush();
+            }
+        } catch (Exception e) {
+            log.debug("Failed to use folder cover image {}: {}", coverImage.get(), e.getMessage());
+            return false;
+        }
+    }
+
+    protected boolean generateAudiobookCoverFromFolderImage(BookEntity bookEntity, Path bookFolder) {
+        Optional<Path> coverImage = FileUtils.findCoverImageInFolder(bookFolder);
+        if (coverImage.isEmpty()) return false;
+        try {
+            BufferedImage image = FileService.readImage(Files.readAllBytes(coverImage.get()));
+            if (image == null) return false;
+            try {
+                return fileService.saveAudiobookCoverImages(image, bookEntity.getId());
+            } finally {
+                image.flush();
+            }
+        } catch (Exception e) {
+            log.debug("Failed to use folder cover image {}: {}", coverImage.get(), e.getMessage());
+            return false;
+        }
+    }
 }

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/AudiobookProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/AudiobookProcessor.java
@@ -53,7 +53,14 @@ public class AudiobookProcessor extends AbstractFileProcessor implements BookFil
     public BookEntity processNewFile(LibraryFile libraryFile) {
         BookEntity bookEntity = bookCreatorService.createShellBook(libraryFile, BookFileType.AUDIOBOOK);
         setBookMetadata(bookEntity, libraryFile.isFolderBased());
-        if (generateCover(bookEntity, libraryFile.isFolderBased())) {
+        boolean coverGenerated = generateCover(bookEntity, libraryFile.isFolderBased());
+        if (!coverGenerated) {
+            var folder = getBookFolderForCoverFallback(libraryFile);
+            if (folder != null) {
+                coverGenerated = generateAudiobookCoverFromFolderImage(bookEntity, folder);
+            }
+        }
+        if (coverGenerated) {
             bookEntity.getMetadata().setAudiobookCoverUpdatedOn(Instant.now());
             bookEntity.setAudiobookCoverHash(BookCoverUtils.generateCoverHash());
         }

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/Azw3Processor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/Azw3Processor.java
@@ -50,7 +50,14 @@ public class Azw3Processor extends AbstractFileProcessor implements BookFileProc
         BookFileType fileType = determineFileType(libraryFile.getFileName());
         BookEntity bookEntity = bookCreatorService.createShellBook(libraryFile, fileType);
         setBookMetadata(bookEntity);
-        if (generateCover(bookEntity)) {
+        boolean coverGenerated = generateCover(bookEntity);
+        if (!coverGenerated) {
+            var folder = getBookFolderForCoverFallback(libraryFile);
+            if (folder != null) {
+                coverGenerated = generateCoverFromFolderImage(bookEntity, folder);
+            }
+        }
+        if (coverGenerated) {
             FileService.setBookCoverPath(bookEntity.getMetadata());
             bookEntity.setBookCoverHash(BookCoverUtils.generateCoverHash());
         }

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/CbxProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/CbxProcessor.java
@@ -66,7 +66,14 @@ public class CbxProcessor extends AbstractFileProcessor implements BookFileProce
     public BookEntity processNewFile(LibraryFile libraryFile) {
         BookEntity bookEntity = bookCreatorService.createShellBook(libraryFile, BookFileType.CBX);
         bookEntity.getPrimaryBookFile().setArchiveType(ArchiveUtils.detectArchiveType(new File(FileUtils.getBookFullPath(bookEntity))));
-        if (generateCover(bookEntity)) {
+        boolean coverGenerated = generateCover(bookEntity);
+        if (!coverGenerated) {
+            var folder = getBookFolderForCoverFallback(libraryFile);
+            if (folder != null) {
+                coverGenerated = generateCoverFromFolderImage(bookEntity, folder);
+            }
+        }
+        if (coverGenerated) {
             FileService.setBookCoverPath(bookEntity.getMetadata());
             bookEntity.setBookCoverHash(BookCoverUtils.generateCoverHash());
         }

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/EpubProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/EpubProcessor.java
@@ -51,7 +51,14 @@ public class EpubProcessor extends AbstractFileProcessor implements BookFileProc
     public BookEntity processNewFile(LibraryFile libraryFile) {
         BookEntity bookEntity = bookCreatorService.createShellBook(libraryFile, BookFileType.EPUB);
         setBookMetadata(bookEntity);
-        if (generateCover(bookEntity)) {
+        boolean coverGenerated = generateCover(bookEntity);
+        if (!coverGenerated) {
+            var folder = getBookFolderForCoverFallback(libraryFile);
+            if (folder != null) {
+                coverGenerated = generateCoverFromFolderImage(bookEntity, folder);
+            }
+        }
+        if (coverGenerated) {
             FileService.setBookCoverPath(bookEntity.getMetadata());
             bookEntity.setBookCoverHash(BookCoverUtils.generateCoverHash());
         }

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/Fb2Processor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/Fb2Processor.java
@@ -49,7 +49,14 @@ public class Fb2Processor extends AbstractFileProcessor implements BookFileProce
     public BookEntity processNewFile(LibraryFile libraryFile) {
         BookEntity bookEntity = bookCreatorService.createShellBook(libraryFile, BookFileType.FB2);
         setBookMetadata(bookEntity);
-        if (generateCover(bookEntity)) {
+        boolean coverGenerated = generateCover(bookEntity);
+        if (!coverGenerated) {
+            var folder = getBookFolderForCoverFallback(libraryFile);
+            if (folder != null) {
+                coverGenerated = generateCoverFromFolderImage(bookEntity, folder);
+            }
+        }
+        if (coverGenerated) {
             FileService.setBookCoverPath(bookEntity.getMetadata());
             bookEntity.setBookCoverHash(BookCoverUtils.generateCoverHash());
         }

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/MobiProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/MobiProcessor.java
@@ -50,7 +50,14 @@ public class MobiProcessor extends AbstractFileProcessor implements BookFileProc
         BookFileType fileType = determineFileType(libraryFile.getFileName());
         BookEntity bookEntity = bookCreatorService.createShellBook(libraryFile, fileType);
         setBookMetadata(bookEntity);
-        if (generateCover(bookEntity)) {
+        boolean coverGenerated = generateCover(bookEntity);
+        if (!coverGenerated) {
+            var folder = getBookFolderForCoverFallback(libraryFile);
+            if (folder != null) {
+                coverGenerated = generateCoverFromFolderImage(bookEntity, folder);
+            }
+        }
+        if (coverGenerated) {
             FileService.setBookCoverPath(bookEntity.getMetadata());
             bookEntity.setBookCoverHash(BookCoverUtils.generateCoverHash());
         }

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/PdfProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/PdfProcessor.java
@@ -52,7 +52,14 @@ public class PdfProcessor extends AbstractFileProcessor implements BookFileProce
     @Override
     public BookEntity processNewFile(LibraryFile libraryFile) {
         BookEntity bookEntity = bookCreatorService.createShellBook(libraryFile, BookFileType.PDF);
-        if (generateCover(bookEntity)) {
+        boolean coverGenerated = generateCover(bookEntity);
+        if (!coverGenerated) {
+            var folder = getBookFolderForCoverFallback(libraryFile);
+            if (folder != null) {
+                coverGenerated = generateCoverFromFolderImage(bookEntity, folder);
+            }
+        }
+        if (coverGenerated) {
             FileService.setBookCoverPath(bookEntity.getMetadata());
             bookEntity.setBookCoverHash(BookCoverUtils.generateCoverHash());
         }

--- a/booklore-api/src/main/java/org/booklore/util/FileUtils.java
+++ b/booklore-api/src/main/java/org/booklore/util/FileUtils.java
@@ -122,6 +122,33 @@ public class FileUtils {
         }
     }
 
+    private static final List<String> COVER_IMAGE_BASENAMES = List.of("cover", "folder", "image");
+    private static final List<String> IMAGE_EXTENSIONS = List.of("jpg", "jpeg", "png", "webp", "gif", "bmp");
+
+    /**
+     * Find a cover image file in a folder by looking for well-known filenames
+     * (cover, folder, image) with common image extensions.
+     */
+    public Optional<Path> findCoverImageInFolder(Path folderPath) {
+        try {
+            if (folderPath == null || !Files.exists(folderPath) || !Files.isDirectory(folderPath)) {
+                return Optional.empty();
+            }
+            for (String baseName : COVER_IMAGE_BASENAMES) {
+                for (String ext : IMAGE_EXTENSIONS) {
+                    Path candidate = folderPath.resolve(baseName + "." + ext);
+                    if (Files.isRegularFile(candidate)) {
+                        return Optional.of(candidate);
+                    }
+                }
+            }
+            return Optional.empty();
+        } catch (Exception e) {
+            log.error("Failed to find cover image in folder [{}]: {}", folderPath, e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+
     /**
      * Check if a filename is an audio file.
      */

--- a/booklore-api/src/test/java/org/booklore/service/fileprocessor/AbstractFileProcessorTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/fileprocessor/AbstractFileProcessorTest.java
@@ -1,0 +1,233 @@
+package org.booklore.service.fileprocessor;
+
+import org.booklore.mapper.BookMapper;
+import org.booklore.model.dto.settings.LibraryFile;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.LibraryEntity;
+import org.booklore.model.entity.LibraryPathEntity;
+import org.booklore.model.enums.BookFileType;
+import org.booklore.model.enums.LibraryOrganizationMode;
+import org.booklore.repository.BookAdditionalFileRepository;
+import org.booklore.repository.BookRepository;
+import org.booklore.service.book.BookCreatorService;
+import org.booklore.service.metadata.MetadataMatchService;
+import org.booklore.service.metadata.sidecar.SidecarMetadataWriter;
+import org.booklore.util.FileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractFileProcessorTest {
+
+    @Mock private BookRepository bookRepository;
+    @Mock private BookAdditionalFileRepository bookAdditionalFileRepository;
+    @Mock private BookCreatorService bookCreatorService;
+    @Mock private BookMapper bookMapper;
+    @Mock private FileService fileService;
+    @Mock private MetadataMatchService metadataMatchService;
+    @Mock private SidecarMetadataWriter sidecarMetadataWriter;
+
+    @TempDir
+    Path tempDir;
+
+    private TestableFileProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new TestableFileProcessor(
+                bookRepository, bookAdditionalFileRepository, bookCreatorService,
+                bookMapper, fileService, metadataMatchService, sidecarMetadataWriter
+        );
+    }
+
+    // ========== getBookFolderForCoverFallback ==========
+
+    @Test
+    void getBookFolderForCoverFallback_folderBased_returnsFullPath() {
+        var libraryFile = buildLibraryFile(tempDir, "audiobooks", "MyAudiobook", true, LibraryOrganizationMode.AUTO_DETECT);
+        var result = processor.exposedGetBookFolderForCoverFallback(libraryFile);
+        assertThat(result).isEqualTo(libraryFile.getFullPath());
+    }
+
+    @Test
+    void getBookFolderForCoverFallback_bookPerFolder_returnsParent() {
+        var libraryFile = buildLibraryFile(tempDir, "books/author", "book.epub", false, LibraryOrganizationMode.BOOK_PER_FOLDER);
+        var result = processor.exposedGetBookFolderForCoverFallback(libraryFile);
+        assertThat(result).isEqualTo(libraryFile.getFullPath().getParent());
+    }
+
+    @Test
+    void getBookFolderForCoverFallback_autoDetectNotFolderBased_returnsNull() {
+        var libraryFile = buildLibraryFile(tempDir, "books", "book.epub", false, LibraryOrganizationMode.AUTO_DETECT);
+        var result = processor.exposedGetBookFolderForCoverFallback(libraryFile);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void getBookFolderForCoverFallback_folderBasedInBookPerFolder_returnsFullPath() {
+        var libraryFile = buildLibraryFile(tempDir, "audiobooks", "MyAudiobook", true, LibraryOrganizationMode.BOOK_PER_FOLDER);
+        var result = processor.exposedGetBookFolderForCoverFallback(libraryFile);
+        assertThat(result).isEqualTo(libraryFile.getFullPath());
+    }
+
+    // ========== generateCoverFromFolderImage ==========
+
+    @Test
+    void generateCoverFromFolderImage_coverExists_savesCover() throws IOException {
+        Path folder = tempDir.resolve("bookfolder");
+        Files.createDirectories(folder);
+        createTestImage(folder.resolve("cover.jpg"));
+
+        var bookEntity = new BookEntity();
+        bookEntity.setId(1L);
+
+        when(fileService.saveCoverImages(any(BufferedImage.class), eq(1L))).thenReturn(true);
+
+        boolean result = processor.exposedGenerateCoverFromFolderImage(bookEntity, folder);
+
+        assertThat(result).isTrue();
+        verify(fileService).saveCoverImages(any(BufferedImage.class), eq(1L));
+    }
+
+    @Test
+    void generateCoverFromFolderImage_noCoverImage_returnsFalse() {
+        Path folder = tempDir.resolve("emptyfolder");
+
+        var bookEntity = new BookEntity();
+        bookEntity.setId(1L);
+
+        boolean result = processor.exposedGenerateCoverFromFolderImage(bookEntity, folder);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void generateCoverFromFolderImage_noCoverImage_doesNotCallSave() throws IOException {
+        Path folder = tempDir.resolve("noimages");
+        Files.createDirectories(folder);
+        Files.createFile(folder.resolve("book.epub"));
+
+        var bookEntity = new BookEntity();
+        bookEntity.setId(1L);
+
+        processor.exposedGenerateCoverFromFolderImage(bookEntity, folder);
+
+        verify(fileService, never()).saveCoverImages(any(), any(long.class));
+    }
+
+    // ========== generateAudiobookCoverFromFolderImage ==========
+
+    @Test
+    void generateAudiobookCoverFromFolderImage_coverExists_savesAudiobookCover() throws IOException {
+        Path folder = tempDir.resolve("audiobookfolder");
+        Files.createDirectories(folder);
+        createTestImage(folder.resolve("cover.jpg"));
+
+        var bookEntity = new BookEntity();
+        bookEntity.setId(2L);
+
+        when(fileService.saveAudiobookCoverImages(any(BufferedImage.class), eq(2L))).thenReturn(true);
+
+        boolean result = processor.exposedGenerateAudiobookCoverFromFolderImage(bookEntity, folder);
+
+        assertThat(result).isTrue();
+        verify(fileService).saveAudiobookCoverImages(any(BufferedImage.class), eq(2L));
+    }
+
+    @Test
+    void generateAudiobookCoverFromFolderImage_noCoverImage_returnsFalse() {
+        Path folder = tempDir.resolve("empty");
+
+        var bookEntity = new BookEntity();
+        bookEntity.setId(2L);
+
+        boolean result = processor.exposedGenerateAudiobookCoverFromFolderImage(bookEntity, folder);
+
+        assertThat(result).isFalse();
+    }
+
+    // ========== helpers ==========
+
+    private void createTestImage(Path path) throws IOException {
+        var image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+        ImageIO.write(image, "jpg", path.toFile());
+    }
+
+    private LibraryFile buildLibraryFile(Path libraryRoot, String subPath, String fileName,
+                                         boolean folderBased, LibraryOrganizationMode mode) {
+        var libraryPath = new LibraryPathEntity();
+        libraryPath.setPath(libraryRoot.toString());
+
+        var library = new LibraryEntity();
+        library.setOrganizationMode(mode);
+
+        return LibraryFile.builder()
+                .libraryEntity(library)
+                .libraryPathEntity(libraryPath)
+                .fileSubPath(subPath)
+                .fileName(fileName)
+                .folderBased(folderBased)
+                .build();
+    }
+
+    /**
+     * Minimal concrete subclass to expose protected methods for testing.
+     */
+    static class TestableFileProcessor extends AbstractFileProcessor {
+
+        TestableFileProcessor(BookRepository bookRepository,
+                              BookAdditionalFileRepository bookAdditionalFileRepository,
+                              BookCreatorService bookCreatorService,
+                              BookMapper bookMapper,
+                              FileService fileService,
+                              MetadataMatchService metadataMatchService,
+                              SidecarMetadataWriter sidecarMetadataWriter) {
+            super(bookRepository, bookAdditionalFileRepository, bookCreatorService,
+                    bookMapper, fileService, metadataMatchService, sidecarMetadataWriter);
+        }
+
+        @Override
+        protected BookEntity processNewFile(LibraryFile libraryFile) {
+            return null;
+        }
+
+        @Override
+        public boolean generateCover(BookEntity bookEntity) {
+            return false;
+        }
+
+        @Override
+        public java.util.List<org.booklore.model.enums.BookFileType> getSupportedTypes() {
+            return java.util.List.of();
+        }
+
+        Path exposedGetBookFolderForCoverFallback(LibraryFile libraryFile) {
+            return getBookFolderForCoverFallback(libraryFile);
+        }
+
+        boolean exposedGenerateCoverFromFolderImage(BookEntity bookEntity, Path folder) {
+            return generateCoverFromFolderImage(bookEntity, folder);
+        }
+
+        boolean exposedGenerateAudiobookCoverFromFolderImage(BookEntity bookEntity, Path folder) {
+            return generateAudiobookCoverFromFolderImage(bookEntity, folder);
+        }
+    }
+}

--- a/booklore-api/src/test/java/org/booklore/util/FileUtilsTest.java
+++ b/booklore-api/src/test/java/org/booklore/util/FileUtilsTest.java
@@ -197,6 +197,135 @@ class FileUtilsTest {
 
     // ========== isSeriesFolder Tests ==========
 
+    // ========== findCoverImageInFolder Tests ==========
+
+    @Test
+    void testFindCoverImageInFolder_coverJpg_found() throws IOException {
+        Files.createFile(tempDir.resolve("cover.jpg"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isPresent());
+        assertEquals("cover.jpg", result.get().getFileName().toString());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_coverPng_found() throws IOException {
+        Files.createFile(tempDir.resolve("cover.png"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isPresent());
+        assertEquals("cover.png", result.get().getFileName().toString());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_imageJpg_found() throws IOException {
+        Files.createFile(tempDir.resolve("image.jpg"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isPresent());
+        assertEquals("image.jpg", result.get().getFileName().toString());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_folderJpg_found() throws IOException {
+        Files.createFile(tempDir.resolve("folder.jpg"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isPresent());
+        assertEquals("folder.jpg", result.get().getFileName().toString());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_coverPrioritizedOverFolder() throws IOException {
+        Files.createFile(tempDir.resolve("folder.jpg"));
+        Files.createFile(tempDir.resolve("cover.jpg"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isPresent());
+        assertEquals("cover.jpg", result.get().getFileName().toString());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_coverPrioritizedOverImage() throws IOException {
+        Files.createFile(tempDir.resolve("image.png"));
+        Files.createFile(tempDir.resolve("cover.png"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isPresent());
+        assertEquals("cover.png", result.get().getFileName().toString());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_folderPrioritizedOverImage() throws IOException {
+        Files.createFile(tempDir.resolve("image.jpg"));
+        Files.createFile(tempDir.resolve("folder.jpg"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isPresent());
+        assertEquals("folder.jpg", result.get().getFileName().toString());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_jpgPrioritizedOverPng() throws IOException {
+        Files.createFile(tempDir.resolve("cover.png"));
+        Files.createFile(tempDir.resolve("cover.jpg"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isPresent());
+        assertEquals("cover.jpg", result.get().getFileName().toString());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_webpSupported() throws IOException {
+        Files.createFile(tempDir.resolve("cover.webp"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isPresent());
+        assertEquals("cover.webp", result.get().getFileName().toString());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_noCoverImage_returnsEmpty() throws IOException {
+        Files.createFile(tempDir.resolve("book.epub"));
+        Files.createFile(tempDir.resolve("metadata.opf"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_emptyFolder_returnsEmpty() {
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_nonExistentPath_returnsEmpty() {
+        var result = FileUtils.findCoverImageInFolder(tempDir.resolve("nonexistent"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_nullPath_returnsEmpty() {
+        var result = FileUtils.findCoverImageInFolder(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_unsupportedExtension_returnsEmpty() throws IOException {
+        Files.createFile(tempDir.resolve("cover.tiff"));
+        Files.createFile(tempDir.resolve("cover.svg"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_directoryNamedCover_ignored() throws IOException {
+        Files.createDirectories(tempDir.resolve("cover.jpg"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindCoverImageInFolder_unrelatedImageName_returnsEmpty() throws IOException {
+        Files.createFile(tempDir.resolve("artwork.jpg"));
+        Files.createFile(tempDir.resolve("poster.png"));
+        var result = FileUtils.findCoverImageInFolder(tempDir);
+        assertTrue(result.isEmpty());
+    }
+
+    // ========== isSeriesFolder Tests ==========
+
     @Test
     void testIsSeriesFolder_distinctTitles_returnsTrue() {
         List<Path> files = List.of(


### PR DESCRIPTION
When scanning books, if the cover can't be extracted from the file itself (no embedded cover in the epub/audiobook/etc), the scanner now checks the book's folder for common cover image files like cover.jpg, folder.jpg, or image.jpg. This kicks in for BOOK_PER_FOLDER libraries and for folder-based (multi-file) audiobooks regardless of library mode. Supports jpg, jpeg, png, webp, gif, and bmp with a priority order so cover.jpg wins over folder.jpg wins over image.jpg.