### PR TITLE
fix(opds): sort libraries by name in OPDS feed

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/opds/OpdsBookService.java
+++ b/booklore-api/src/main/java/org/booklore/service/opds/OpdsBookService.java
@@ -51,11 +51,16 @@ public class OpdsBookService {
                 .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(userId));
         BookLoreUser user = bookLoreUserTransformer.toDTO(entity);
 
+        List<Library> libraries;
         if (user.getPermissions() != null && user.getPermissions().isAdmin()) {
-            return libraryService.getAllLibraries();
+            libraries = libraryService.getAllLibraries();
+        } else {
+            libraries = user.getAssignedLibraries();
         }
 
-        return user.getAssignedLibraries();
+        return libraries.stream()
+                .sorted(Comparator.comparing(Library::getName, String.CASE_INSENSITIVE_ORDER))
+                .toList();
     }
 
     public Page<Book> getBooksPage(Long userId, String query, Long libraryId, Set<Long> shelfIds, int page, int size) {


### PR DESCRIPTION
## 📝 Description

Changes ordering of OPDS library feed entries to lexicographical ordering instead of creation date.

**Linked Issue:** Fixes #3219

## 🏷️ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor (no behavior change)
- [ ] Breaking change (existing functionality affected)
- [ ] Documentation update

## 🔧 Changes

- added a (stream-based) sorting operation based on library name to the method `getAccessibleLibraries` in `OpdsBookService` 

## 🧪 Testing (MANDATORY)

**Manual testing steps you performed:**
1. Added two libraries in reverse lexicographical order
2. Opened OPDS feed before the change.
3. Applied the change.
4. Opened OPDS again to verify corrected order.

**Regression testing:**
-n/a

**Edge cases covered:**
-n/a

**Test output:**
<!-- Paste the actual terminal output from running tests. Not "all pass", the real output. -->

<details>
<summary>Backend test output (<code>./gradlew test</code>)</summary>

```
/booklore-api # ./gradlew test --tests "org.booklore.service.opds.OpdsFeedServiceTest"
> Task :compileJava UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :compileTestJava UP-TO-DATE
> Task :processTestResources UP-TO-DATE
> Task :testClasses UP-TO-DATE
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
> Task :test
> Task :jacocoTestReport

BUILD SUCCESSFUL in 9s
6 actionable tasks: 2 executed, 4 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.4.0/userguide/configuration_cache_enabling.html

```

</details>

## 📸 Screen Recording / Screenshots (MANDATORY)

> Every PR must include a **screen recording or screenshots** showing the change working end-to-end in a running local instance (both backend and frontend). This means you must have actually built, run, and tested the code yourself. PRs without visual proof will be closed without review.

<details>
<summary>local feed access with curl</summary>

```
user@host:~$ curl -u […] -v http://192.168.178.29:6060/api/v1/opds/libraries
*   Trying 192.168.178.29:6060...
* Connected to 192.168.178.29 port 6060 (#0)
* Server auth using Basic with user 'test'
> GET /api/v1/opds/libraries HTTP/1.1
> Host: 192.168.178.29:6060
> Authorization: Basic […]
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 
< vary: accept-encoding
< Content-Type: application/atom+xml;profile=opds-catalog;kind=navigation;charset=utf-8
< Content-Length: 1524
< Date: Sat, 07 Mar 2026 19:35:00 GMT
< 
<?xml version="1.0" encoding="UTF-8"?>
<feed xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog">
  <id>urn:booklore:navigation:libraries</id>
  <title>Libraries</title>
  <updated>2026-03-07T19:35:00.328239033Z</updated>
  <link rel="self" href="/api/v1/opds/libraries" type="application/atom+xml;profile=opds-catalog;kind=navigation"/>
  <link rel="start" href="/api/v1/opds" type="application/atom+xml;profile=opds-catalog;kind=navigation"/>
  <link rel="search" type="application/opensearchdescription+xml" title="Search" href="/api/v1/opds/search.opds"/>
  <entry>
    <title>A</title>
    <id>urn:booklore:library:3</id>
    <updated>2026-03-07T19:35:00.328348516Z</updated>
    <link rel="subsection" href="/api/v1/opds/catalog?libraryId=3" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
    <content type="text">A</content>
  </entry>
  <entry>
    <title>TEst</title>
    <id>urn:booklore:library:1</id>
    <updated>2026-03-07T19:35:00.328500608Z</updated>
    <link rel="subsection" href="/api/v1/opds/catalog?libraryId=1" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
    <content type="text">Test</content>
  </entry>
  <entry>
    <title>Test2</title>
    <id>urn:booklore:library:2</id>
    <updated>2026-03-07T19:35:00.328541063Z</updated>
    <link rel="subsection" href="/api/v1/opds/catalog?libraryId=2" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
    <content type="text">Test2</content>
  </entry>
```

</details>

---

## ✅ Pre-Submission Checklist

> **All boxes must be checked before requesting review.** Incomplete PRs will be closed without review. No exceptions.

- [x] This PR is linked to an approved issue
- [x] Code follows project [backend and frontend conventions](../CONTRIBUTING.md#backend-conventions)
- [x] Branch is up to date with `develop` (merge conflicts resolved)
- [x] I ran the full stack locally (backend + frontend + database) and verified the change works
- [ ] Automated tests added or updated to cover changes (backend **and** frontend)
- [x] All tests pass locally and output is pasted above
- [x] Screen recording or screenshots are attached above proving the change works
- [x] PR is a single focused change (one bug fix OR one feature, not multiple unrelated changes)
- [x] PR is reasonably scoped (PRs over 1000+ changed lines will be closed, split into smaller PRs)
- [x] No unsolicited refactors, cleanups, or "improvements" are bundled in
- [ ] Flyway migration versioning is correct _(if schema was modified)_
- [ ] Documentation PR submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(if user-facing changes)_
