### PR TITLE
Fix metadata center dialog mode being ignored on book card info button (#3218)

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.html
@@ -34,8 +34,8 @@
     @if (_isSeriesViewActive) {
       <p-button [rounded]="true" icon="pi pi-info" class="info-btn" (click)="openSeriesInfo()" [ariaLabel]="'book.card.alt.viewSeriesInfo' | transloco"></p-button>
     } @else {
-      <a [routerLink]="urlHelper.getBookUrl(book)" (click)="prepareNavigation(book)"><p-button [rounded]="true" icon="pi pi-info" class="info-btn" [ariaLabel]="'book.card.alt.viewDetails' | transloco">
-      </p-button></a>
+      <p-button [rounded]="true" icon="pi pi-info" class="info-btn" (click)="openBookInfo(book)" [ariaLabel]="'book.card.alt.viewDetails' | transloco">
+      </p-button>
     }
 
     @if (!_isSeriesViewActive && hasDigitalFile()) {

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -688,13 +688,6 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 
-  prepareNavigation(book: Book): void {
-    const allBookIds = this.bookNavigationService.getAvailableBookIds();
-    if (allBookIds.length > 0) {
-      this.bookNavigationService.setNavigationContext(allBookIds, book.id);
-    }
-  }
-
   openBookInfo(book: Book): void {
     const allBookIds = this.bookNavigationService.getAvailableBookIds();
     if (allBookIds.length > 0) {


### PR DESCRIPTION
The info button on book cards was wrapped in a routerLink that always navigated to the book page, completely bypassing the user's "Metadata Center Display Mode" preference. Replaced it with a click handler that goes through `openBookInfo()`, which checks the setting and opens a dialog when configured to do so.

Fixes #3218