### PR TITLE
Fix organize files preview missing subtitle (#3217)

### DIFF
--- a/booklore-ui/src/app/shared/components/file-mover/file-mover-component.ts
+++ b/booklore-ui/src/app/shared/components/file-mover/file-mover-component.ts
@@ -254,6 +254,7 @@ export class FileMoverComponent implements OnDestroy {
     const values: Record<string, string> = {
       authors: this.sanitize(meta.authors?.join(', ') || 'Unknown Author'),
       title: this.sanitize(meta.title || 'Untitled'),
+      subtitle: this.sanitize(meta.subtitle || ''),
       year: this.formatYear(meta.publishedDate),
       series: this.sanitize(meta.seriesName || ''),
       seriesIndex: this.formatSeriesIndex(meta.seriesNumber ?? undefined),


### PR DESCRIPTION
The organize files preview wasn't resolving the {subtitle} placeholder because it was missing from the frontend's values map. The backend had it, so the actual rename worked fine, just the preview was wrong.

Fixes #3217