### PR TITLE
Add Hardcover Book ID to custom metadata fetch (#3214)

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/metadata-options-dialog/metadata-advanced-fetch-options/metadata-advanced-fetch-options.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/metadata-options-dialog/metadata-advanced-fetch-options/metadata-advanced-fetch-options.component.ts
@@ -33,7 +33,7 @@ export class MetadataAdvancedFetchOptionsComponent implements OnChanges {
     'asin', 'amazonRating', 'amazonReviewCount',
     'googleId',
     'goodreadsId', 'goodreadsRating', 'goodreadsReviewCount',
-    'hardcoverId', 'hardcoverRating', 'hardcoverReviewCount', 'moods', 'tags',
+    'hardcoverId', 'hardcoverBookId', 'hardcoverRating', 'hardcoverReviewCount', 'moods', 'tags',
     'comicvineId',
     'lubimyczytacId', 'lubimyczytacRating',
     'ranobedbId', 'ranobedbRating',
@@ -44,7 +44,7 @@ export class MetadataAdvancedFetchOptionsComponent implements OnChanges {
     'asin', 'amazonRating', 'amazonReviewCount',
     'googleId',
     'goodreadsId', 'goodreadsRating', 'goodreadsReviewCount',
-    'hardcoverId', 'hardcoverRating', 'hardcoverReviewCount', 'moods', 'tags',
+    'hardcoverId', 'hardcoverBookId', 'hardcoverRating', 'hardcoverReviewCount', 'moods', 'tags',
     'comicvineId',
     'lubimyczytacId', 'lubimyczytacRating',
     'ranobedbId', 'ranobedbRating',
@@ -97,7 +97,7 @@ export class MetadataAdvancedFetchOptionsComponent implements OnChanges {
     'goodreadsId', 'goodreadsRating', 'goodreadsReviewCount',
 
     // Hardcover
-    'hardcoverId', 'hardcoverRating', 'hardcoverReviewCount',
+    'hardcoverId', 'hardcoverBookId', 'hardcoverRating', 'hardcoverReviewCount',
 
     // Comicvine
     'comicvineId',
@@ -272,6 +272,7 @@ export class MetadataAdvancedFetchOptionsComponent implements OnChanges {
       'goodreadsId': 'Goodreads ID',
       'comicvineId': 'Comicvine ID',
       'hardcoverId': 'Hardcover ID',
+      'hardcoverBookId': 'Hardcover Book ID',
       'googleId': 'Google Books ID',
       'amazonRating': 'Amazon Rating',
       'amazonReviewCount': 'Amazon Review Count',

--- a/booklore-ui/src/app/features/metadata/model/request/metadata-refresh-options.model.ts
+++ b/booklore-ui/src/app/features/metadata/model/request/metadata-refresh-options.model.ts
@@ -42,6 +42,7 @@ export interface FieldOptions {
   goodreadsId: FieldProvider;
   comicvineId: FieldProvider;
   hardcoverId: FieldProvider;
+  hardcoverBookId: FieldProvider;
   googleId: FieldProvider;
   lubimyczytacId: FieldProvider;
   amazonRating: FieldProvider;


### PR DESCRIPTION
The Hardcover Book ID field was already supported everywhere else (metadata editor, sidecar extraction, lock/unlock) but was missing from the custom metadata fetch dialog. Added it to the field options so it shows up alongside the other Hardcover fields.

Fixes #3214