### PR TITLE
Add groups scope to OIDC authorization request (#3211)

### DIFF
--- a/booklore-ui/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/booklore-ui/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -141,7 +141,7 @@
             id="scope"
             [readonly]="true"
             disabled="disabled"
-            value="openid profile email offline_access"/>
+            value="openid profile email groups offline_access"/>
           <span class="field-hint">{{ t('providerConfig.scopeHint') }}</span>
         </div>
       </div>

--- a/booklore-ui/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/booklore-ui/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -74,7 +74,7 @@ export class AuthenticationSettingsComponent implements OnInit {
     {labelKey: 'infoPanel.redirectUri', value: `${window.location.origin}/oauth2-callback`},
     {labelKey: 'infoPanel.postLogoutRedirectUri', value: `${window.location.origin}/login`},
     {labelKey: 'infoPanel.backChannelLogoutUri', value: `${window.location.origin}/api/v1/auth/oidc/backchannel-logout`},
-    {labelKey: 'infoPanel.requiredScopes', value: 'openid profile email offline_access'},
+    {labelKey: 'infoPanel.requiredScopes', value: 'openid profile email groups offline_access'},
     {labelKey: 'infoPanel.pkceMethod', value: 'S256'},
     {labelKey: 'infoPanel.grantType', value: 'Authorization Code'},
   ];

--- a/booklore-ui/src/app/core/security/oidc.service.ts
+++ b/booklore-ui/src/app/core/security/oidc.service.ts
@@ -50,7 +50,7 @@ export class OidcService {
     authorizationEndpoint?: string
   ): Promise<string> {
     const redirectUri = `${window.location.origin}/oauth2-callback`;
-    const scope = 'openid profile email offline_access';
+    const scope = 'openid profile email groups offline_access';
 
     if (authorizationEndpoint) {
       return Promise.resolve(this.buildUrl(authorizationEndpoint, clientId, redirectUri, scope, codeChallenge, state, nonce));

--- a/booklore-ui/src/app/features/settings/library-metadata-settings/library-metadata-settings.component.ts
+++ b/booklore-ui/src/app/features/settings/library-metadata-settings/library-metadata-settings.component.ts
@@ -229,6 +229,7 @@ export class LibraryMetadataSettingsComponent implements OnInit {
         goodreadsId: {p1: null, p2: null, p3: null, p4: null},
         comicvineId: {p1: null, p2: null, p3: null, p4: null},
         hardcoverId: {p1: null, p2: null, p3: null, p4: null},
+        hardcoverBookId: {p1: null, p2: null, p3: null, p4: null},
         googleId: {p1: null, p2: null, p3: null, p4: null},
         amazonRating: {p1: null, p2: null, p3: null, p4: null},
         amazonReviewCount: {p1: null, p2: null, p3: null, p4: null},


### PR DESCRIPTION
The OIDC authorization request was missing the `groups` scope, so providers like Pocket ID never included group claims in the token. Group mappings were configured correctly but had nothing to match against, leaving users with default permissions. Adding `groups` to the default scopes fixes it.

Fixes #3211