### PR TITLE
Add option to regenerate only missing covers (#3181)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/BookCoverController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/BookCoverController.java
@@ -95,8 +95,8 @@ public class BookCoverController {
     @ApiResponse(responseCode = "204", description = "Covers regenerated successfully")
     @PostMapping("/regenerate-covers")
     @PreAuthorize("@securityUtil.canBulkRegenerateCover() or @securityUtil.isAdmin()")
-    public void regenerateCovers() {
-        bookCoverService.regenerateCovers();
+    public void regenerateCovers(@RequestParam(defaultValue = "false") boolean missingOnly) {
+        bookCoverService.regenerateCovers(missingOnly);
     }
 
     @Operation(summary = "Regenerate cover for a book", description = "Regenerate cover for a specific book. Requires metadata edit permission or admin.")

--- a/booklore-api/src/main/java/org/booklore/service/metadata/BookCoverService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/BookCoverService.java
@@ -293,18 +293,20 @@ public class BookCoverService {
     }
 
     /**
-     * Regenerate covers for all books.
+     * Regenerate covers for all books, optionally only for books with missing covers.
      */
-    public void regenerateCovers() {
+    public void regenerateCovers(boolean missingOnly) {
         SecurityContextVirtualThread.runWithSecurityContext(() -> {
             try {
                 List<BookRegenerationInfo> books = bookQueryService.getAllFullBookEntities().stream()
                         .filter(book -> !isCoverLocked(book))
                         .filter(book -> book.getPrimaryBookFile() != null)
+                        .filter(book -> !missingOnly || book.getBookCoverHash() == null)
                         .map(book -> new BookRegenerationInfo(book.getId(), book.getMetadata().getTitle(), book.getPrimaryBookFile().getBookType(), false))
                         .toList();
                 int total = books.size();
-                notificationService.sendMessage(Topic.LOG, LogNotification.info("Started regenerating covers for " + total + " books"));
+                String label = missingOnly ? "missing" : "all";
+                notificationService.sendMessage(Topic.LOG, LogNotification.info("Started regenerating covers for " + total + " books (" + label + ")"));
 
                 int current = 1;
                 List<Long> refreshedIds = new ArrayList<>();

--- a/booklore-api/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
@@ -755,7 +755,7 @@ class BookCoverServiceTest {
                             return null;
                         });
 
-                service.regenerateCovers();
+                service.regenerateCovers(false);
 
                 verify(bookRepository).save(book);
                 assertThat(book.getMetadata().getCoverUpdatedOn()).isNotNull();
@@ -779,9 +779,52 @@ class BookCoverServiceTest {
                             return null;
                         });
 
-                service.regenerateCovers();
+                service.regenerateCovers(false);
 
                 verify(bookRepository, never()).save(any());
+            }
+        }
+
+        @Test
+        void missingOnlySkipsBooksWithExistingCover() {
+            BookEntity withCover = buildBook(1L, false);
+            withCover.setBookCoverHash("existingHash");
+            BookFileEntity ebookFile1 = BookFileEntity.builder()
+                    .bookType(BookFileType.EPUB).isBookFormat(true).build();
+            withCover.setBookFiles(List.of(ebookFile1));
+            withCover.setLibrary(LibraryEntity.builder().build());
+
+            BookEntity withoutCover = buildBook(2L, false);
+            withoutCover.setBookCoverHash(null);
+            BookFileEntity ebookFile2 = BookFileEntity.builder()
+                    .bookType(BookFileType.EPUB).isBookFormat(true).build();
+            withoutCover.setBookFiles(List.of(ebookFile2));
+            withoutCover.setLibrary(LibraryEntity.builder().build());
+
+            when(bookQueryService.getAllFullBookEntities()).thenReturn(List.of(withCover, withoutCover));
+
+            BookFileProcessor processor = mock(BookFileProcessor.class);
+            when(transactionTemplate.execute(any())).thenAnswer(inv -> {
+                var callback = inv.getArgument(0, org.springframework.transaction.support.TransactionCallback.class);
+                return callback.doInTransaction(null);
+            });
+            when(bookRepository.findById(2L)).thenReturn(Optional.of(withoutCover));
+            when(processorRegistry.getProcessorOrThrow(BookFileType.EPUB)).thenReturn(processor);
+            when(processor.generateCover(withoutCover)).thenReturn(true);
+            when(bookRepository.findCoverUpdateInfoByIds(any())).thenReturn(List.of());
+
+            try (MockedStatic<SecurityContextVirtualThread> secMock = mockStatic(SecurityContextVirtualThread.class)) {
+                secMock.when(() -> SecurityContextVirtualThread.runWithSecurityContext(any(Runnable.class)))
+                        .thenAnswer(inv -> {
+                            inv.<Runnable>getArgument(0).run();
+                            return null;
+                        });
+
+                service.regenerateCovers(true);
+
+                verify(transactionTemplate, times(1)).execute(any());
+                verify(bookRepository).save(withoutCover);
+                verify(bookRepository, never()).findById(1L);
             }
         }
 
@@ -799,7 +842,7 @@ class BookCoverServiceTest {
                             return null;
                         });
 
-                service.regenerateCovers();
+                service.regenerateCovers(false);
 
                 verify(transactionTemplate, never()).execute(any());
             }

--- a/booklore-ui/src/app/features/book/service/book-metadata-manage.service.ts
+++ b/booklore-ui/src/app/features/book/service/book-metadata-manage.service.ts
@@ -130,8 +130,8 @@ export class BookMetadataManageService {
     return this.http.post<BookMetadata>(`${this.url}/${bookId}/metadata/cover/from-url`, {url});
   }
 
-  regenerateCovers(): Observable<void> {
-    return this.http.post<void>(`${this.url}/regenerate-covers`, {});
+  regenerateCovers(missingOnly = false): Observable<void> {
+    return this.http.post<void>(`${this.url}/regenerate-covers?missingOnly=${missingOnly}`, {});
   }
 
   regenerateCover(bookId: number): Observable<void> {

--- a/booklore-ui/src/app/features/settings/global-preferences/global-preferences.component.html
+++ b/booklore-ui/src/app/features/settings/global-preferences/global-preferences.component.html
@@ -51,14 +51,15 @@
           <div class="setting-info">
             <div class="setting-label-row">
               <label class="setting-label">{{ t('covers.regenerate') }}</label>
-              <p-button
-                [label]="t('covers.regenerateBtn')"
+              <p-splitbutton
+                [label]="t('covers.regenerateAllBtn')"
                 icon="pi pi-refresh"
                 outlined="true"
                 size="small"
                 severity="info"
+                [model]="regenerateCoverMenuItems"
                 (onClick)="regenerateCovers()">
-              </p-button>
+              </p-splitbutton>
             </div>
             <p class="setting-description">
               <i class="pi pi-info-circle"></i>

--- a/booklore-ui/src/app/features/settings/global-preferences/global-preferences.component.ts
+++ b/booklore-ui/src/app/features/settings/global-preferences/global-preferences.component.ts
@@ -3,7 +3,8 @@ import {FormsModule} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {Button} from 'primeng/button';
 import {ToggleSwitch} from 'primeng/toggleswitch';
-import {MessageService} from 'primeng/api';
+import {MenuItem, MessageService} from 'primeng/api';
+import {SplitButton} from 'primeng/splitbutton';
 
 import {AppSettingsService} from '../../../shared/service/app-settings.service';
 import {BookMetadataManageService} from '../../book/service/book-metadata-manage.service';
@@ -25,6 +26,7 @@ export const SUPPORT_ANIMATION_KEY = 'booklore-support-animation';
     FormsModule,
     InputText,
     Slider,
+    SplitButton,
     ExternalDocLinkComponent,
     TranslocoDirective,
     TranslocoPipe
@@ -56,8 +58,17 @@ export class GlobalPreferencesComponent implements OnInit {
 
   appSettings$: Observable<AppSettings | null> = this.appSettingsService.appSettings$;
   maxFileUploadSizeInMb?: number;
+  regenerateCoverMenuItems: MenuItem[] = [];
 
   ngOnInit(): void {
+    this.regenerateCoverMenuItems = [
+      {
+        label: this.t.translate('settingsApp.covers.regenerateMissingBtn'),
+        icon: 'pi pi-images',
+        command: () => this.regenerateCovers(true)
+      }
+    ];
+
     this.appSettings$.pipe(
       filter(settings => !!settings),
       take(1)
@@ -107,8 +118,8 @@ export class GlobalPreferencesComponent implements OnInit {
     this.saveSetting(AppSettingKey.MAX_FILE_UPLOAD_SIZE_IN_MB, this.maxFileUploadSizeInMb);
   }
 
-  regenerateCovers(): void {
-    this.bookMetadataManageService.regenerateCovers().subscribe({
+  regenerateCovers(missingOnly = false): void {
+    this.bookMetadataManageService.regenerateCovers(missingOnly).subscribe({
       next: () =>
         this.showMessage('success', this.t.translate('settingsApp.covers.regenerateStarted'), this.t.translate('settingsApp.covers.regenerateStartedDetail')),
       error: () =>

--- a/booklore-ui/src/i18n/en/settings-application.json
+++ b/booklore-ui/src/i18n/en/settings-application.json
@@ -4,8 +4,9 @@
   "covers": {
     "sectionTitle": "Book Cover Image",
     "regenerate": "Regenerate Covers",
-    "regenerateBtn": "Regenerate",
-    "regenerateDesc": "Regenerates cover images for all books from the embedded covers in the file.",
+    "regenerateAllBtn": "Regenerate All",
+    "regenerateMissingBtn": "Regenerate Missing",
+    "regenerateDesc": "Regenerates cover images for all books from the embedded covers in the file. Use \"Regenerate Missing\" to only generate covers for books that don't have one yet.",
     "regenerateStarted": "Cover Regeneration Started",
     "regenerateStartedDetail": "Book covers are being regenerated.",
     "regenerateError": "Failed to start cover regeneration.",

--- a/booklore-ui/src/i18n/es/settings-application.json
+++ b/booklore-ui/src/i18n/es/settings-application.json
@@ -4,8 +4,9 @@
     "covers": {
         "sectionTitle": "Imagen de portada del libro",
         "regenerate": "Regenerar portadas",
-        "regenerateBtn": "Regenerar",
-        "regenerateDesc": "Regenera las imágenes de portada de todos los libros a partir de las portadas incrustadas en el archivo.",
+        "regenerateAllBtn": "Regenerar todas",
+        "regenerateMissingBtn": "Regenerar faltantes",
+        "regenerateDesc": "Regenera las imágenes de portada de todos los libros a partir de las portadas incrustadas en el archivo. Usa \"Regenerar faltantes\" para generar portadas solo para libros que aún no tienen una.",
         "regenerateStarted": "Regeneración de portadas iniciada",
         "regenerateStartedDetail": "Las portadas de los libros se están regenerando.",
         "regenerateError": "Error al iniciar la regeneración de portadas.",


### PR DESCRIPTION
The existing "Regenerate Covers" button regenerates covers for all books, which overwrites manually selected or imported covers. This adds a "Regenerate Missing" option (via a split button dropdown) that only processes books with no cover (null book_cover_hash), leaving existing covers untouched.

Fixes #3181