### PR TITLE
Add ASIN lookup to author search (#3162)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/AuthorController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/AuthorController.java
@@ -1,5 +1,6 @@
 package org.booklore.controller;
 
+import org.booklore.exception.ApiError;
 import org.booklore.model.dto.AuthorDetails;
 import org.booklore.model.dto.AuthorSearchResult;
 import org.booklore.model.dto.AuthorSummary;
@@ -91,8 +92,15 @@ public class AuthorController {
     @GetMapping("/{authorId}/search-metadata")
     public ResponseEntity<List<AuthorSearchResult>> searchAuthorMetadata(
             @Parameter(description = "ID of the author") @PathVariable long authorId,
-            @Parameter(description = "Author name to search") @RequestParam("q") String query,
+            @Parameter(description = "Author name to search") @RequestParam(value = "q", required = false) String query,
+            @Parameter(description = "Author ASIN to look up") @RequestParam(required = false) String asin,
             @Parameter(description = "Region for provider lookup") @RequestParam(defaultValue = "us") String region) {
+        if (asin != null && !asin.isBlank()) {
+            return ResponseEntity.ok(authorMetadataService.lookupAuthorByAsin(asin.trim(), region));
+        }
+        if (query == null || query.isBlank()) {
+            throw ApiError.GENERIC_BAD_REQUEST.createException("Either 'q' or 'asin' parameter is required");
+        }
         return ResponseEntity.ok(authorMetadataService.searchAuthorMetadata(query, region));
     }
 

--- a/booklore-api/src/main/java/org/booklore/service/AuthorMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/AuthorMetadataService.java
@@ -85,6 +85,13 @@ public class AuthorMetadataService {
                 .toList();
     }
 
+    public List<AuthorSearchResult> lookupAuthorByAsin(String asin, String region) {
+        return authorParserMap.values().stream()
+                .map(provider -> provider.getAuthorByAsin(asin, region))
+                .filter(java.util.Objects::nonNull)
+                .toList();
+    }
+
     public AuthorDetails matchAuthor(Long authorId, AuthorMatchRequest request) {
         AuthorEntity author = authorRepository.findById(authorId)
                 .orElseThrow(() -> ApiError.AUTHOR_NOT_FOUND.createException(authorId));

--- a/booklore-ui/src/app/features/author-browser/components/author-match/author-match.component.html
+++ b/booklore-ui/src/app/features/author-browser/components/author-match/author-match.component.html
@@ -6,6 +6,10 @@
           <label>{{ t('authorNameLabel') }}</label>
           <input pInputText type="text" [(ngModel)]="searchQuery" [placeholder]="t('authorNamePlaceholder')" class="search-input"/>
         </div>
+        <div class="field">
+          <label>{{ t('asinLabel') }}</label>
+          <input pInputText type="text" [(ngModel)]="asinQuery" [placeholder]="t('asinPlaceholder')" class="search-input"/>
+        </div>
         <div class="field region-field">
           <label>{{ t('regionLabel') }}</label>
           <p-select
@@ -22,7 +26,7 @@
             icon="pi pi-search"
             (onClick)="search()"
             [loading]="searching"
-            [disabled]="!searchQuery.trim()">
+            [disabled]="!canSearch">
           </p-button>
         </div>
       </div>

--- a/booklore-ui/src/app/features/author-browser/components/author-match/author-match.component.ts
+++ b/booklore-ui/src/app/features/author-browser/components/author-match/author-match.component.ts
@@ -39,6 +39,7 @@ export class AuthorMatchComponent implements OnInit {
   private t = inject(TranslocoService);
 
   searchQuery = '';
+  asinQuery = '';
   selectedRegion = 'us';
   searching = false;
   matching = false;
@@ -62,13 +63,19 @@ export class AuthorMatchComponent implements OnInit {
     this.searchQuery = this.authorName;
   }
 
+  get canSearch(): boolean {
+    return !!this.searchQuery.trim() || !!this.asinQuery.trim();
+  }
+
   search(): void {
-    if (!this.searchQuery.trim()) return;
+    const asin = this.asinQuery.trim();
+    const query = this.searchQuery.trim();
+    if (!query && !asin) return;
     this.searching = true;
     this.results = [];
     this.hasSearched = true;
 
-    this.authorService.searchAuthorMetadata(this.authorId, this.searchQuery.trim(), this.selectedRegion)
+    this.authorService.searchAuthorMetadata(this.authorId, query, this.selectedRegion, asin || undefined)
       .subscribe({
         next: (results) => {
           this.results = results;

--- a/booklore-ui/src/app/features/author-browser/service/author.service.ts
+++ b/booklore-ui/src/app/features/author-browser/service/author.service.ts
@@ -35,10 +35,14 @@ export class AuthorService {
     return this.http.get<AuthorDetails>(`${this.baseUrl}/by-name`, {params: {name}});
   }
 
-  searchAuthorMetadata(authorId: number, query: string, region: string): Observable<AuthorSearchResult[]> {
-    return this.http.get<AuthorSearchResult[]>(`${this.baseUrl}/${authorId}/search-metadata`, {
-      params: {q: query, region}
-    });
+  searchAuthorMetadata(authorId: number, query: string, region: string, asin?: string): Observable<AuthorSearchResult[]> {
+    const params: Record<string, string> = {region};
+    if (asin) {
+      params['asin'] = asin;
+    } else {
+      params['q'] = query;
+    }
+    return this.http.get<AuthorSearchResult[]>(`${this.baseUrl}/${authorId}/search-metadata`, {params});
   }
 
   matchAuthor(authorId: number, request: AuthorMatchRequest): Observable<AuthorDetails> {

--- a/booklore-ui/src/i18n/en/author-browser.json
+++ b/booklore-ui/src/i18n/en/author-browser.json
@@ -119,13 +119,15 @@
   "match": {
     "authorNameLabel": "Author Name",
     "authorNamePlaceholder": "Enter author name to search",
+    "asinLabel": "ASIN",
+    "asinPlaceholder": "Enter ASIN to look up directly",
     "regionLabel": "Region",
     "searchBtn": "Search",
     "searching": "Searching...",
     "noResults": "No Results Found",
-    "noResultsHint": "Try adjusting your search term or selecting a different region",
+    "noResultsHint": "Try adjusting your search term, entering an ASIN, or selecting a different region",
     "readyToSearch": "Ready to Search",
-    "readyToSearchHint": "Enter the author name and click Search to find metadata",
+    "readyToSearchHint": "Search by author name or enter an ASIN to look up directly",
     "resultsFound": "{{ count }} results found",
     "matchBtn": "Match",
     "toast": {

--- a/booklore-ui/src/i18n/es/author-browser.json
+++ b/booklore-ui/src/i18n/es/author-browser.json
@@ -119,13 +119,15 @@
     "match": {
         "authorNameLabel": "Nombre del autor",
         "authorNamePlaceholder": "Ingrese el nombre del autor para buscar",
+        "asinLabel": "ASIN",
+        "asinPlaceholder": "Ingrese el ASIN para buscar directamente",
         "regionLabel": "Región",
         "searchBtn": "Buscar",
         "searching": "Buscando...",
         "noResults": "Sin resultados",
-        "noResultsHint": "Intente ajustar el término de búsqueda o seleccionar una región diferente",
+        "noResultsHint": "Intente ajustar el término de búsqueda, ingresar un ASIN o seleccionar una región diferente",
         "readyToSearch": "Listo para buscar",
-        "readyToSearchHint": "Ingrese el nombre del autor y haga clic en Buscar para encontrar metadatos",
+        "readyToSearchHint": "Busque por nombre de autor o ingrese un ASIN para buscar directamente",
         "resultsFound": "{{ count }} resultados encontrados",
         "matchBtn": "Coincidir",
         "toast": {


### PR DESCRIPTION
Adds an ASIN input field to the author match dialog so users can look up authors directly by ASIN instead of only by name. The existing name search still works as before. When an ASIN is provided, the backend calls getAuthorByAsin on registered parsers (Audnexus) and returns the result.

Fixes #3162