### PR TITLE
Fix reading sessions tab showing blank (#3160)

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/book-reading-sessions/book-reading-sessions.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/book-reading-sessions/book-reading-sessions.component.ts
@@ -37,7 +37,7 @@ export class BookReadingSessionsComponent implements OnInit, OnChanges {
 
   loadSessions() {
     this.loading = true;
-    this.readingSessionService.getSessionsByBookId(this.bookId, 0, 9999)
+    this.readingSessionService.getSessionsByBookId(this.bookId, 0, 100)
       .subscribe({
         next: (response) => {
           this.sessions = response.content;


### PR DESCRIPTION
The reading sessions tab under book details was always showing "No reading sessions recorded yet" even when sessions existed. The security hardening commit (d2075fd) added @Max(100) validation to the page size parameter on the backend, but the frontend was still requesting size=9999, causing a silent validation error.

Fixes #3160