### PR TITLE
Fix untranslatable UI strings, broken pluralization, and translation reactivity (#3108)

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/metadata-manager/metadata-manager.component.html
+++ b/booklore-ui/src/app/features/metadata/component/metadata-manager/metadata-manager.component.html
@@ -21,7 +21,7 @@
       <p-tablist>
         @for (tab of tabConfigs; track tab.type) {
           <p-tab [value]="tab.type">
-            <i class="pi {{ tab.icon }}"></i> {{ t(tab.labelKey).endsWith('s') ? t(tab.labelKey) : t(tab.labelKey) + 's' }} ({{ getMetadataItems(tab.type).length }})
+            <i class="pi {{ tab.icon }}"></i> {{ t(tab.labelPluralKey) }} ({{ getMetadataItems(tab.type).length }})
           </p-tab>
         }
       </p-tablist>
@@ -160,13 +160,13 @@
   </div>
 
   <p-dialog
-    [header]="t('mergeSplitDialogTitle', { type: currentMergeType | titlecase })"
+    [header]="t('mergeSplitDialogTitle', { type: getTypeLabel(currentMergeType, true) })"
     [(visible)]="showMergeDialog"
     [modal]="true"
     class="user-dialog"
     [style]="{width: '50rem'}">
     <div class="dialog-form">
-      <p>{{ t('mergeSplitDescription', { count: getSelectedItems(currentMergeType).length, type: currentMergeType }) }}</p>
+      <p>{{ t('mergeSplitDescription', { count: getSelectedItems(currentMergeType).length, type: getTypeLabel(currentMergeType, true) }) }}</p>
       <ul class="selected-items">
         @for (item of getSelectedItems(currentMergeType); track item.value) {
           <li>
@@ -185,9 +185,9 @@
           class="full-width-input"
           [placeholder]="isSingleValueField(currentMergeType) ? t('singleValuePlaceholder') : t('multiValuePlaceholder')"/>
         @if (isSingleValueField(currentMergeType)) {
-          <small class="help-text" [innerHTML]="t('singleMergeHowItWorks', { type: currentMergeType, singular: currentMergeType.slice(0, -1) })"></small>
+          <small class="help-text" [innerHTML]="t('singleMergeHowItWorks', { type: getTypeLabel(currentMergeType, true), singular: getTypeLabel(currentMergeType, false) })"></small>
         } @else {
-          <small class="help-text" [innerHTML]="t('multiMergeHowItWorks', { type: currentMergeType })"></small>
+          <small class="help-text" [innerHTML]="t('multiMergeHowItWorks', { type: getTypeLabel(currentMergeType, true) })"></small>
         }
       </div>
       @if (mergingInProgress) {
@@ -219,7 +219,7 @@
   </p-dialog>
 
   <p-dialog
-    [header]="t('renameSplitDialogTitle', { type: currentMergeType | titlecase })"
+    [header]="t('renameSplitDialogTitle', { type: getTypeLabel(currentMergeType, true) })"
     [(visible)]="showRenameDialog"
     [modal]="true"
     class="user-dialog"
@@ -242,9 +242,9 @@
           [placeholder]="isSingleValueField(currentMergeType) ? t('singleRenamePlaceholder') : t('multiRenamePlaceholder')"
           (keyup.enter)="confirmRename()"/>
         @if (isSingleValueField(currentMergeType)) {
-          <small class="help-text" [innerHTML]="t('singleRenameHowItWorks', { singular: currentMergeType.slice(0, -1) })"></small>
+          <small class="help-text" [innerHTML]="t('singleRenameHowItWorks', { singular: getTypeLabel(currentMergeType, false) })"></small>
         } @else {
-          <small class="help-text" [innerHTML]="t('multiRenameHowItWorks', { singular: currentMergeType.slice(0, -1), type: currentMergeType })"></small>
+          <small class="help-text" [innerHTML]="t('multiRenameHowItWorks', { singular: getTypeLabel(currentMergeType, false), type: getTypeLabel(currentMergeType, true) })"></small>
         }
       </div>
       @if (mergingInProgress) {
@@ -276,7 +276,7 @@
   </p-dialog>
 
   <p-dialog
-    [header]="t('deleteDialogTitle', { type: currentMergeType | titlecase })"
+    [header]="t('deleteDialogTitle', { type: getTypeLabel(currentMergeType, true) })"
     [(visible)]="showDeleteDialog"
     [modal]="true"
     class="user-dialog"
@@ -284,7 +284,7 @@
     <div class="dialog-form">
       <div class="warning-message">
         <i class="pi pi-exclamation-triangle"></i>
-        <p>{{ t('deleteWarning', { count: currentDeleteItem ? 1 : getSelectedItems(currentMergeType).length, type: currentMergeType }) }}</p>
+        <p>{{ t('deleteWarning', { count: currentDeleteItem ? 1 : getSelectedItems(currentMergeType).length, type: getTypeLabel(currentMergeType, true) }) }}</p>
       </div>
 
       @if (currentDeleteItem) {
@@ -305,7 +305,7 @@
       <div class="delete-info">
         <p><strong>{{ t('whatWillHappen') }}</strong></p>
         <ul>
-          <li>{{ t('deleteItemRemoved', { singular: currentMergeType.slice(0, -1) }) }}</li>
+          <li>{{ t('deleteItemRemoved', { singular: getTypeLabel(currentMergeType, false) }) }}</li>
           <li>{{ t('deleteCannotUndo') }}</li>
           <li>{{ t('totalBooksAffected') }} <strong>{{ currentDeleteItem ? currentDeleteItem.count : getTotalAffectedBooks(getSelectedItems(currentMergeType)) }}</strong></li>
         </ul>

--- a/booklore-ui/src/app/features/metadata/component/metadata-manager/metadata-manager.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/metadata-manager/metadata-manager.component.ts
@@ -33,6 +33,7 @@ type MetadataType = 'authors' | 'categories' | 'moods' | 'tags' | 'series' | 'pu
 interface TabConfig {
   type: MetadataType;
   labelKey: string;
+  labelPluralKey: string;
   placeholderKey: string;
   selectAllKey: 'selectAllAuthors' | 'selectAllCategories' | 'selectAllMoods' | 'selectAllTags' | 'selectAllSeries' | 'selectAllPublishers' | 'selectAllLanguages';
   icon: string;
@@ -125,13 +126,13 @@ export class MetadataManagerComponent implements OnInit, OnDestroy {
   }
 
   tabConfigs: TabConfig[] = [
-    {type: 'authors', labelKey: 'tabs.author', placeholderKey: 'placeholders.searchAuthors', selectAllKey: 'selectAllAuthors', icon: 'pi-user'},
-    {type: 'categories', labelKey: 'tabs.genre', placeholderKey: 'placeholders.searchGenres', selectAllKey: 'selectAllCategories', icon: 'pi-tag'},
-    {type: 'moods', labelKey: 'tabs.mood', placeholderKey: 'placeholders.searchMoods', selectAllKey: 'selectAllMoods', icon: 'pi-heart'},
-    {type: 'tags', labelKey: 'tabs.tag', placeholderKey: 'placeholders.searchTags', selectAllKey: 'selectAllTags', icon: 'pi-tags'},
-    {type: 'series', labelKey: 'tabs.series', placeholderKey: 'placeholders.searchSeries', selectAllKey: 'selectAllSeries', icon: 'pi-book'},
-    {type: 'publishers', labelKey: 'tabs.publisher', placeholderKey: 'placeholders.searchPublishers', selectAllKey: 'selectAllPublishers', icon: 'pi-building'},
-    {type: 'languages', labelKey: 'tabs.language', placeholderKey: 'placeholders.searchLanguages', selectAllKey: 'selectAllLanguages', icon: 'pi-globe'}
+    {type: 'authors', labelKey: 'tabs.author', labelPluralKey: 'tabs.authors', placeholderKey: 'placeholders.searchAuthors', selectAllKey: 'selectAllAuthors', icon: 'pi-user'},
+    {type: 'categories', labelKey: 'tabs.genre', labelPluralKey: 'tabs.genres', placeholderKey: 'placeholders.searchGenres', selectAllKey: 'selectAllCategories', icon: 'pi-tag'},
+    {type: 'moods', labelKey: 'tabs.mood', labelPluralKey: 'tabs.moods', placeholderKey: 'placeholders.searchMoods', selectAllKey: 'selectAllMoods', icon: 'pi-heart'},
+    {type: 'tags', labelKey: 'tabs.tag', labelPluralKey: 'tabs.tags', placeholderKey: 'placeholders.searchTags', selectAllKey: 'selectAllTags', icon: 'pi-tags'},
+    {type: 'series', labelKey: 'tabs.series', labelPluralKey: 'tabs.seriesPlural', placeholderKey: 'placeholders.searchSeries', selectAllKey: 'selectAllSeries', icon: 'pi-book'},
+    {type: 'publishers', labelKey: 'tabs.publisher', labelPluralKey: 'tabs.publishers', placeholderKey: 'placeholders.searchPublishers', selectAllKey: 'selectAllPublishers', icon: 'pi-building'},
+    {type: 'languages', labelKey: 'tabs.language', labelPluralKey: 'tabs.languages', placeholderKey: 'placeholders.searchLanguages', selectAllKey: 'selectAllLanguages', icon: 'pi-globe'}
   ];
 
   ngOnInit() {
@@ -303,7 +304,7 @@ export class MetadataManagerComponent implements OnInit, OnDestroy {
       this.messageService.add({
         severity: 'warn',
         summary: this.t.translate('metadata.manager.toast.invalidTargetSummary'),
-        detail: this.t.translate('metadata.manager.toast.singleValueOnly', {singular: this.currentMergeType.slice(0, -1)})
+        detail: this.t.translate('metadata.manager.toast.singleValueOnly', {singular: this.getTypeLabel(this.currentMergeType, false)})
       });
       return;
     }
@@ -389,7 +390,7 @@ export class MetadataManagerComponent implements OnInit, OnDestroy {
       this.messageService.add({
         severity: 'warn',
         summary: this.t.translate('metadata.manager.toast.invalidTargetSummary'),
-        detail: this.t.translate('metadata.manager.toast.singleMergeValueOnly', {singular: this.currentMergeType.slice(0, -1)})
+        detail: this.t.translate('metadata.manager.toast.singleMergeValueOnly', {singular: this.getTypeLabel(this.currentMergeType, false)})
       });
       return;
     }
@@ -413,8 +414,8 @@ export class MetadataManagerComponent implements OnInit, OnDestroy {
             ? this.t.translate('metadata.manager.toast.mergeSuccessfulSummary')
             : this.t.translate('metadata.manager.toast.mergeSplitSuccessfulSummary'),
           detail: operation === 'merge'
-            ? this.t.translate('metadata.manager.toast.mergeSuccessfulDetail', {selectedCount: selected.length, type: this.currentMergeType, targetCount: targetValues.length, bookCount: affectedBooks})
-            : this.t.translate('metadata.manager.toast.mergeSplitSuccessfulDetail', {selectedCount: selected.length, type: this.currentMergeType, targetCount: targetValues.length, bookCount: affectedBooks}),
+            ? this.t.translate('metadata.manager.toast.mergeSuccessfulDetail', {selectedCount: selected.length, type: this.getTypeLabel(this.currentMergeType, true), targetCount: targetValues.length, bookCount: affectedBooks})
+            : this.t.translate('metadata.manager.toast.mergeSplitSuccessfulDetail', {selectedCount: selected.length, type: this.getTypeLabel(this.currentMergeType, true), targetCount: targetValues.length, bookCount: affectedBooks}),
           life: 5000
         });
         this.showMergeDialog = false;
@@ -470,7 +471,7 @@ export class MetadataManagerComponent implements OnInit, OnDestroy {
         this.messageService.add({
           severity: 'success',
           summary: this.t.translate('metadata.manager.toast.deleteSuccessfulSummary'),
-          detail: this.t.translate('metadata.manager.toast.deleteSuccessfulDetail', {count: itemCount, type: this.currentMergeType.slice(0, -1) + (itemCount > 1 ? 's' : ''), bookCount: affectedBooks}),
+          detail: this.t.translate('metadata.manager.toast.deleteSuccessfulDetail', {count: itemCount, type: itemCount > 1 ? this.getTypeLabel(this.currentMergeType, true) : this.getTypeLabel(this.currentMergeType, false), bookCount: affectedBooks}),
           life: 5000
         });
         this.showDeleteDialog = false;
@@ -609,6 +610,12 @@ export class MetadataManagerComponent implements OnInit, OnDestroy {
         filter: `${filterKey}:${encodeURIComponent(filterValue)}`
       }
     });
+  }
+
+  protected getTypeLabel(type: MetadataType, plural: boolean): string {
+    const tab = this.tabConfigs.find(tc => tc.type === type);
+    if (!tab) return type;
+    return this.t.translate('metadata.manager.' + (plural ? tab.labelPluralKey : tab.labelKey));
   }
 
   protected isSingleValueField(type: MetadataType): boolean {

--- a/booklore-ui/src/app/features/metadata/component/metadata-provider-field-selector/metadata-provider-field-selector.component.html
+++ b/booklore-ui/src/app/features/metadata/component/metadata-provider-field-selector/metadata-provider-field-selector.component.html
@@ -12,11 +12,11 @@
 
     <div class="section-body">
       <div class="provider-groups-container">
-        @for (group of providerGroups; track group.label) {
+        @for (group of providerGroups; track group.labelKey) {
           <div class="provider-group">
             <div class="group-header">
               <span class="group-icon pi pi-database"></span>
-              <h4 class="group-label">{{ group.label }}</h4>
+              <h4 class="group-label">{{ getProviderLabel(group.labelKey) }}</h4>
             </div>
             <div class="field-list">
               @for (field of group.fields; track field) {
@@ -26,7 +26,7 @@
                     [ngModel]="selectedFields.includes(field)"
                     (ngModelChange)="toggleField(field, $event)">
                   </p-toggleswitch>
-                  <label [for]="field">{{ fieldLabels[field] || field }}</label>
+                  <label [for]="field">{{ getFieldLabel(field) }}</label>
                 </div>
               }
             </div>

--- a/booklore-ui/src/app/features/metadata/component/metadata-provider-field-selector/metadata-provider-field-selector.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/metadata-provider-field-selector/metadata-provider-field-selector.component.ts
@@ -4,7 +4,7 @@ import {FormsModule} from '@angular/forms';
 import {AppSettingsService} from '../../../../shared/service/app-settings.service';
 import {AppSettingKey, MetadataProviderSpecificFields} from '../../../../shared/model/app-settings.model';
 import {filter, take} from 'rxjs/operators';
-import {TranslocoDirective} from '@jsverse/transloco';
+import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 
 @Component({
   selector: 'app-metadata-provider-field-selector',
@@ -17,63 +17,26 @@ export class MetadataProviderFieldSelectorComponent implements OnInit {
   @Input() selectedFields: string[] = [];
 
   private appSettingsService = inject(AppSettingsService);
+  private t = inject(TranslocoService);
 
-  providerGroups: { label: string, fields: string[] }[] = [
-    {
-      label: 'Amazon',
-      fields: ['asin', 'amazonRating', 'amazonReviewCount']
-    },
-    {
-      label: 'Google Books',
-      fields: ['googleId']
-    },
-    {
-      label: 'Goodreads',
-      fields: ['goodreadsId', 'goodreadsRating', 'goodreadsReviewCount']
-    },
-    {
-      label: 'Hardcover',
-      fields: ['hardcoverId', 'hardcoverBookId', 'hardcoverRating', 'hardcoverReviewCount']
-    },
-    {
-      label: 'Audible',
-      fields: ['audibleId', 'audibleRating', 'audibleReviewCount']
-    },
-    {
-      label: 'Comicvine',
-      fields: ['comicvineId']
-    },
-    {
-      label: 'Lubimyczytac',
-      fields: ['lubimyczytacId', 'lubimyczytacRating']
-    },
-    {
-      label: 'Ranobedb',
-      fields: ['ranobedbId', 'ranobedbRating']
-    }
+  providerGroups: { labelKey: string, fields: string[] }[] = [
+    {labelKey: 'amazon', fields: ['asin', 'amazonRating', 'amazonReviewCount']},
+    {labelKey: 'googleBooks', fields: ['googleId']},
+    {labelKey: 'goodreads', fields: ['goodreadsId', 'goodreadsRating', 'goodreadsReviewCount']},
+    {labelKey: 'hardcover', fields: ['hardcoverId', 'hardcoverBookId', 'hardcoverRating', 'hardcoverReviewCount']},
+    {labelKey: 'audible', fields: ['audibleId', 'audibleRating', 'audibleReviewCount']},
+    {labelKey: 'comicvine', fields: ['comicvineId']},
+    {labelKey: 'lubimyczytac', fields: ['lubimyczytacId', 'lubimyczytacRating']},
+    {labelKey: 'ranobedb', fields: ['ranobedbId', 'ranobedbRating']}
   ];
 
-  fieldLabels: Record<string, string> = {
-    'asin': 'Amazon ASIN',
-    'amazonRating': 'Amazon Rating',
-    'amazonReviewCount': 'Amazon Review Count',
-    'googleId': 'Google Books ID',
-    'goodreadsId': 'Goodreads ID',
-    'goodreadsRating': 'Goodreads Rating',
-    'goodreadsReviewCount': 'Goodreads Review Count',
-    'hardcoverId': 'Hardcover ID',
-    'hardcoverBookId': 'Hardcover Book ID',
-    'hardcoverRating': 'Hardcover Rating',
-    'hardcoverReviewCount': 'Hardcover Review Count',
-    'comicvineId': 'Comicvine ID',
-    'lubimyczytacId': 'Lubimyczytac ID',
-    'lubimyczytacRating': 'Lubimyczytac Rating',
-    'ranobedbId': 'Ranobedb ID',
-    'ranobedbRating': 'Ranobedb Rating',
-    'audibleId': 'Audible ID',
-    'audibleRating': 'Audible Rating',
-    'audibleReviewCount': 'Audible Review Count',
-  };
+  getProviderLabel(key: string): string {
+    return this.t.translate('settingsMeta.fieldSelector.providers.' + key);
+  }
+
+  getFieldLabel(field: string): string {
+    return this.t.translate('settingsMeta.fieldSelector.fields.' + field);
+  }
 
   private readonly allFieldNames: (keyof MetadataProviderSpecificFields)[] = [
     'asin', 'amazonRating', 'amazonReviewCount',

--- a/booklore-ui/src/app/features/settings/global-preferences/metadata-match-weights/metadata-match-weights-component.html
+++ b/booklore-ui/src/app/features/settings/global-preferences/metadata-match-weights/metadata-match-weights-component.html
@@ -38,7 +38,7 @@
           <div class="weights-grid">
             @for (key of orderedKeys; track key) {
               <div class="weight-field">
-                <label class="field-label">{{ labelMap[key] }}</label>
+                <label class="field-label">{{ getFieldLabel(key) }}</label>
                 <p-inputNumber
                   size="small"
                   [formControlName]="key"

--- a/booklore-ui/src/app/features/settings/global-preferences/metadata-match-weights/metadata-match-weights-component.ts
+++ b/booklore-ui/src/app/features/settings/global-preferences/metadata-match-weights/metadata-match-weights-component.ts
@@ -23,34 +23,14 @@ import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 })
 export class MetadataMatchWeightsComponent implements OnInit {
 
-  readonly labelMap: Record<string, string> = {
-    title: 'Title',
-    subtitle: 'Subtitle',
-    authors: 'Authors',
-    description: 'Description',
-    publisher: 'Publisher',
-    publishedDate: 'Published Date',
-    categories: 'Categories',
-    coverImage: 'Cover Image',
-    seriesName: 'Series Name',
-    seriesNumber: 'Series Number',
-    seriesTotal: 'Series Total',
-    language: 'Language',
-    isbn13: 'ISBN-13',
-    isbn10: 'ISBN-10',
-    pageCount: 'Page Count',
-    amazonRating: 'Amazon Rating',
-    amazonReviewCount: 'Amazon Rating #',
-    goodreadsRating: 'Goodreads Rating',
-    goodreadsReviewCount: 'Goodreads Rating #',
-    hardcoverRating: 'Hardcover Rating',
-    hardcoverReviewCount: 'Hardcover Rating #',
-    audibleRating: 'Audible Rating',
-    audibleReviewCount: 'Audible Rating #',
-    doubanRating: 'Douban Rating',
-    doubanReviewCount: 'Douban Rating #',
-    ranobedbRating: 'Ranobedb Rating',
-  };
+  readonly orderedFieldKeys: string[] = [
+    'title', 'subtitle', 'authors', 'description', 'publisher', 'publishedDate',
+    'categories', 'coverImage', 'seriesName', 'seriesNumber', 'seriesTotal',
+    'language', 'isbn13', 'isbn10', 'pageCount',
+    'amazonRating', 'amazonReviewCount', 'goodreadsRating', 'goodreadsReviewCount',
+    'hardcoverRating', 'hardcoverReviewCount', 'audibleRating', 'audibleReviewCount',
+    'doubanRating', 'doubanReviewCount', 'ranobedbRating'
+  ];
 
   form!: FormGroup;
   isSaving = false;
@@ -103,7 +83,11 @@ export class MetadataMatchWeightsComponent implements OnInit {
   }
 
   get orderedKeys(): string[] {
-    return Object.keys(this.labelMap);
+    return this.orderedFieldKeys;
+  }
+
+  getFieldLabel(key: string): string {
+    return this.t.translate('settingsMeta.matchWeights.fields.' + key);
   }
 
   save(): void {

--- a/booklore-ui/src/app/features/settings/view-preferences-parent/sidebar-sorting-preferences/sidebar-sorting-preferences.component.ts
+++ b/booklore-ui/src/app/features/settings/view-preferences-parent/sidebar-sorting-preferences/sidebar-sorting-preferences.component.ts
@@ -19,12 +19,14 @@ import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 })
 export class SidebarSortingPreferencesComponent implements OnInit, OnDestroy {
 
-  readonly sortingOptions = [
-    {label: 'Name | Ascending', value: {field: 'name', order: 'asc'}, translationKey: 'nameAsc'},
-    {label: 'Name | Descending', value: {field: 'name', order: 'desc'}, translationKey: 'nameDesc'},
-    {label: 'Creation Date | Ascending', value: {field: 'id', order: 'asc'}, translationKey: 'creationAsc'},
-    {label: 'Creation Date | Descending', value: {field: 'id', order: 'desc'}, translationKey: 'creationDesc'},
+  private readonly sortingOptionDefs = [
+    {value: {field: 'name', order: 'asc'}, translationKey: 'nameAsc'},
+    {value: {field: 'name', order: 'desc'}, translationKey: 'nameDesc'},
+    {value: {field: 'id', order: 'asc'}, translationKey: 'creationAsc'},
+    {value: {field: 'id', order: 'desc'}, translationKey: 'creationDesc'},
   ];
+
+  sortingOptions: {label: string; value: {field: string; order: string}; translationKey: string}[] = [];
 
   selectedLibrarySorting: SidebarLibrarySorting = {field: 'id', order: 'asc'};
   selectedShelfSorting: SidebarShelfSorting = {field: 'id', order: 'asc'};
@@ -39,6 +41,9 @@ export class SidebarSortingPreferencesComponent implements OnInit, OnDestroy {
   private currentUser: User | null = null;
 
   ngOnInit(): void {
+    this.buildSortingOptions();
+    this.t.langChanges$.pipe(takeUntil(this.destroy$)).subscribe(() => this.buildSortingOptions());
+
     this.userData$.pipe(
       filter(userState => !!userState?.user && userState.loaded),
       takeUntil(this.destroy$)
@@ -51,6 +56,13 @@ export class SidebarSortingPreferencesComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  private buildSortingOptions(): void {
+    this.sortingOptions = this.sortingOptionDefs.map(opt => ({
+      ...opt,
+      label: this.t.translate('settingsView.sidebarSort.' + opt.translationKey)
+    }));
   }
 
   private loadPreferences(settings: UserSettings): void {

--- a/booklore-ui/src/app/features/settings/view-preferences-parent/view-preferences/view-preferences.component.ts
+++ b/booklore-ui/src/app/features/settings/view-preferences-parent/view-preferences/view-preferences.component.ts
@@ -44,47 +44,42 @@ import {CdkDrag, CdkDragDrop, CdkDragHandle, CdkDropList, moveItemInArray} from 
 export class ViewPreferencesComponent implements OnInit, OnDestroy {
   private t = inject(TranslocoService);
 
-  sortOptions: {label: string; field: string; translationKey: string}[] = [
-    {label: 'Title', field: 'title', translationKey: 'sortTitle'},
-    {label: 'File Name', field: 'fileName', translationKey: 'sortFileName'},
-    {label: 'File Path', field: 'filePath', translationKey: 'sortFilePath'},
-    {label: 'Author', field: 'author', translationKey: 'sortAuthor'},
-    {label: 'Author (Surname)', field: 'authorSurnameVorname', translationKey: 'sortAuthorSurname'},
-    {label: 'Series Name', field: 'seriesName', translationKey: 'sortSeriesName'},
-    {label: 'Series Number', field: 'seriesNumber', translationKey: 'sortSeriesNumber'},
-    {label: 'Last Read', field: 'lastReadTime', translationKey: 'sortLastRead'},
-    {label: 'Personal Rating', field: 'personalRating', translationKey: 'sortPersonalRating'},
-    {label: 'Added On', field: 'addedOn', translationKey: 'sortAddedOn'},
-    {label: 'File Size', field: 'fileSizeKb', translationKey: 'sortFileSize'},
-    {label: 'Locked', field: 'locked', translationKey: 'sortLocked'},
-    {label: 'Publisher', field: 'publisher', translationKey: 'sortPublisher'},
-    {label: 'Published Date', field: 'publishedDate', translationKey: 'sortPublishedDate'},
-    {label: 'Read Status', field: 'readStatus', translationKey: 'sortReadStatus'},
-    {label: 'Date Finished', field: 'dateFinished', translationKey: 'sortDateFinished'},
-    {label: 'Reading Progress', field: 'readingProgress', translationKey: 'sortReadingProgress'},
-    {label: 'Book Type', field: 'bookType', translationKey: 'sortBookType'},
-    {label: 'Amazon Rating', field: 'amazonRating', translationKey: 'sortAmazonRating'},
-    {label: 'Amazon #', field: 'amazonReviewCount', translationKey: 'sortAmazonCount'},
-    {label: 'Goodreads Rating', field: 'goodreadsRating', translationKey: 'sortGoodreadsRating'},
-    {label: 'Goodreads #', field: 'goodreadsReviewCount', translationKey: 'sortGoodreadsCount'},
-    {label: 'Hardcover Rating', field: 'hardcoverRating', translationKey: 'sortHardcoverRating'},
-    {label: 'Hardcover #', field: 'hardcoverReviewCount', translationKey: 'sortHardcoverCount'},
-    {label: 'Ranobedb Rating', field: 'ranobedbRating', translationKey: 'sortRanobedbRating'},
-    {label: 'Narrator', field: 'narrator', translationKey: 'sortNarrator'},
-    {label: 'Pages', field: 'pageCount', translationKey: 'sortPages'},
-    {label: 'Random', field: 'random', translationKey: 'sortRandom'},
+  private readonly sortOptionDefs: {field: string; translationKey: string}[] = [
+    {field: 'title', translationKey: 'sortTitle'},
+    {field: 'fileName', translationKey: 'sortFileName'},
+    {field: 'filePath', translationKey: 'sortFilePath'},
+    {field: 'author', translationKey: 'sortAuthor'},
+    {field: 'authorSurnameVorname', translationKey: 'sortAuthorSurname'},
+    {field: 'seriesName', translationKey: 'sortSeriesName'},
+    {field: 'seriesNumber', translationKey: 'sortSeriesNumber'},
+    {field: 'lastReadTime', translationKey: 'sortLastRead'},
+    {field: 'personalRating', translationKey: 'sortPersonalRating'},
+    {field: 'addedOn', translationKey: 'sortAddedOn'},
+    {field: 'fileSizeKb', translationKey: 'sortFileSize'},
+    {field: 'locked', translationKey: 'sortLocked'},
+    {field: 'publisher', translationKey: 'sortPublisher'},
+    {field: 'publishedDate', translationKey: 'sortPublishedDate'},
+    {field: 'readStatus', translationKey: 'sortReadStatus'},
+    {field: 'dateFinished', translationKey: 'sortDateFinished'},
+    {field: 'readingProgress', translationKey: 'sortReadingProgress'},
+    {field: 'bookType', translationKey: 'sortBookType'},
+    {field: 'amazonRating', translationKey: 'sortAmazonRating'},
+    {field: 'amazonReviewCount', translationKey: 'sortAmazonCount'},
+    {field: 'goodreadsRating', translationKey: 'sortGoodreadsRating'},
+    {field: 'goodreadsReviewCount', translationKey: 'sortGoodreadsCount'},
+    {field: 'hardcoverRating', translationKey: 'sortHardcoverRating'},
+    {field: 'hardcoverReviewCount', translationKey: 'sortHardcoverCount'},
+    {field: 'ranobedbRating', translationKey: 'sortRanobedbRating'},
+    {field: 'narrator', translationKey: 'sortNarrator'},
+    {field: 'pageCount', translationKey: 'sortPages'},
+    {field: 'random', translationKey: 'sortRandom'},
   ];
 
-  entityTypeOptions: {label: string; value: string; translationKey: string}[] = [
-    {label: 'Library', value: 'LIBRARY', translationKey: 'entityLibrary'},
-    {label: 'Shelf', value: 'SHELF', translationKey: 'entityShelf'},
-    {label: 'Magic Shelf', value: 'MAGIC_SHELF', translationKey: 'entityMagicShelf'}
-  ];
+  sortOptions: {label: string; field: string; translationKey: string}[] = [];
 
-  viewModeOptions: {label: string; value: string; translationKey: string}[] = [
-    {label: 'Grid', value: 'GRID', translationKey: 'viewGrid'},
-    {label: 'Table', value: 'TABLE', translationKey: 'viewTable'}
-  ];
+  entityTypeOptions: {label: string; value: string; translationKey: string}[] = [];
+
+  viewModeOptions: {label: string; value: string; translationKey: string}[] = [];
 
   libraryOptions: { label: string; value: number }[] = [];
   shelfOptions: { label: string; value: number }[] = [];
@@ -128,6 +123,20 @@ export class ViewPreferencesComponent implements OnInit, OnDestroy {
   private messageService = inject(MessageService);
 
   ngOnInit(): void {
+    this.rebuildTranslatedLabels();
+    this.t.langChanges$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.rebuildTranslatedLabels();
+      this.allSortAsOptions = this.sortOptions.map(o => ({
+        label: this.t.translate('settingsView.librarySort.' + o.translationKey),
+        field: o.field,
+        direction: SortDirection.ASCENDING
+      }));
+      this.globalSortAsOptions = this.toSortOptions(this.sortCriteria);
+      this.overrides.forEach(o => {
+        o.sortCriteriaAsOptions = this.toSortOptions(o.sortCriteria);
+      });
+    });
+
     combineLatest([
       this.userService.userState$.pipe(filter(userState => !!userState?.user && userState.loaded), take(1)),
       this.libraryService.libraryState$.pipe(filter(libraryState => !!libraryState?.libraries && libraryState.loaded), take(1)),
@@ -194,6 +203,23 @@ export class ViewPreferencesComponent implements OnInit, OnDestroy {
         value: s.id!
       }));
     });
+  }
+
+  private rebuildTranslatedLabels(): void {
+    this.sortOptions = this.sortOptionDefs.map(o => ({
+      label: this.t.translate('settingsView.librarySort.' + o.translationKey),
+      field: o.field,
+      translationKey: o.translationKey
+    }));
+    this.entityTypeOptions = [
+      {label: this.t.translate('settingsView.librarySort.entityLibrary'), value: 'LIBRARY', translationKey: 'entityLibrary'},
+      {label: this.t.translate('settingsView.librarySort.entityShelf'), value: 'SHELF', translationKey: 'entityShelf'},
+      {label: this.t.translate('settingsView.librarySort.entityMagicShelf'), value: 'MAGIC_SHELF', translationKey: 'entityMagicShelf'}
+    ];
+    this.viewModeOptions = [
+      {label: this.t.translate('settingsView.librarySort.viewGrid'), value: 'GRID', translationKey: 'viewGrid'},
+      {label: this.t.translate('settingsView.librarySort.viewTable'), value: 'TABLE', translationKey: 'viewTable'}
+    ];
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/app/shared/components/github-support-dialog/github-support-dialog.html
+++ b/booklore-ui/src/app/shared/components/github-support-dialog/github-support-dialog.html
@@ -1,11 +1,12 @@
+<ng-container *transloco="let t; prefix: 'shared.supportDialog'">
 <div class="support-dialog-container">
   <div class="panel-header">
     <div class="header-icon-wrapper">
       <i class="pi pi-heart header-icon"></i>
     </div>
     <div class="header-text">
-      <h2 class="panel-title">Support BookLore</h2>
-      <p class="panel-description">From a solo dev who loves books</p>
+      <h2 class="panel-title">{{ t('title') }}</h2>
+      <p class="panel-description">{{ t('subtitle') }}</p>
     </div>
     <p-button
       icon="pi pi-times"
@@ -19,15 +20,15 @@
 
   <div class="dialog-content">
     <p class="intro">
-      BookLore is built and maintained by a single developer who genuinely loves books. If it's made organizing your library a little more enjoyable, here are a few ways to support the project and keep it going.
+      {{ t('intro') }}
     </p>
 
     <div class="support-cards">
       <a class="support-card star-card" href="https://github.com/booklore-app/booklore" target="_blank" rel="noopener noreferrer">
         <i class="pi pi-github card-icon"></i>
         <div class="card-text">
-          <span class="card-title">Star on GitHub</span>
-          <span class="card-desc">A star goes a long way. It helps new people find BookLore and keeps me motivated.</span>
+          <span class="card-title">{{ t('starTitle') }}</span>
+          <span class="card-desc">{{ t('starDesc') }}</span>
         </div>
         <i class="pi pi-arrow-up-right card-arrow"></i>
       </a>
@@ -35,8 +36,8 @@
       <a class="support-card collective-card" href="https://opencollective.com/booklore" target="_blank" rel="noopener noreferrer">
         <i class="pi pi-heart card-icon"></i>
         <div class="card-text">
-          <span class="card-title">Open Collective</span>
-          <span class="card-desc">Recurring support that helps cover hosting and keeps development sustainable.</span>
+          <span class="card-title">{{ t('collectiveTitle') }}</span>
+          <span class="card-desc">{{ t('collectiveDesc') }}</span>
         </div>
         <i class="pi pi-arrow-up-right card-arrow"></i>
       </a>
@@ -44,13 +45,14 @@
       <a class="support-card kofi-card" href="https://ko-fi.com/bookloredev" target="_blank" rel="noopener noreferrer">
         <i class="pi pi-gift card-icon"></i>
         <div class="card-text">
-          <span class="card-title">Buy me a coffee</span>
-          <span class="card-desc">A one-time tip to fuel late-night coding sessions. Every bit is appreciated!</span>
+          <span class="card-title">{{ t('kofiTitle') }}</span>
+          <span class="card-desc">{{ t('kofiDesc') }}</span>
         </div>
         <i class="pi pi-arrow-up-right card-arrow"></i>
       </a>
     </div>
 
-    <p class="closing">Thank you for being part of the BookLore community.</p>
+    <p class="closing">{{ t('closing') }}</p>
   </div>
 </div>
+</ng-container>

--- a/booklore-ui/src/app/shared/components/github-support-dialog/github-support-dialog.ts
+++ b/booklore-ui/src/app/shared/components/github-support-dialog/github-support-dialog.ts
@@ -1,11 +1,13 @@
 import {Component, inject} from '@angular/core';
 import {Button} from 'primeng/button';
 import {DynamicDialogRef} from 'primeng/dynamicdialog';
+import {TranslocoDirective} from '@jsverse/transloco';
 
 @Component({
   selector: 'app-github-support-dialog',
   imports: [
-    Button
+    Button,
+    TranslocoDirective
   ],
   templateUrl: './github-support-dialog.html',
   styleUrls: ['./github-support-dialog.scss']

--- a/booklore-ui/src/app/shared/components/live-notification-box/live-notification-box.component.ts
+++ b/booklore-ui/src/app/shared/components/live-notification-box/live-notification-box.component.ts
@@ -1,8 +1,10 @@
-import {Component, inject} from '@angular/core';
+import {Component, inject, OnDestroy} from '@angular/core';
 import {NotificationEventService} from '../../websocket/notification-event.service';
 import {LogNotification} from '../../websocket/model/log-notification.model';
 import {Tag} from 'primeng/tag';
 import {TranslocoService} from '@jsverse/transloco';
+import {Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 
 import {TagComponent} from '../tag/tag.component';
 
@@ -18,16 +20,29 @@ import {TagComponent} from '../tag/tag.component';
     TagComponent
   ]
 })
-export class LiveNotificationBoxComponent {
+export class LiveNotificationBoxComponent implements OnDestroy {
   private readonly t = inject(TranslocoService);
+  private readonly destroy$ = new Subject<void>();
   latestNotification: LogNotification = {message: this.t.translate('shared.liveNotification.defaultMessage')};
+  private hasReceivedNotification = false;
 
   private notificationService = inject(NotificationEventService);
 
   constructor() {
-    this.notificationService.latestNotification$.subscribe(notification => {
+    this.notificationService.latestNotification$.pipe(takeUntil(this.destroy$)).subscribe(notification => {
+      this.hasReceivedNotification = true;
       this.latestNotification = notification;
     });
+    this.t.langChanges$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      if (!this.hasReceivedNotification) {
+        this.latestNotification = {message: this.t.translate('shared.liveNotification.defaultMessage')};
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   getSeverityColor(severity?: string): 'red' | 'amber' | 'green' | 'gray' {

--- a/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.ts
+++ b/booklore-ui/src/app/shared/layout/component/layout-topbar/app.topbar.component.ts
@@ -132,6 +132,12 @@ export class AppTopBarComponent implements OnDestroy {
       .subscribe(() => {
         this.initializeStatsMenu();
       });
+
+    this.translocoService.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.initializeStatsMenu();
+      });
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/i18n/en/metadata.json
+++ b/booklore-ui/src/i18n/en/metadata.json
@@ -498,12 +498,19 @@
     "deleting": "Deleting...",
     "tabs": {
       "author": "Author",
+      "authors": "Authors",
       "genre": "Genre",
+      "genres": "Genres",
       "mood": "Mood",
+      "moods": "Moods",
       "tag": "Tag",
+      "tags": "Tags",
       "series": "Series",
+      "seriesPlural": "Series",
       "publisher": "Publisher",
-      "language": "Language"
+      "publishers": "Publishers",
+      "language": "Language",
+      "languages": "Languages"
     },
     "placeholders": {
       "searchAuthors": "Search authors...",

--- a/booklore-ui/src/i18n/en/settings-metadata.json
+++ b/booklore-ui/src/i18n/en/settings-metadata.json
@@ -63,10 +63,6 @@
     "hardcoverPlaceholder": "Enter Hardcover API token",
     "comicvinePlaceholder": "Enter Comic Vine API token"
   },
-  "fieldSelector": {
-    "sectionTitle": "Enabled Fields in Metadata Editor & Picker",
-    "sectionDesc": "Select which metadata fields to display when editing book information or picking metadata from providers. Disabled fields will be hidden from the interface."
-  },
   "publicReviews": {
     "sectionTitle": "Public Reviews",
     "sectionDesc": "Configure automatic downloading of user reviews from external platforms. Reviews can be fetched from Amazon, Goodreads, and Hardcover for offline access.",
@@ -91,6 +87,69 @@
     "saveSuccess": "Weights saved successfully",
     "saveError": "Failed to save weights",
     "recalcSuccess": "All book match scores were recalculated successfully.",
-    "recalcError": "Failed to recalculate match scores."
+    "recalcError": "Failed to recalculate match scores.",
+    "fields": {
+      "title": "Title",
+      "subtitle": "Subtitle",
+      "authors": "Authors",
+      "description": "Description",
+      "publisher": "Publisher",
+      "publishedDate": "Published Date",
+      "categories": "Categories",
+      "coverImage": "Cover Image",
+      "seriesName": "Series Name",
+      "seriesNumber": "Series Number",
+      "seriesTotal": "Series Total",
+      "language": "Language",
+      "isbn13": "ISBN-13",
+      "isbn10": "ISBN-10",
+      "pageCount": "Page Count",
+      "amazonRating": "Amazon Rating",
+      "amazonReviewCount": "Amazon Rating #",
+      "goodreadsRating": "Goodreads Rating",
+      "goodreadsReviewCount": "Goodreads Rating #",
+      "hardcoverRating": "Hardcover Rating",
+      "hardcoverReviewCount": "Hardcover Rating #",
+      "audibleRating": "Audible Rating",
+      "audibleReviewCount": "Audible Rating #",
+      "doubanRating": "Douban Rating",
+      "doubanReviewCount": "Douban Rating #",
+      "ranobedbRating": "Ranobedb Rating"
+    }
+  },
+  "fieldSelector": {
+    "sectionTitle": "Enabled Fields in Metadata Editor & Picker",
+    "sectionDesc": "Select which metadata fields to display when editing book information or picking metadata from providers. Disabled fields will be hidden from the interface.",
+    "providers": {
+      "amazon": "Amazon",
+      "googleBooks": "Google Books",
+      "goodreads": "Goodreads",
+      "hardcover": "Hardcover",
+      "audible": "Audible",
+      "comicvine": "Comicvine",
+      "lubimyczytac": "Lubimyczytac",
+      "ranobedb": "Ranobedb"
+    },
+    "fields": {
+      "asin": "Amazon ASIN",
+      "amazonRating": "Amazon Rating",
+      "amazonReviewCount": "Amazon Review Count",
+      "googleId": "Google Books ID",
+      "goodreadsId": "Goodreads ID",
+      "goodreadsRating": "Goodreads Rating",
+      "goodreadsReviewCount": "Goodreads Review Count",
+      "hardcoverId": "Hardcover ID",
+      "hardcoverBookId": "Hardcover Book ID",
+      "hardcoverRating": "Hardcover Rating",
+      "hardcoverReviewCount": "Hardcover Review Count",
+      "comicvineId": "Comicvine ID",
+      "lubimyczytacId": "Lubimyczytac ID",
+      "lubimyczytacRating": "Lubimyczytac Rating",
+      "ranobedbId": "Ranobedb ID",
+      "ranobedbRating": "Ranobedb Rating",
+      "audibleId": "Audible ID",
+      "audibleRating": "Audible Rating",
+      "audibleReviewCount": "Audible Review Count"
+    }
   }
 }

--- a/booklore-ui/src/i18n/en/shared.json
+++ b/booklore-ui/src/i18n/en/shared.json
@@ -92,6 +92,18 @@
   "liveNotification": {
     "defaultMessage": "No recent notifications..."
   },
+  "supportDialog": {
+    "title": "Support BookLore",
+    "subtitle": "From a solo dev who loves books",
+    "intro": "BookLore is built and maintained by a single developer who genuinely loves books. If it's made organizing your library a little more enjoyable, here are a few ways to support the project and keep it going.",
+    "starTitle": "Star on GitHub",
+    "starDesc": "A star goes a long way. It helps new people find BookLore and keeps me motivated.",
+    "collectiveTitle": "Open Collective",
+    "collectiveDesc": "Recurring support that helps cover hosting and keeps development sustainable.",
+    "kofiTitle": "Buy me a coffee",
+    "kofiDesc": "A one-time tip to fuel late-night coding sessions. Every bit is appreciated!",
+    "closing": "Thank you for being part of the BookLore community."
+  },
   "metadataProgress": {
     "taskStalled": "Task stalled or backend unavailable",
     "taskCancelled": "Task cancelled by user",

--- a/booklore-ui/src/i18n/es/metadata.json
+++ b/booklore-ui/src/i18n/es/metadata.json
@@ -498,12 +498,19 @@
         "deleting": "Eliminando...",
         "tabs": {
             "author": "Autor",
+            "authors": "Autores",
             "genre": "Género",
+            "genres": "Géneros",
             "mood": "Estado de ánimo",
+            "moods": "Estados de ánimo",
             "tag": "Etiqueta",
+            "tags": "Etiquetas",
             "series": "Serie",
+            "seriesPlural": "Series",
             "publisher": "Editorial",
-            "language": "Idioma"
+            "publishers": "Editoriales",
+            "language": "Idioma",
+            "languages": "Idiomas"
         },
         "placeholders": {
             "searchAuthors": "Buscar autores...",

--- a/booklore-ui/src/i18n/es/settings-metadata.json
+++ b/booklore-ui/src/i18n/es/settings-metadata.json
@@ -65,7 +65,38 @@
     },
     "fieldSelector": {
         "sectionTitle": "Campos habilitados en el editor y selector de metadatos",
-        "sectionDesc": "Selecciona qué campos de metadatos mostrar al editar información del libro o seleccionar metadatos de proveedores. Los campos deshabilitados se ocultarán de la interfaz."
+        "sectionDesc": "Selecciona qué campos de metadatos mostrar al editar información del libro o seleccionar metadatos de proveedores. Los campos deshabilitados se ocultarán de la interfaz.",
+        "providers": {
+            "amazon": "Amazon",
+            "googleBooks": "Google Books",
+            "goodreads": "Goodreads",
+            "hardcover": "Hardcover",
+            "audible": "Audible",
+            "comicvine": "Comicvine",
+            "lubimyczytac": "Lubimyczytac",
+            "ranobedb": "Ranobedb"
+        },
+        "fields": {
+            "asin": "Amazon ASIN",
+            "amazonRating": "Valoración de Amazon",
+            "amazonReviewCount": "Reseñas de Amazon",
+            "googleId": "ID de Google Books",
+            "goodreadsId": "ID de Goodreads",
+            "goodreadsRating": "Valoración de Goodreads",
+            "goodreadsReviewCount": "Reseñas de Goodreads",
+            "hardcoverId": "ID de Hardcover",
+            "hardcoverBookId": "ID de libro Hardcover",
+            "hardcoverRating": "Valoración de Hardcover",
+            "hardcoverReviewCount": "Reseñas de Hardcover",
+            "comicvineId": "ID de Comicvine",
+            "lubimyczytacId": "ID de Lubimyczytac",
+            "lubimyczytacRating": "Valoración de Lubimyczytac",
+            "ranobedbId": "ID de Ranobedb",
+            "ranobedbRating": "Valoración de Ranobedb",
+            "audibleId": "ID de Audible",
+            "audibleRating": "Valoración de Audible",
+            "audibleReviewCount": "Reseñas de Audible"
+        }
     },
     "publicReviews": {
         "sectionTitle": "Reseñas públicas",
@@ -91,6 +122,34 @@
         "saveSuccess": "Pesos guardados correctamente",
         "saveError": "Error al guardar los pesos",
         "recalcSuccess": "Todas las puntuaciones de coincidencia de libros se recalcularon correctamente.",
-        "recalcError": "Error al recalcular las puntuaciones de coincidencia."
+        "recalcError": "Error al recalcular las puntuaciones de coincidencia.",
+        "fields": {
+            "title": "Título",
+            "subtitle": "Subtítulo",
+            "authors": "Autores",
+            "description": "Descripción",
+            "publisher": "Editorial",
+            "publishedDate": "Fecha de publicación",
+            "categories": "Categorías",
+            "coverImage": "Imagen de portada",
+            "seriesName": "Nombre de serie",
+            "seriesNumber": "Número de serie",
+            "seriesTotal": "Total de serie",
+            "language": "Idioma",
+            "isbn13": "ISBN-13",
+            "isbn10": "ISBN-10",
+            "pageCount": "Número de páginas",
+            "amazonRating": "Valoración de Amazon",
+            "amazonReviewCount": "Valoración de Amazon #",
+            "goodreadsRating": "Valoración de Goodreads",
+            "goodreadsReviewCount": "Valoración de Goodreads #",
+            "hardcoverRating": "Valoración de Hardcover",
+            "hardcoverReviewCount": "Valoración de Hardcover #",
+            "audibleRating": "Valoración de Audible",
+            "audibleReviewCount": "Valoración de Audible #",
+            "doubanRating": "Valoración de Douban",
+            "doubanReviewCount": "Valoración de Douban #",
+            "ranobedbRating": "Valoración de Ranobedb"
+        }
     }
 }

--- a/booklore-ui/src/i18n/es/shared.json
+++ b/booklore-ui/src/i18n/es/shared.json
@@ -92,6 +92,18 @@
     "liveNotification": {
         "defaultMessage": "Sin notificaciones recientes..."
     },
+    "supportDialog": {
+        "title": "Apoyar BookLore",
+        "subtitle": "De un desarrollador independiente que ama los libros",
+        "intro": "BookLore es creado y mantenido por un solo desarrollador que realmente ama los libros. Si ha hecho que organizar tu biblioteca sea un poco más agradable, aquí tienes algunas formas de apoyar el proyecto y mantenerlo en marcha.",
+        "starTitle": "Estrella en GitHub",
+        "starDesc": "Una estrella ayuda mucho. Permite que nuevas personas descubran BookLore y me mantiene motivado.",
+        "collectiveTitle": "Open Collective",
+        "collectiveDesc": "Apoyo recurrente que ayuda a cubrir el alojamiento y mantener el desarrollo sostenible.",
+        "kofiTitle": "Invítame un café",
+        "kofiDesc": "Una propina para las sesiones de programación nocturnas. ¡Cada aporte se agradece!",
+        "closing": "Gracias por ser parte de la comunidad de BookLore."
+    },
     "metadataProgress": {
         "taskStalled": "Tarea detenida o servidor no disponible",
         "taskCancelled": "Tarea cancelada por el usuario",


### PR DESCRIPTION
Fixes a batch of i18n issues where parts of the UI were either hardcoded in English or not reacting to language changes.

The metadata manager tabs were pluralizing by appending 's' to the translated word (so Slovenian "Jezik" became "Jeziks"). Now uses separate singular/plural translation keys so each language can provide proper forms. Also replaced the `.slice(0, -1)` singularization hack in dialog messages with translated labels.

Made the Support BookLore dialog, metadata match weight field names, and provider field selector labels all translatable (they were hardcoded English strings with no i18n keys). Added corresponding en/es translations.

Fixed sort options in view preferences, sidebar sorting labels, the live notification default message, and stats topbar menu items not updating when the user switches language without a page reload. They now subscribe to `langChanges$` and rebuild their labels reactively.

Fixes #3108