### PR TITLE
Persist metadata search provider selection across book switches (#3107)

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
@@ -68,6 +68,7 @@ export class MetadataSearcherComponent implements OnInit, OnDestroy, OnChanges {
   private metadataByProvider: Map<string, BookMetadata[]> = new Map();
   private providerCompletionStatus: Map<string, boolean> = new Map();
   private pendingAutoSearch = false;
+  private providerInitialized = false;
 
   constructor() {
     this.form = this.formBuilder.group({
@@ -148,12 +149,18 @@ export class MetadataSearcherComponent implements OnInit, OnDestroy, OnChanges {
     this.selectedProviderFilters = new Set(['all']);
     this.bookId = book.id;
 
-    this.form.patchValue({
-      provider: this.providers,
+    const formUpdate: Record<string, any> = {
       title: book.metadata?.title ?? '',
       author: book.metadata?.authors?.[0] ?? '',
       isbn: book.metadata?.isbn13 ?? book.metadata?.isbn10 ?? ''
-    });
+    };
+
+    if (!this.providerInitialized) {
+      formUpdate['provider'] = this.providers;
+      this.providerInitialized = true;
+    }
+
+    this.form.patchValue(formUpdate);
   }
 
   private updateFormFromBook(book: Book): void {


### PR DESCRIPTION
Provider multiselect in the metadata search tab was resetting to all providers every time you switched books within the Book Details dialog. Now the selection sticks for the duration of the dialog session, so if you're searching comics and only want ComicVine results, you don't have to deselect everything else each time.

Fixes #3107