### PR TITLE
Pin footer buttons in metadata review dialog (#3053)

### DIFF
--- a/booklore-ui/src/app/features/metadata/component/metadata-review-dialog/metadata-review-dialog-component.scss
+++ b/booklore-ui/src/app/features/metadata/component/metadata-review-dialog/metadata-review-dialog-component.scss
@@ -8,11 +8,12 @@
 
 .panel-header {
   @include panel.panel-header;
+  flex-shrink: 0;
 }
 
 .dialog-content {
-  flex: 1;
-  overflow: auto;
+  height: calc(95dvh - 90px - 80px);
+  overflow-y: auto;
   padding: 1rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
@@ -33,6 +34,7 @@
 
 .dialog-footer {
   @include panel.dialog-footer;
+  flex-shrink: 0;
 
   .footer-info {
     flex: 1;


### PR DESCRIPTION
The action buttons (save, next, close, lock/unlock) in the metadata review dialog were scrolling away with the content, forcing users to scroll back down to reach them. Gave the content area an explicit height so it scrolls independently and the footer stays visible at all times.

Fixes #3053