### PR TITLE
Allow physical and digital book states to coexist (#3043)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/BookController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/BookController.java
@@ -280,6 +280,20 @@ public class BookController {
         return ResponseEntity.ok(duplicateDetectionService.findDuplicates(request));
     }
 
+    @Operation(summary = "Toggle physical book flag", description = "Mark or unmark a book as a physical book.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Physical flag updated successfully"),
+            @ApiResponse(responseCode = "404", description = "Book not found")
+    })
+    @PatchMapping("/{bookId}/physical")
+    @CheckBookAccess(bookIdParam = "bookId")
+    @PreAuthorize("@securityUtil.canManageLibrary() or @securityUtil.isAdmin()")
+    public ResponseEntity<Book> togglePhysicalFlag(
+            @Parameter(description = "ID of the book") @PathVariable long bookId,
+            @Parameter(description = "Whether the book is physical") @RequestParam boolean physical) {
+        return ResponseEntity.ok(physicalBookService.togglePhysicalFlag(bookId, physical));
+    }
+
     @Operation(summary = "Attach book files", description = "Attach book files from single-file source books to a target book as alternative formats.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Book files attached successfully"),

--- a/booklore-api/src/main/java/org/booklore/mobile/service/MobileAuthorService.java
+++ b/booklore-api/src/main/java/org/booklore/mobile/service/MobileAuthorService.java
@@ -139,7 +139,7 @@ public class MobileAuthorService {
         StringBuilder jpql = new StringBuilder(
                 "SELECT COUNT(DISTINCT bm.id) FROM AuthorEntity a JOIN a.bookMetadataEntityList bm JOIN bm.book b"
                         + " WHERE a.id = :authorId AND (b.deleted IS NULL OR b.deleted = false)"
-                        + " AND (b.isPhysical IS NULL OR b.isPhysical = false)");
+                        + " AND b.bookFiles IS NOT EMPTY");
         if (accessibleLibraryIds != null) {
             jpql.append(" AND b.library.id IN :libraryIds");
         }
@@ -174,9 +174,8 @@ public class MobileAuthorService {
         } else if (accessibleLibraryIds != null) {
             whereClause.append(" AND b.library.id IN :libraryIds");
         }
-        // Always filter out deleted/physical books when library filtering
         whereClause.append(" AND (b.deleted IS NULL OR b.deleted = false)");
-        whereClause.append(" AND (b.isPhysical IS NULL OR b.isPhysical = false)");
+        whereClause.append(" AND b.bookFiles IS NOT EMPTY");
     }
 
     private void buildSearchFilter(StringBuilder whereClause, String search) {

--- a/booklore-api/src/main/java/org/booklore/mobile/service/MobileBookService.java
+++ b/booklore-api/src/main/java/org/booklore/mobile/service/MobileBookService.java
@@ -298,7 +298,7 @@ public class MobileBookService {
         Map<Long, UserBookProgressEntity> progressMap = getProgressMapForBooks(userId, bookEntities);
 
         List<MobileBookSummary> summaries = bookEntities.stream()
-                .filter(bookEntity -> bookEntity.getIsPhysical() == null || !bookEntity.getIsPhysical())
+                .filter(BookEntity::hasFiles)
                 .map(bookEntity -> mobileBookMapper.toSummary(bookEntity, progressMap.get(bookEntity.getId())))
                 .collect(Collectors.toList());
 
@@ -363,7 +363,7 @@ public class MobileBookService {
         String authorQuery = "SELECT a.name, COUNT(DISTINCT b.id) FROM BookEntity b"
                 + " JOIN b.metadata m JOIN m.authors a"
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + " AND (b.isPhysical IS NULL OR b.isPhysical = false)"
+                + " AND b.bookFiles IS NOT EMPTY"
                 + scopeClause
                 + " GROUP BY a.name ORDER BY COUNT(DISTINCT b.id) DESC";
         var authorQ = entityManager.createQuery(authorQuery, Tuple.class);
@@ -381,7 +381,7 @@ public class MobileBookService {
         String langQuery = "SELECT m.language, COUNT(DISTINCT b.id) FROM BookEntity b"
                 + " JOIN b.metadata m"
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + " AND (b.isPhysical IS NULL OR b.isPhysical = false)"
+                + " AND b.bookFiles IS NOT EMPTY"
                 + " AND m.language IS NOT NULL AND m.language <> ''"
                 + scopeClause
                 + " GROUP BY m.language ORDER BY COUNT(DISTINCT b.id) DESC";
@@ -400,7 +400,7 @@ public class MobileBookService {
         String fileTypeQuery = "SELECT DISTINCT bf.bookType FROM BookEntity b"
                 + " JOIN b.bookFiles bf"
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + " AND (b.isPhysical IS NULL OR b.isPhysical = false)"
+                + " AND b.bookFiles IS NOT EMPTY"
                 + " AND bf.isBookFormat = true"
                 + scopeClause;
         var ftQ = entityManager.createQuery(fileTypeQuery, BookFileType.class);

--- a/booklore-api/src/main/java/org/booklore/mobile/service/MobileSeriesService.java
+++ b/booklore-api/src/main/java/org/booklore/mobile/service/MobileSeriesService.java
@@ -80,7 +80,7 @@ public class MobileSeriesService {
                 + " FROM BookEntity b JOIN b.metadata m"
                 + " LEFT JOIN b.userBookProgress p ON p.user.id = :userId"
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + " AND (b.isPhysical IS NULL OR b.isPhysical = false)"
+                + " AND b.bookFiles IS NOT EMPTY"
                 + " AND m.seriesName IS NOT NULL"
                 + libraryClause
                 + searchClause
@@ -103,7 +103,7 @@ public class MobileSeriesService {
         String countQuery = "SELECT COUNT(DISTINCT m.seriesName) FROM BookEntity b JOIN b.metadata m"
                 + (inProgressOnly ? " LEFT JOIN b.userBookProgress p ON p.user.id = :userId" : "")
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + " AND (b.isPhysical IS NULL OR b.isPhysical = false)"
+                + " AND b.bookFiles IS NOT EMPTY"
                 + " AND m.seriesName IS NOT NULL"
                 + libraryClause
                 + searchClause;
@@ -114,7 +114,7 @@ public class MobileSeriesService {
                     + "SELECT m.seriesName FROM BookEntity b JOIN b.metadata m"
                     + " LEFT JOIN b.userBookProgress p ON p.user.id = :userId"
                     + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                    + " AND (b.isPhysical IS NULL OR b.isPhysical = false)"
+                    + " AND b.bookFiles IS NOT EMPTY"
                     + " AND m.seriesName IS NOT NULL"
                     + libraryClause
                     + searchClause
@@ -125,7 +125,7 @@ public class MobileSeriesService {
             String countAlt = "SELECT m.seriesName FROM BookEntity b JOIN b.metadata m"
                     + " LEFT JOIN b.userBookProgress p ON p.user.id = :userId"
                     + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                    + " AND (b.isPhysical IS NULL OR b.isPhysical = false)"
+                    + " AND b.bookFiles IS NOT EMPTY"
                     + " AND m.seriesName IS NOT NULL"
                     + libraryClause
                     + searchClause
@@ -179,7 +179,7 @@ public class MobileSeriesService {
                 + " LEFT JOIN FETCH b.bookFiles"
                 + " WHERE m.seriesName IN :seriesNames"
                 + " AND (b.deleted IS NULL OR b.deleted = false)"
-                + " AND (b.isPhysical IS NULL OR b.isPhysical = false)"
+                + " AND b.bookFiles IS NOT EMPTY"
                 + libraryClause;
 
         var booksQ = entityManager.createQuery(booksQuery, BookEntity.class);

--- a/booklore-api/src/main/java/org/booklore/mobile/specification/MobileBookSpecification.java
+++ b/booklore-api/src/main/java/org/booklore/mobile/specification/MobileBookSpecification.java
@@ -113,10 +113,7 @@ public class MobileBookSpecification {
     }
 
     public static Specification<BookEntity> hasDigitalFile() {
-        return (root, query, cb) -> cb.or(
-                cb.isNull(root.get("isPhysical")),
-                cb.equal(root.get("isPhysical"), false)
-        );
+        return (root, query, cb) -> cb.isNotEmpty(root.get("bookFiles"));
     }
 
     public static Specification<BookEntity> hasAudiobookFile() {

--- a/booklore-api/src/main/java/org/booklore/service/book/PhysicalBookService.java
+++ b/booklore-api/src/main/java/org/booklore/service/book/PhysicalBookService.java
@@ -1,5 +1,6 @@
 package org.booklore.service.book;
 
+import org.booklore.exception.ApiError;
 import org.booklore.exception.APIException;
 import org.booklore.mapper.BookMapper;
 import org.booklore.model.dto.Book;
@@ -144,6 +145,16 @@ public class PhysicalBookService {
                 .map(truncated -> categoryRepository.findByName(truncated)
                         .orElseGet(() -> categoryRepository.save(CategoryEntity.builder().name(truncated).build())))
                 .forEach(catEntity -> bookEntity.getMetadata().getCategories().add(catEntity));
+    }
+
+    @Transactional
+    public Book togglePhysicalFlag(long bookId, boolean physical) {
+        BookEntity book = bookRepository.findById(bookId)
+                .orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
+        book.setIsPhysical(physical);
+        bookRepository.save(book);
+        log.info("Book {} physical flag set to {}", bookId, physical);
+        return bookMapper.toBook(book);
     }
 
     private String truncate(String input, int maxLength) {

--- a/booklore-api/src/main/java/org/booklore/service/file/AdditionalFileService.java
+++ b/booklore-api/src/main/java/org/booklore/service/file/AdditionalFileService.java
@@ -83,13 +83,6 @@ public class AdditionalFileService {
 
         if (file.isBook() && book != null) {
             book.getBookFiles().remove(file);
-            boolean hasRemainingBookFiles = book.getBookFiles().stream()
-                    .anyMatch(BookFileEntity::isBook);
-            if (!hasRemainingBookFiles) {
-                book.setIsPhysical(true);
-                bookRepository.save(book);
-                log.info("Book {} reverted to physical (last book file removed)", book.getId());
-            }
         }
     }
 

--- a/booklore-api/src/main/java/org/booklore/service/upload/FileUploadService.java
+++ b/booklore-api/src/main/java/org/booklore/service/upload/FileUploadService.java
@@ -163,13 +163,6 @@ public class FileUploadService {
             final BookFileEntity entity = createAdditionalFileEntityWithSubPath(book, finalFileName, fileSubPath, isBook, effectiveBookType, file.getSize(), fileHash, description);
             final BookFileEntity savedEntity = additionalFileRepository.save(entity);
 
-            // Promote physical book to digital if this is a book file
-            if (wasPhysicalBook && isBook) {
-                book.setIsPhysical(false);
-                bookRepository.save(book);
-                log.info("Physical book {} promoted to digital book after file upload", bookId);
-            }
-
             return additionalFileMapper.toAdditionalFile(savedEntity);
 
         } catch (IOException e) {

--- a/booklore-api/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
@@ -179,8 +179,7 @@ class AdditionalFileServiceTest {
             verify(monitoringRegistrationService).unregisterSpecificPath(parentPath);
             filesMock.verify(() -> Files.deleteIfExists(fileEntity.getFullFilePath()));
             verify(additionalFileRepository).delete(fileEntity);
-            verify(bookRepository).save(bookEntity);
-            assertTrue(bookEntity.getIsPhysical());
+            verify(bookRepository, never()).save(any());
         }
     }
 
@@ -200,8 +199,7 @@ class AdditionalFileServiceTest {
             verify(monitoringRegistrationService).unregisterSpecificPath(parentPath);
             filesMock.verify(() -> Files.deleteIfExists(fileEntity.getFullFilePath()));
             verify(additionalFileRepository).delete(fileEntity);
-            verify(bookRepository).save(bookEntity);
-            assertTrue(bookEntity.getIsPhysical());
+            verify(bookRepository, never()).save(any());
         }
     }
 

--- a/booklore-ui/src/app/features/book/service/book.service.ts
+++ b/booklore-ui/src/app/features/book/service/book.service.ts
@@ -257,6 +257,16 @@ export class BookService {
     );
   }
 
+  togglePhysicalFlag(bookId: number, physical: boolean): Observable<Book> {
+    return this.http.patch<Book>(`${this.url}/${bookId}/physical`, null, {params: {physical}}).pipe(
+      tap(updatedBook => {
+        const currentState = this.bookStateService.getCurrentBookState();
+        const updatedBooks = (currentState.books || []).map(b => b.id === bookId ? {...b, isPhysical: physical} : b);
+        this.bookStateService.updateBookState({...currentState, books: updatedBooks});
+      })
+    );
+  }
+
   /*------------------ Reading & Viewer Settings ------------------*/
 
   readBook(bookId: number, reader?: 'epub-streaming', explicitBookType?: BookType): void {

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
@@ -153,7 +153,7 @@
                   </app-tag>
                 </span>
               }
-              @if (!book?.primaryFile?.filePath && !book?.alternativeFormats?.length) {
+              @if (book?.isPhysical) {
                 <app-tag size="3xs" variant="pill" [customBgColor]="'var(--book-type-physical-color)'" customTextColor="#fff">{{ t('physicalBadge') }}</app-tag>
               }
             </div>

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -235,6 +235,19 @@ export class MetadataViewerComponent implements OnInit, OnChanges, AfterViewChec
               command: () => this.assignShelf(book.id)
             });
 
+            if (userState?.user?.permissions.canManageLibrary || userState?.user?.permissions.admin) {
+              const isPhysical = book.isPhysical ?? false;
+              items.push({
+                label: isPhysical
+                  ? this.t.translate('metadata.viewer.menuUnmarkPhysical')
+                  : this.t.translate('metadata.viewer.menuMarkPhysical'),
+                icon: isPhysical ? 'pi pi-times-circle' : 'pi pi-book',
+                command: () => {
+                  this.bookService.togglePhysicalFlag(book.id, !isPhysical).subscribe();
+                }
+              });
+            }
+
             // Add allowed submenus based on user permissions
 
             if (userState?.user?.permissions.canUpload || userState?.user?.permissions.admin) {

--- a/booklore-ui/src/i18n/en/metadata.json
+++ b/booklore-ui/src/i18n/en/metadata.json
@@ -327,6 +327,8 @@
     "menuSendBook": "Send Book",
     "menuQuickSend": "Quick Send",
     "menuCustomSend": "Custom Send",
+    "menuMarkPhysical": "Mark as Physical",
+    "menuUnmarkPhysical": "Unmark as Physical",
     "menuAttachToAnotherBook": "Attach to Another Book",
     "menuDeleteFileFormats": "Delete File Formats",
     "menuDeleteSupplementaryFiles": "Delete Supplementary Files",

--- a/booklore-ui/src/i18n/es/metadata.json
+++ b/booklore-ui/src/i18n/es/metadata.json
@@ -327,6 +327,8 @@
         "menuSendBook": "Enviar libro",
         "menuQuickSend": "Envío rápido",
         "menuCustomSend": "Envío personalizado",
+        "menuMarkPhysical": "Marcar como físico",
+        "menuUnmarkPhysical": "Desmarcar como físico",
         "menuAttachToAnotherBook": "Adjuntar a otro libro",
         "menuDeleteFileFormats": "Eliminar formatos de archivo",
         "menuDeleteSupplementaryFiles": "Eliminar archivos complementarios",


### PR DESCRIPTION
Previously, attaching a digital file to a physical book would clear the physical flag, and removing all files from a digital book would incorrectly mark it as physical. The physical/digital states were treated as mutually exclusive when they really aren't.

Now the `isPhysical` flag is independent of whether digital files exist. A book can be both physical and digital (e.g., you have the paperback and the e-book). Mobile app queries filter on "has files" instead of "not physical" so physical+digital books show up correctly. There's also a new toggle in the three-dot menu to mark/unmark any book as physical.

Fixes #3043