### PR TITLE
Fix DST-related datetime rejection on TIMESTAMP columns (#3240) (#3241)

### DIFF
--- a/booklore-api/src/main/resources/application.yaml
+++ b/booklore-api/src/main/resources/application.yaml
@@ -51,7 +51,7 @@ spring:
       pageable:
         max-page-size: 100
   datasource:
-    url: ${DATABASE_URL:jdbc:mariadb://${DATABASE_HOST:${DB_HOST:mariadb}}:${DATABASE_PORT:3306}/${DATABASE_NAME:booklore}?createDatabaseIfNotExist=true}
+    url: ${DATABASE_URL:jdbc:mariadb://${DATABASE_HOST:${DB_HOST:mariadb}}:${DATABASE_PORT:3306}/${DATABASE_NAME:booklore}?createDatabaseIfNotExist=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true}
     username: ${DATABASE_USERNAME:root}
     password: ${DATABASE_PASSWORD:${MYSQL_ROOT_PASSWORD}}
     hikari:
@@ -72,6 +72,7 @@ spring:
         query:
           timeout: 30              # 30s max for any HQL/JPQL query
         jdbc:
+          time_zone: UTC
           batch_size: 500
           order_inserts: true
           order_updates: true


### PR DESCRIPTION
Adds `connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true` to the default JDBC URL and sets `hibernate.jdbc.time_zone: UTC`. This forces the MariaDB session timezone to UTC on every connection, so TIMESTAMP columns never try to interpret incoming datetimes in a DST-observing timezone. Fixes the `Incorrect datetime value` errors users hit during spring-forward when UTC times like `02:19` get misinterpreted as local Eastern time (which doesn't exist in the DST gap).

Fixes #3240
Fixes #3241