### PR TITLE
Add configurable magnifier zoom and lens size for CBX reader (#3260)

### DIFF
--- a/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -6,7 +6,7 @@ import {debounceTime, filter, first, map, switchMap, takeUntil, timeout} from 'r
 import {PageTitleService} from "../../../shared/service/page-title.service";
 import {CbxReaderService} from '../../book/service/cbx-reader.service';
 import {BookService} from '../../book/service/book.service';
-import {CbxBackgroundColor, CbxFitMode, CbxPageSpread, CbxPageViewMode, CbxScrollMode, CbxReadingDirection, CbxSlideshowInterval, UserService} from '../../settings/user-management/user.service';
+import {CbxBackgroundColor, CbxFitMode, CbxMagnifierLensSize, CbxMagnifierZoom, CbxPageSpread, CbxPageViewMode, CbxScrollMode, CbxReadingDirection, CbxSlideshowInterval, UserService} from '../../settings/user-management/user.service';
 import {MessageService} from 'primeng/api';
 import {TranslocoService, TranslocoPipe} from '@jsverse/transloco';
 import {Book, BookSetting, BookType} from '../../book/model/book.model';
@@ -120,8 +120,9 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
   // Magnifier
   isMagnifierActive = false;
   @ViewChild('magnifierLens', {static: true}) private magnifierLensRef!: ElementRef<HTMLDivElement>;
-  private static readonly MAGNIFIER_SIZE = 200;
-  private static readonly MAGNIFIER_ZOOM = 3;
+  magnifierZoom: CbxMagnifierZoom = CbxMagnifierZoom.ZOOM_3X;
+  magnifierLensSize: CbxMagnifierLensSize = CbxMagnifierLensSize.MEDIUM;
+  private lastMouseEvent: MouseEvent | null = null;
 
   // Double page detection
   private pageDimensionsCache = new Map<number, {width: number, height: number}>();
@@ -419,6 +420,14 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     this.quickSettingsService.slideshowIntervalChange$
       .pipe(takeUntil(this.destroy$))
       .subscribe(interval => this.onSlideshowIntervalChange(interval));
+
+    this.quickSettingsService.magnifierZoomChange$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(zoom => this.onMagnifierZoomChange(zoom));
+
+    this.quickSettingsService.magnifierLensSizeChange$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(size => this.onMagnifierLensSizeChange(size));
   }
 
   private updateServiceStates(): void {
@@ -438,7 +447,9 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
       pageSpread: this.pageSpread,
       backgroundColor: this.backgroundColor,
       readingDirection: this.readingDirection,
-      slideshowInterval: this.slideshowInterval
+      slideshowInterval: this.slideshowInterval,
+      magnifierZoom: this.magnifierZoom,
+      magnifierLensSize: this.magnifierLensSize
     });
 
     this.headerService.updateState({
@@ -970,6 +981,31 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
         }
         this.headerService.updateState({isMagnifierActive: this.isMagnifierActive});
         break;
+      case '+':
+      case '=':
+        if (this.isMagnifierActive) {
+          event.preventDefault();
+          this.cycleMagnifierZoom(1);
+        }
+        break;
+      case '-':
+        if (this.isMagnifierActive) {
+          event.preventDefault();
+          this.cycleMagnifierZoom(-1);
+        }
+        break;
+      case ']':
+        if (this.isMagnifierActive) {
+          event.preventDefault();
+          this.cycleMagnifierLensSize(1);
+        }
+        break;
+      case '[':
+        if (this.isMagnifierActive) {
+          event.preventDefault();
+          this.cycleMagnifierLensSize(-1);
+        }
+        break;
       case '?':
         event.preventDefault();
         this.showShortcutsHelp = true;
@@ -1017,6 +1053,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
 
   @HostListener('document:mousemove', ['$event'])
   onMouseMove(event: MouseEvent): void {
+    this.lastMouseEvent = event;
     this.visibilityManager.handleMouseMove(event.clientY);
     if (this.isMagnifierActive) {
       this.updateMagnifier(event);
@@ -1224,6 +1261,44 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     }
   }
 
+  onMagnifierZoomChange(zoom: CbxMagnifierZoom): void {
+    this.magnifierZoom = zoom;
+    this.quickSettingsService.setMagnifierZoom(zoom);
+    this.refreshMagnifier();
+  }
+
+  onMagnifierLensSizeChange(size: CbxMagnifierLensSize): void {
+    this.magnifierLensSize = size;
+    this.quickSettingsService.setMagnifierLensSize(size);
+    this.refreshMagnifier();
+  }
+
+  private refreshMagnifier(): void {
+    if (this.isMagnifierActive && this.lastMouseEvent) {
+      this.updateMagnifier(this.lastMouseEvent);
+    }
+  }
+
+  private cycleMagnifierZoom(direction: 1 | -1): void {
+    const values = Object.values(CbxMagnifierZoom).filter(v => typeof v === 'number') as number[];
+    values.sort((a, b) => a - b);
+    const currentIndex = values.indexOf(this.magnifierZoom as number);
+    const newIndex = currentIndex + direction;
+    if (newIndex >= 0 && newIndex < values.length) {
+      this.onMagnifierZoomChange(values[newIndex] as CbxMagnifierZoom);
+    }
+  }
+
+  private cycleMagnifierLensSize(direction: 1 | -1): void {
+    const values = Object.values(CbxMagnifierLensSize).filter(v => typeof v === 'number') as number[];
+    values.sort((a, b) => a - b);
+    const currentIndex = values.indexOf(this.magnifierLensSize as number);
+    const newIndex = currentIndex + direction;
+    if (newIndex >= 0 && newIndex < values.length) {
+      this.onMagnifierLensSizeChange(values[newIndex] as CbxMagnifierLensSize);
+    }
+  }
+
   // Double-tap zoom
   onImageDoubleClick(): void {
     if (this.originalFitMode === null) {
@@ -1263,8 +1338,8 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     const el = this.magnifierLensRef?.nativeElement;
     if (!el) return;
 
-    const lensSize = CbxReaderComponent.MAGNIFIER_SIZE;
-    const zoom = CbxReaderComponent.MAGNIFIER_ZOOM;
+    const lensSize = this.magnifierLensSize as number;
+    const zoom = this.magnifierZoom as number;
 
     const target = document.elementFromPoint(event.clientX, event.clientY);
     if (!(target instanceof HTMLImageElement) || !target.classList.contains('page-image')) {

--- a/booklore-ui/src/app/features/readers/cbx-reader/dialogs/cbx-shortcuts-help.component.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/dialogs/cbx-shortcuts-help.component.ts
@@ -47,7 +47,9 @@ export class CbxShortcutsHelpComponent {
           {keys: ['D'], description: this.t.translate('readerCbx.shortcutsHelp.toggleReadingDirection')},
           {keys: ['Escape'], description: this.t.translate('readerCbx.shortcutsHelp.exitFullscreenCloseDialogs')},
           {keys: ['Double-click'], description: this.t.translate('readerCbx.shortcutsHelp.toggleZoom'), mobileGesture: this.t.translate('readerCbx.shortcutsHelp.doubleTap')},
-          {keys: ['M'], description: this.t.translate('readerCbx.shortcutsHelp.toggleMagnifier')}
+          {keys: ['M'], description: this.t.translate('readerCbx.shortcutsHelp.toggleMagnifier')},
+          {keys: ['+', '−'], description: this.t.translate('readerCbx.shortcutsHelp.magnifierZoom')},
+          {keys: ['[', ']'], description: this.t.translate('readerCbx.shortcutsHelp.magnifierLensSize')}
         ]
       },
       {

--- a/booklore-ui/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.component.html
+++ b/booklore-ui/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.component.html
@@ -110,6 +110,42 @@
           </div>
         </div>
       </div>
+
+      <!-- Magnifier Lens Size -->
+      <div class="control">
+        <label>{{ 'readerCbx.quickSettings.magnifierLensSize' | transloco }}</label>
+        <div class="control-right">
+          <div class="button-group text-btns">
+            @for (option of magnifierLensSizeOptions; track option.value) {
+              <button
+                class="option-btn text-btn small"
+                [class.active]="state.magnifierLensSize === option.value"
+                (click)="onMagnifierLensSizeSelect(option.value)"
+                [title]="option.label">
+                {{ option.label }}
+              </button>
+            }
+          </div>
+        </div>
+      </div>
+
+      <!-- Magnifier Zoom -->
+      <div class="control">
+        <label>{{ 'readerCbx.quickSettings.magnifierZoom' | transloco }}</label>
+        <div class="control-right">
+          <div class="button-group text-btns">
+            @for (option of magnifierZoomOptions; track option.value) {
+              <button
+                class="option-btn text-btn small"
+                [class.active]="state.magnifierZoom === option.value"
+                (click)="onMagnifierZoomSelect(option.value)"
+                [title]="option.label">
+                {{ option.label }}
+              </button>
+            }
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/booklore-ui/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.component.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.component.ts
@@ -10,7 +10,9 @@ import {
   CbxPageSpread,
   CbxBackgroundColor,
   CbxReadingDirection,
-  CbxSlideshowInterval
+  CbxSlideshowInterval,
+  CbxMagnifierZoom,
+  CbxMagnifierLensSize
 } from '../../../../settings/user-management/user.service';
 import {ReaderIconComponent, ReaderIconName} from '../../../ebook-reader/shared/icon.component';
 import {CbxQuickSettingsService, CbxQuickSettingsState} from './cbx-quick-settings.service';
@@ -34,7 +36,9 @@ export class CbxQuickSettingsComponent implements OnInit, OnDestroy {
     pageSpread: CbxPageSpread.ODD,
     backgroundColor: CbxBackgroundColor.GRAY,
     readingDirection: CbxReadingDirection.LTR,
-    slideshowInterval: CbxSlideshowInterval.FIVE_SECONDS
+    slideshowInterval: CbxSlideshowInterval.FIVE_SECONDS,
+    magnifierZoom: CbxMagnifierZoom.ZOOM_3X,
+    magnifierLensSize: CbxMagnifierLensSize.MEDIUM
   };
 
   protected readonly CbxFitMode = CbxFitMode;
@@ -44,6 +48,8 @@ export class CbxQuickSettingsComponent implements OnInit, OnDestroy {
   protected readonly CbxBackgroundColor = CbxBackgroundColor;
   protected readonly CbxReadingDirection = CbxReadingDirection;
   protected readonly CbxSlideshowInterval = CbxSlideshowInterval;
+  protected readonly CbxMagnifierZoom = CbxMagnifierZoom;
+  protected readonly CbxMagnifierLensSize = CbxMagnifierLensSize;
 
   get fitModeOptions(): {value: CbxFitMode, label: string, icon: ReaderIconName}[] {
     return [
@@ -69,6 +75,21 @@ export class CbxQuickSettingsComponent implements OnInit, OnDestroy {
     {value: CbxSlideshowInterval.TEN_SECONDS, label: '10s'},
     {value: CbxSlideshowInterval.FIFTEEN_SECONDS, label: '15s'},
     {value: CbxSlideshowInterval.THIRTY_SECONDS, label: '30s'}
+  ];
+
+  magnifierZoomOptions: {value: CbxMagnifierZoom, label: string}[] = [
+    {value: CbxMagnifierZoom.ZOOM_1_5X, label: '1.5×'},
+    {value: CbxMagnifierZoom.ZOOM_2X, label: '2×'},
+    {value: CbxMagnifierZoom.ZOOM_2_5X, label: '2.5×'},
+    {value: CbxMagnifierZoom.ZOOM_3X, label: '3×'},
+    {value: CbxMagnifierZoom.ZOOM_4X, label: '4×'}
+  ];
+
+  magnifierLensSizeOptions: {value: CbxMagnifierLensSize, label: string}[] = [
+    {value: CbxMagnifierLensSize.SMALL, label: 'S'},
+    {value: CbxMagnifierLensSize.MEDIUM, label: 'M'},
+    {value: CbxMagnifierLensSize.LARGE, label: 'L'},
+    {value: CbxMagnifierLensSize.EXTRA_LARGE, label: 'XL'}
   ];
 
   get backgroundOptions() {
@@ -149,6 +170,14 @@ export class CbxQuickSettingsComponent implements OnInit, OnDestroy {
 
   onSlideshowIntervalSelect(interval: CbxSlideshowInterval): void {
     this.quickSettingsService.emitSlideshowIntervalChange(interval);
+  }
+
+  onMagnifierZoomSelect(zoom: CbxMagnifierZoom): void {
+    this.quickSettingsService.emitMagnifierZoomChange(zoom);
+  }
+
+  onMagnifierLensSizeSelect(size: CbxMagnifierLensSize): void {
+    this.quickSettingsService.emitMagnifierLensSizeChange(size);
   }
 
   onOverlayClick(): void {

--- a/booklore-ui/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.service.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {BehaviorSubject, Subject} from 'rxjs';
-import {CbxBackgroundColor, CbxFitMode, CbxPageSpread, CbxPageViewMode, CbxScrollMode, CbxReadingDirection, CbxSlideshowInterval} from '../../../../settings/user-management/user.service';
+import {CbxBackgroundColor, CbxFitMode, CbxMagnifierLensSize, CbxMagnifierZoom, CbxPageSpread, CbxPageViewMode, CbxScrollMode, CbxReadingDirection, CbxSlideshowInterval} from '../../../../settings/user-management/user.service';
 
 export interface CbxQuickSettingsState {
   fitMode: CbxFitMode;
@@ -10,6 +10,8 @@ export interface CbxQuickSettingsState {
   backgroundColor: CbxBackgroundColor;
   readingDirection: CbxReadingDirection;
   slideshowInterval: CbxSlideshowInterval;
+  magnifierZoom: CbxMagnifierZoom;
+  magnifierLensSize: CbxMagnifierLensSize;
 }
 
 @Injectable()
@@ -21,7 +23,9 @@ export class CbxQuickSettingsService {
     pageSpread: CbxPageSpread.ODD,
     backgroundColor: CbxBackgroundColor.GRAY,
     readingDirection: CbxReadingDirection.LTR,
-    slideshowInterval: CbxSlideshowInterval.FIVE_SECONDS
+    slideshowInterval: CbxSlideshowInterval.FIVE_SECONDS,
+    magnifierZoom: CbxMagnifierZoom.ZOOM_3X,
+    magnifierLensSize: CbxMagnifierLensSize.MEDIUM
   });
   state$ = this._state.asObservable();
 
@@ -48,6 +52,12 @@ export class CbxQuickSettingsService {
 
   private _slideshowIntervalChange = new Subject<CbxSlideshowInterval>();
   slideshowIntervalChange$ = this._slideshowIntervalChange.asObservable();
+
+  private _magnifierZoomChange = new Subject<CbxMagnifierZoom>();
+  magnifierZoomChange$ = this._magnifierZoomChange.asObservable();
+
+  private _magnifierLensSizeChange = new Subject<CbxMagnifierLensSize>();
+  magnifierLensSizeChange$ = this._magnifierLensSizeChange.asObservable();
 
   get state(): CbxQuickSettingsState {
     return this._state.value;
@@ -97,6 +107,14 @@ export class CbxQuickSettingsService {
     this.updateState({slideshowInterval: interval});
   }
 
+  setMagnifierZoom(zoom: CbxMagnifierZoom): void {
+    this.updateState({magnifierZoom: zoom});
+  }
+
+  setMagnifierLensSize(size: CbxMagnifierLensSize): void {
+    this.updateState({magnifierLensSize: size});
+  }
+
   // Actions emitted from component
   emitFitModeChange(mode: CbxFitMode): void {
     this._fitModeChange.next(mode);
@@ -126,6 +144,14 @@ export class CbxQuickSettingsService {
     this._slideshowIntervalChange.next(interval);
   }
 
+  emitMagnifierZoomChange(zoom: CbxMagnifierZoom): void {
+    this._magnifierZoomChange.next(zoom);
+  }
+
+  emitMagnifierLensSizeChange(size: CbxMagnifierLensSize): void {
+    this._magnifierLensSizeChange.next(size);
+  }
+
   reset(): void {
     this._state.next({
       fitMode: CbxFitMode.FIT_PAGE,
@@ -134,7 +160,9 @@ export class CbxQuickSettingsService {
       pageSpread: CbxPageSpread.ODD,
       backgroundColor: CbxBackgroundColor.GRAY,
       readingDirection: CbxReadingDirection.LTR,
-      slideshowInterval: CbxSlideshowInterval.FIVE_SECONDS
+      slideshowInterval: CbxSlideshowInterval.FIVE_SECONDS,
+      magnifierZoom: CbxMagnifierZoom.ZOOM_3X,
+      magnifierLensSize: CbxMagnifierLensSize.MEDIUM
     });
     this._visible.next(false);
   }

--- a/booklore-ui/src/app/features/settings/user-management/user.service.ts
+++ b/booklore-ui/src/app/features/settings/user-management/user.service.ts
@@ -102,6 +102,21 @@ export enum CbxSlideshowInterval {
   THIRTY_SECONDS = 30000
 }
 
+export enum CbxMagnifierZoom {
+  ZOOM_1_5X = 1.5,
+  ZOOM_2X = 2,
+  ZOOM_2_5X = 2.5,
+  ZOOM_3X = 3,
+  ZOOM_4X = 4
+}
+
+export enum CbxMagnifierLensSize {
+  SMALL = 150,
+  MEDIUM = 200,
+  LARGE = 250,
+  EXTRA_LARGE = 300
+}
+
 export interface PdfReaderSetting {
   pageSpread: PageSpread;
   pageZoom: string;

--- a/booklore-ui/src/i18n/en/reader-cbx.json
+++ b/booklore-ui/src/i18n/en/reader-cbx.json
@@ -42,6 +42,8 @@
     "doubleTap": "Double-tap",
     "toggleSlideshow": "Toggle slideshow / auto-play",
     "toggleMagnifier": "Toggle magnifying glass",
+    "magnifierZoom": "Magnifier zoom (when active)",
+    "magnifierLensSize": "Magnifier lens size (when active)",
     "showHelpDialog": "Show this help dialog"
   },
   "footer": {
@@ -106,7 +108,9 @@
     "background": "Background",
     "black": "Black",
     "gray": "Gray",
-    "white": "White"
+    "white": "White",
+    "magnifierLensSize": "Lens Size",
+    "magnifierZoom": "Magnification"
   },
   "sidebar": {
     "contentTab": "Content",

--- a/booklore-ui/src/i18n/es/reader-cbx.json
+++ b/booklore-ui/src/i18n/es/reader-cbx.json
@@ -42,6 +42,8 @@
         "doubleTap": "Doble toque",
         "toggleSlideshow": "Alternar presentación / reproducción automática",
         "toggleMagnifier": "Alternar lupa",
+        "magnifierZoom": "Zoom de lupa (cuando está activa)",
+        "magnifierLensSize": "Tamaño de lente de lupa (cuando está activa)",
         "showHelpDialog": "Mostrar este diálogo de ayuda"
     },
     "footer": {
@@ -106,7 +108,9 @@
         "background": "Fondo",
         "black": "Negro",
         "gray": "Gris",
-        "white": "Blanco"
+        "white": "Blanco",
+        "magnifierLensSize": "Tamaño de lente",
+        "magnifierZoom": "Aumento"
     },
     "sidebar": {
         "contentTab": "Contenido",


### PR DESCRIPTION
The CBX magnifier was locked to a fixed 200px lens at 3x zoom, which doesn't work great for all screen sizes or content types (large speech bubbles in comics, etc). This adds configurable lens size (S/M/L/XL) and magnification (1.5x to 4x) controls to the quick settings panel, plus keyboard shortcuts (+/- for zoom, [/] for lens size) that take effect immediately without needing to move the mouse.

Fixes #3260