### PR TITLE
Lock organization mode for AUTO_DETECT libraries

### DIFF
--- a/booklore-ui/src/app/features/library-creator/library-creator.component.html
+++ b/booklore-ui/src/app/features/library-creator/library-creator.component.html
@@ -156,7 +156,7 @@
               <span>{{ t('organizationMode') }}</span>
               <i
                 class="pi pi-question-circle info-icon"
-                [pTooltip]="t('organizationModeTooltip')"
+                [pTooltip]="organizationMode === 'AUTO_DETECT' ? t('organizationModeLockedTooltip') : t('organizationModeTooltip')"
                 tooltipPosition="top"
               ></i>
             </div>
@@ -165,6 +165,7 @@
               [options]="organizationModeOptions"
               optionLabel="label"
               optionValue="value"
+              [disabled]="organizationMode === 'AUTO_DETECT'"
               class="metadata-source-select"
               appendTo="body"
             />

--- a/booklore-ui/src/i18n/en/library-creator.json
+++ b/booklore-ui/src/i18n/en/library-creator.json
@@ -26,6 +26,7 @@
     "metadataSourceNone": "None",
     "organizationMode": "Organization mode",
     "organizationModeTooltip": "How files are grouped into books during scanning",
+    "organizationModeLockedTooltip": "Organization mode cannot be changed after library creation. To use a different mode, create a new library.",
     "organizationModeBookPerFile": "One book per file",
     "organizationModeBookPerFolder": "One book per folder",
     "organizationModeAutoDetect": "Auto-detect (legacy)",

--- a/booklore-ui/src/i18n/es/library-creator.json
+++ b/booklore-ui/src/i18n/es/library-creator.json
@@ -26,6 +26,7 @@
         "metadataSourceNone": "Ninguno",
         "organizationMode": "Modo de organización",
         "organizationModeTooltip": "Como se agrupan los archivos en libros durante el escaneo",
+        "organizationModeLockedTooltip": "El modo de organizacion no se puede cambiar despues de crear la biblioteca. Para usar un modo diferente, crea una nueva biblioteca.",
         "organizationModeBookPerFile": "Un libro por archivo",
         "organizationModeBookPerFolder": "Un libro por carpeta",
         "organizationModeAutoDetect": "Deteccion automatica (legado)",


### PR DESCRIPTION
Disables the organization mode dropdown when editing a library that's on Auto-detect, since switching modes can't regroup existing books without wiping them. The tooltip explains why it's locked and suggests creating a new library instead. Libraries on Book per File or Book per Folder can still switch between those two freely.