### PR TITLE
Improve filter sidebar sorting and footer note behaviour

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.component.html
@@ -64,7 +64,11 @@
     </p-accordion>
 
     <div class="footer-notice">
-      {{ t('footerNote') }}
+      @if (filterItemLimit) {
+   	 {{ t('footerNoteN', { count: filterItemLimit }) }}
+      } @else {
+    	 {{ t('footerNote') }}
+      }
     </div>
   </div>
 </div>

--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.component.ts
@@ -15,6 +15,7 @@ import {Filter, FILTER_LABEL_KEYS, FilterType} from './book-filter.config';
 import {BookFilterService} from './book-filter.service';
 import {filter} from 'rxjs/operators';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
+import { DEFAULT_FILTER_LIMIT } from './book-filter.constants';
 
 type FilterModeOption = { label: string; value: BookFilterMode };
 
@@ -31,6 +32,8 @@ type FilterModeOption = { label: string; value: BookFilterMode };
     TranslocoDirective
   ]
 })
+
+
 export class BookFilterComponent implements OnInit, OnDestroy {
   @Input() entity$: Observable<Library | Shelf | MagicShelf | null> | undefined;
   @Input() entityType$: Observable<EntityType> | undefined;
@@ -39,6 +42,8 @@ export class BookFilterComponent implements OnInit, OnDestroy {
 
   @Output() filterSelected = new EventEmitter<Record<string, unknown> | null>();
   @Output() filterModeChanged = new EventEmitter<BookFilterMode>();
+
+  readonly filterItemLimit = DEFAULT_FILTER_LIMIT;
 
   private readonly filterService = inject(BookFilterService);
   private readonly userService = inject(UserService);

--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.constants.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.constants.ts
@@ -1,0 +1,2 @@
+//To be developed into a user-changeable setting
+export const DEFAULT_FILTER_LIMIT = 500;

--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.service.spec.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.service.spec.ts
@@ -1,0 +1,80 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+import {TestBed} from '@angular/core/testing';
+import {of, firstValueFrom} from 'rxjs';
+
+import {BookFilterService} from './book-filter.service';
+import {BookService} from '../../../service/book.service';
+import {LibraryService} from '../../../service/library.service';
+import {BookRuleEvaluatorService} from '../../../../magic-shelf/service/book-rule-evaluator.service';
+
+describe('BookFilterService', () => {
+  let service: BookFilterService;
+  let bookState$: any;
+
+  function setupBooks(books: any[]) {
+    bookState$.bookState$ = of({ books });
+  }
+
+  beforeEach(() => {
+    bookState$ = {};
+
+    TestBed.configureTestingModule({
+      providers: [
+        BookFilterService,
+        {
+          provide: BookService,
+          useValue: bookState$
+        },
+        {
+          provide: LibraryService,
+          useValue: {
+            libraryState$: of([])
+          }
+        },
+        {
+          provide: BookRuleEvaluatorService,
+          useValue: {}
+        }
+      ]
+    });
+
+    service = TestBed.inject(BookFilterService);
+  });
+
+  it('should sort category filters alphabetically', async () => {
+    setupBooks([
+      { metadata: { categories: ['Zulu'] } },
+      { metadata: { categories: ['Alpha'] } }
+    ]);
+
+    const streams = service.createFilterStreams(
+      of(null),
+      of('library' as any),
+      of(null),
+      of('and')
+    );
+
+    const categoryFilters = await firstValueFrom(streams.category);
+
+    expect(categoryFilters.map(f => f.value.name)).toEqual(['Alpha', 'Zulu']);
+  });
+
+  it('should sort category filters alphabetically ignoring case', async () => {
+    setupBooks([
+      { metadata: { categories: ['zulu'] } },
+      { metadata: { categories: ['Alpha'] } },
+      { metadata: { categories: ['bravo'] } }
+    ]);
+
+    const streams = service.createFilterStreams(
+      of(null),
+      of('library' as any),
+      of(null),
+      of('and')
+    );
+
+    const categoryFilters = await firstValueFrom(streams.category);
+
+    expect(categoryFilters.map(f => f.value.name)).toEqual(['Alpha', 'bravo', 'zulu']);
+  });
+});

--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.service.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.service.ts
@@ -13,7 +13,7 @@ import {Filter, FILTER_CONFIGS, FILTER_EXTRACTORS, FilterType, FilterValue, NUME
 import {filterBooksByFilters} from '../filters/sidebar-filter';
 import {BookFilterMode} from '../../../../settings/user-management/user.service';
 
-const MAX_FILTER_ITEMS = 100;
+const MAX_FILTER_ITEMS = Number.MAX_SAFE_INTEGER;
 
 @Injectable({providedIn: 'root'})
 export class BookFilterService {
@@ -171,9 +171,13 @@ export class BookFilterService {
     }
 
     const filters = Array.from(filterMap.values());
-    const sorted = sortMode === 'sortIndex'
-      ? this.sortFiltersBySortIndex(filters)
-      : this.sortFiltersByCount(filters);
+    const sorted = filters.sort((a, b) =>
+	String(a.value.name ?? a.value).localeCompare(
+	String(b.value.name ?? b.value),
+	undefined,
+	{ sensitivity: 'base' }
+	)
+	);
 
     return sorted.slice(0, MAX_FILTER_ITEMS);
   }

--- a/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.service.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-filter/book-filter.service.ts
@@ -12,8 +12,9 @@ import {EntityType} from '../book-browser.component';
 import {Filter, FILTER_CONFIGS, FILTER_EXTRACTORS, FilterType, FilterValue, NUMERIC_ID_FILTER_TYPES, SortMode} from './book-filter.config';
 import {filterBooksByFilters} from '../filters/sidebar-filter';
 import {BookFilterMode} from '../../../../settings/user-management/user.service';
+import { DEFAULT_FILTER_LIMIT } from './book-filter.constants';
 
-const MAX_FILTER_ITEMS = Number.MAX_SAFE_INTEGER;
+const MAX_FILTER_ITEMS = DEFAULT_FILTER_LIMIT;
 
 @Injectable({providedIn: 'root'})
 export class BookFilterService {

--- a/booklore-ui/src/i18n/en/book.json
+++ b/booklore-ui/src/i18n/en/book.json
@@ -510,7 +510,9 @@
   "filter": {
     "title": "Filters",
     "showingFirst100": "Showing first 100 items",
-    "footerNote": "Note: Top 100 items are displayed per filter category",
+    "footerNoteN": "Note: Top {{count}} items are displayed per filter category",
+    "footerNote100": "Note: Top 100 items are displayed per filter category",
+    "footerNote": "Note: Currently showing all items for every  filter category",
     "labels": {
       "author": "Author",
       "category": "Genre",


### PR DESCRIPTION
## 📝 Description

Currently the only way to view and select one or more genre tags is through the sidebar, however that only shows 100 items, hiding the rest. In addition, the genres in the sidebar are sorted by book count which is unhelpful as it makes it very difficult to find a particular genre. 

**Linked Issue:** Fixes #3156


## 🏷️ Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement to existing feature
- [ ] Refactor (no behavior change)
- [ ] Breaking change (existing functionality affected)
- [ ] Documentation update

## 🔧 Changes

- Sort filter values alphabetically instead of by count.
- Remove the hard 100-item limit for filter values.
- Introduce DEFAULT_FILTER_LIMIT constant for filter limits.
- Improve footer notes to reflect whether:
- all items are shown, or
- only the top N items are displayed.
- Added tests for alphabetical sorting of filter values

## 🧪 Testing (MANDATORY)

> **PRs without this section filled out will be closed.** "Tests pass" or "Tested locally" is not sufficient. You must provide specifics.

**Manual testing steps you performed:**
<!-- Walk through the exact steps you took to verify your change works. Be specific. -->
1. I created a new branch for my own mods
2. A docker image is created based on mods from my branch
3. I run a container from my own image
4. It all works as expected

**Regression testing:**
<!-- How did you verify that existing related features still work after your change? -->
- I have checked to see all genres show up
- I have clicked one genre and ensure the correct books show up
- I have clicked multiple genres with various combinations of the boolean functions at the top of the sidebar and they still work fine

**Edge cases covered:**
<!-- What boundary conditions or unusual inputs did you test? -->
- None

**Test output:**
<!-- Paste the actual terminal output from running tests. Not "all pass", the real output. -->

<details>
<summary>Backend test output (<code>./gradlew test</code>)</summary>

```
BUILD SUCCESSFUL in 9s
6 actionable tasks: 6 up-to-date

```

</details>

<details>
<summary>Frontend test output (<code>ng test</code>)</summary>

```
Node.js version v25.8.1 detected.
Odd numbered Node.js versions will not enter LTS status and should not be used for production. For more information, please see https://nodejs.org/en/about/previous-releases/.
Using Vitest configuration file: /home/dinosm/apps/src/booklore/booklore-ui/vitest-base.config.ts
Initial chunk files                                                            | Names                                                                       |  Raw size
spec-app-features-magic-shelf-component-magic-shelf-component.js               | spec-app-features-magic-shelf-component-magic-shelf-component               |   1.12 MB | 
spec-app-features-magic-shelf-service-book-rule-evaluator.service.js           | spec-app-features-magic-shelf-service-book-rule-evaluator.service           |  65.08 kB | 
spec-app-app.component.js                                                      | spec-app-app.component                                                      |  59.24 kB | 
chunk-OODOJWIH.js                                                              | -                                                                           |  55.00 kB | 
styles.css                                                                     | styles                                                                      |  30.99 kB | 
chunk-6GQKDBEE.js                                                              | -                                                                           |  25.09 kB | 
spec-app-features-magic-shelf-service-book-rule-evaluator-metadata-presence.js | spec-app-features-magic-shelf-service-book-rule-evaluator-metadata-presence |  23.21 kB | 
chunk-DTAZO7BH.js                                                              | -                                                                           |  15.75 kB | 
spec-app-features-magic-shelf-service-magic-shelf-utils.js                     | spec-app-features-magic-shelf-service-magic-shelf-utils                     |  11.36 kB | 
chunk-PUIDBMXW.js                                                              | -                                                                           |   6.10 kB | 
chunk-HMKTQGOO.js                                                              | -                                                                           |   4.92 kB | 
spec-app-core-security-auth-initializer.js                                     | spec-app-core-security-auth-initializer                                     |   4.73 kB | 
spec-app-features-book-service-library-health.service.js                       | spec-app-features-book-service-library-health.service                       |   2.95 kB | 
chunk-3J3QIHZF.js                                                              | -                                                                           |   2.19 kB | 
chunk-MUCKHQNJ.js                                                              | -                                                                           |   2.07 kB | 
chunk-HPNCK62B.js                                                              | -                                                                           |   1.33 kB | 
init-testbed.js                                                                | init-testbed                                                                |   1.27 kB | 
vitest-mock-patch.js                                                           | vitest-mock-patch                                                           | 481 bytes | 
spec-app-app.js                                                                | spec-app-app                                                                | 202 bytes | 
polyfills.js                                                                   | polyfills                                                                   | 121 bytes | 

                                                                               | Initial total                                                               |   1.43 MB

Application bundle generation complete. [7.377 seconds] - 2026-03-12T11:22:30.710Z


 RUN  v4.0.18 /home/dinosm/apps/src/booklore/booklore-ui
      Coverage enabled with v8

 ✓  booklore  src/app/features/magic-shelf/service/book-rule-evaluator.service.spec.ts (199 tests) 426ms
stderr | src/app/app.component.spec.ts > AppComponent offline detection > should initialize with offline set to false
TypeError: localStorage.getItem is not a function
    at _AuthService.getInternalAccessToken (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:69:25)
    at _AuthService.<instance_members_initializer> (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:24:65)
    at new _AuthService (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:13:7)
    at Object.AuthService_Factory [as factory] (/home/dinosm/apps/src/booklore/booklore-ui/chunk-DTAZO7BH.js:445:16)
    at file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1316:35
    at runInInjectorProfilerContext (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:444:5)
    at R3Injector.hydrate (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1314:11)
    at R3Injector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1203:23)
    at ChainedInjector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:7749:32)
    at lookupTokenUsingModuleInjector (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:890:31)

stderr | src/app/app.component.spec.ts > AppComponent offline detection > should set offline to false when online event fires
TypeError: localStorage.getItem is not a function
    at _AuthService.getInternalAccessToken (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:69:25)
    at _AuthService.<instance_members_initializer> (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:24:65)
    at new _AuthService (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:13:7)
    at Object.AuthService_Factory [as factory] (/home/dinosm/apps/src/booklore/booklore-ui/chunk-DTAZO7BH.js:445:16)
    at file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1316:35
    at runInInjectorProfilerContext (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:444:5)
    at R3Injector.hydrate (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1314:11)
    at R3Injector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1203:23)
    at ChainedInjector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:7749:32)
    at lookupTokenUsingModuleInjector (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:890:31)

stderr | src/app/app.component.spec.ts > AppComponent offline detection > should not show offline when server is reachable despite browser offline event
TypeError: localStorage.getItem is not a function
    at _AuthService.getInternalAccessToken (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:69:25)
    at _AuthService.<instance_members_initializer> (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:24:65)
    at new _AuthService (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:13:7)
    at Object.AuthService_Factory [as factory] (/home/dinosm/apps/src/booklore/booklore-ui/chunk-DTAZO7BH.js:445:16)
    at file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1316:35
    at runInInjectorProfilerContext (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:444:5)
    at R3Injector.hydrate (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1314:11)
    at R3Injector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1203:23)
    at ChainedInjector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:7749:32)
    at lookupTokenUsingModuleInjector (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:890:31)

stderr | src/app/app.component.spec.ts > AppComponent offline detection > should show offline when server is unreachable on browser offline event
TypeError: localStorage.getItem is not a function
    at _AuthService.getInternalAccessToken (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:69:25)
    at _AuthService.<instance_members_initializer> (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:24:65)
    at new _AuthService (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:13:7)
    at Object.AuthService_Factory [as factory] (/home/dinosm/apps/src/booklore/booklore-ui/chunk-DTAZO7BH.js:445:16)
    at file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1316:35
    at runInInjectorProfilerContext (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:444:5)
    at R3Injector.hydrate (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1314:11)
    at R3Injector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1203:23)
    at ChainedInjector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:7749:32)
    at lookupTokenUsingModuleInjector (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:890:31)

stderr | src/app/app.component.spec.ts > AppComponent offline detection > should ping server with HEAD method and no-store cache
TypeError: localStorage.getItem is not a function
    at _AuthService.getInternalAccessToken (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:69:25)
    at _AuthService.<instance_members_initializer> (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:24:65)
    at new _AuthService (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:13:7)
    at Object.AuthService_Factory [as factory] (/home/dinosm/apps/src/booklore/booklore-ui/chunk-DTAZO7BH.js:445:16)
    at file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1316:35
    at runInInjectorProfilerContext (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:444:5)
    at R3Injector.hydrate (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1314:11)
    at R3Injector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1203:23)
    at ChainedInjector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:7749:32)
    at lookupTokenUsingModuleInjector (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:890:31)

stderr | src/app/app.component.spec.ts > AppComponent offline detection > should treat server errors as reachable
TypeError: localStorage.getItem is not a function
    at _AuthService.getInternalAccessToken (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:69:25)
    at _AuthService.<instance_members_initializer> (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:24:65)
    at new _AuthService (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:13:7)
    at Object.AuthService_Factory [as factory] (/home/dinosm/apps/src/booklore/booklore-ui/chunk-DTAZO7BH.js:445:16)
    at file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1316:35
    at runInInjectorProfilerContext (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:444:5)
    at R3Injector.hydrate (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1314:11)
    at R3Injector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1203:23)
    at ChainedInjector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:7749:32)
    at lookupTokenUsingModuleInjector (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:890:31)

stderr | src/app/app.component.spec.ts > AppComponent offline detection > should treat network timeout as unreachable
TypeError: localStorage.getItem is not a function
    at _AuthService.getInternalAccessToken (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:69:25)
    at _AuthService.<instance_members_initializer> (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:24:65)
    at new _AuthService (/home/dinosm/apps/src/booklore/booklore-ui/src/app/shared/service/auth.service.ts:13:7)
    at Object.AuthService_Factory [as factory] (/home/dinosm/apps/src/booklore/booklore-ui/chunk-DTAZO7BH.js:445:16)
    at file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1316:35
    at runInInjectorProfilerContext (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:444:5)
    at R3Injector.hydrate (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1314:11)
    at R3Injector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1203:23)
    at ChainedInjector.get (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:7749:32)
    at lookupTokenUsingModuleInjector (file:///home/dinosm/apps/src/booklore/booklore-ui/node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:890:31)

(node:2053150) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
 ❯  booklore  src/app/app.component.spec.ts (7 tests | 7 failed) 247ms
     × should initialize with offline set to false 170ms
     × should set offline to false when online event fires 24ms
     × should not show offline when server is reachable despite browser offline event 11ms
     × should show offline when server is unreachable on browser offline event 9ms
     × should ping server with HEAD method and no-store cache 8ms
     × should treat server errors as reachable 10ms
     × should treat network timeout as unreachable 11ms
 ✓  booklore  src/app/features/magic-shelf/service/book-rule-evaluator-metadata-presence.spec.ts (85 tests) 266ms
 ✓  booklore  src/app/features/book/service/library-health.service.spec.ts (6 tests) 65ms
 ✓  booklore  src/app/features/magic-shelf/service/magic-shelf-utils.spec.ts (46 tests) 39ms
 ✓  booklore  src/app/features/magic-shelf/component/magic-shelf-component.spec.ts (73 tests) 1551ms
 ✓  booklore  src/app/core/security/auth-initializer.spec.ts (2 tests) 33ms
 ✓  booklore  src/app/app.spec.ts (1 test) 8ms

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 7 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL   booklore  src/app/app.component.spec.ts > AppComponent offline detection > should initialize with offline set to false
 FAIL   booklore  src/app/app.component.spec.ts > AppComponent offline detection > should set offline to false when online event fires
 FAIL   booklore  src/app/app.component.spec.ts > AppComponent offline detection > should not show offline when server is reachable despite browser offline event
 FAIL   booklore  src/app/app.component.spec.ts > AppComponent offline detection > should show offline when server is unreachable on browser offline event
 FAIL   booklore  src/app/app.component.spec.ts > AppComponent offline detection > should ping server with HEAD method and no-store cache
 FAIL   booklore  src/app/app.component.spec.ts > AppComponent offline detection > should treat server errors as reachable
 FAIL   booklore  src/app/app.component.spec.ts > AppComponent offline detection > should treat network timeout as unreachable
TypeError: localStorage.getItem is not a function
 ❯ _AuthService.getInternalAccessToken src/app/shared/service/auth.service.ts:69:25
 ❯ _AuthService.<instance_members_initializer> src/app/shared/service/auth.service.ts:24:65
 ❯ new _AuthService src/app/shared/service/auth.service.ts:13:7
 ❯ Object.AuthService_Factory [as factory] chunk-DTAZO7BH.js:445:16
 ❯ node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1316:35
 ❯ runInInjectorProfilerContext node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:444:5
 ❯ R3Injector.hydrate node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1314:11
 ❯ R3Injector.get node_modules/@angular/core/fesm2022/_effect-chunk2.mjs:1203:23
 ❯ ChainedInjector.get node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:7749:32
 ❯ lookupTokenUsingModuleInjector node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:890:31

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/7]⎯


 Test Files  1 failed | 7 passed (8)
      Tests  7 failed | 412 passed (419)
   Start at  11:22:30
   Duration  12.00s (transform 1.36s, setup 3.25s, import 5.20s, tests 2.63s, environment 5.15s)

JUNIT report written to /home/dinosm/apps/src/booklore/booklore-ui/test-results/vitest-results.xml
```

Frontend test suite currently has 7 failures in src/app/app.component.spec.ts related to localStorage/AuthService setup:
TypeError: localStorage.getItem is not a function

I confirmed these same frontend failures also occur on the current develop branch, so they appear to be pre-existing and unrelated to this PR.
</details>

## 📸 Screen Recording / Screenshots (MANDATORY)

> Every PR must include a **screen recording or screenshots** showing the change working end-to-end in a running local instance (both backend and frontend). This means you must have actually built, run, and tested the code yourself. PRs without visual proof will be closed without review.

Screenshot showing alphabetical sorting of genres and amended footerNote:
<img width="798" height="896" alt="image" src="https://github.com/user-attachments/assets/c78fc0d6-525b-4b21-bee8-1b3d842d78bc" />


---

## ✅ Pre-Submission Checklist

> **All boxes must be checked before requesting review.** Incomplete PRs will be closed without review. No exceptions.

- [x] This PR is linked to an approved issue
- [x] Code follows project [backend and frontend conventions](../CONTRIBUTING.md#backend-conventions)
- [x] Branch is up to date with `develop` (merge conflicts resolved)
- [x] I ran the full stack locally (backend + frontend + database) and verified the change works
- [x] Automated tests added or updated to cover changes (backend **and** frontend)
- [x] All tests pass locally and output is pasted above
- [x] Screen recording or screenshots are attached above proving the change works
- [x] PR is a single focused change (one bug fix OR one feature, not multiple unrelated changes)
- [x] PR is reasonably scoped (PRs over 1000+ changed lines will be closed, split into smaller PRs)
- [x] No unsolicited refactors, cleanups, or "improvements" are bundled in
- [x] Flyway migration versioning is correct _(if schema was modified)_
- [x] Documentation PR submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(if user-facing changes)_

### 🤖 AI-Assisted Contributions

> **If any part of this PR was generated or assisted by AI tools (Copilot, Claude, ChatGPT, etc.), all items below are mandatory.** You are fully responsible for every line you submit. "The AI wrote it" is not an excuse, and AI-generated PRs that clearly haven't been reviewed are the #1 reason PRs get closed.

- [x] I have read and understand every line of this PR and can explain any part of it during review
- [x] I personally ran the code and verified it works (not just trusted the AI's output)
- [x] PR is scoped to a single logical change, not a dump of everything the AI suggested
- [x] Tests validate actual behavior, not just coverage (AI-generated tests often assert nothing meaningful)
- [x] No dead code, placeholder comments, `TODO`s, or unused scaffolding left behind by AI
- [x] I did not submit refactors, style changes, or "improvements" the AI suggested beyond the scope of the issue

---

## 💬 Additional Context _(optional)_

<!-- Any extra information or discussion points for reviewers -->
