### PR TITLE
Fix completion race chart showing 100% for all books (#3288)

### DIFF
--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.ts
@@ -175,7 +175,7 @@ export class CompletionRaceChartComponent implements OnInit, OnDestroy {
       }
       bookMap.get(item.bookId)!.sessions.push({
         date: new Date(item.sessionDate),
-        progress: Math.min(item.endProgress * 100, 100)
+        progress: Math.min(item.endProgress, 100)
       });
     }
 


### PR DESCRIPTION
Reading progress values are already stored as percentages (0-100) but the completion race chart was multiplying by 100 again, so anything over 1% got capped to 100%. Removed the extra scaling.

Fixes #3288