### PR TITLE
Sort and filter shelves in the assign books to shelves dialog (#3276)

### DIFF
--- a/booklore-ui/src/app/features/book/components/shelf-assigner/shelf-assigner.component.html
+++ b/booklore-ui/src/app/features/book/components/shelf-assigner/shelf-assigner.component.html
@@ -32,10 +32,22 @@
             <i class="pi pi-bookmark"></i>
             {{ t('shelvesAvailable', { count: (shelfState$ | async)!.shelves!.length }) }}
           </span>
+          <p-iconfield class="shelf-search">
+            <p-inputicon class="pi pi-search"/>
+            <input
+              type="text"
+              pInputText
+              [(ngModel)]="searchQuery"
+              [placeholder]="t('searchPlaceholder')"
+            />
+            @if (searchQuery) {
+              <i class="pi pi-times clear-icon" (click)="searchQuery = ''"></i>
+            }
+          </p-iconfield>
         </div>
 
         <div class="shelves-grid">
-          @for (shelf of (shelfState$ | async)?.shelves; track shelf.id) {
+          @for (shelf of filterShelves((shelfState$ | async)!.shelves!); track shelf.id) {
             <div class="shelf-item" [class.selected]="isShelfSelected(shelf)">
               <div class="shelf-checkbox">
                 <p-checkbox

--- a/booklore-ui/src/app/features/book/components/shelf-assigner/shelf-assigner.component.scss
+++ b/booklore-ui/src/app/features/book/components/shelf-assigner/shelf-assigner.component.scss
@@ -51,6 +51,7 @@
   padding: 0.625rem 0.875rem;
   background: var(--overlay-background);
   border-radius: 6px;
+  gap: 0.5rem;
 
   .shelf-count {
     display: flex;
@@ -59,17 +60,51 @@
     font-size: 0.9rem;
     font-weight: 600;
     color: var(--text-color);
+    white-space: nowrap;
 
     i {
       color: var(--primary-color);
     }
   }
 
+  .shelf-search {
+    flex: 1;
+    max-width: 200px;
+    position: relative;
+
+    input {
+      width: 100%;
+      font-size: 0.85rem;
+      padding: 0.375rem 2rem 0.375rem 2rem;
+    }
+
+    .clear-icon {
+      position: absolute;
+      right: 0.5rem;
+      top: 50%;
+      transform: translateY(-50%);
+      cursor: pointer;
+      color: var(--text-secondary-color);
+      font-size: 0.75rem;
+      z-index: 1;
+
+      &:hover {
+        color: var(--text-color);
+      }
+    }
+  }
+
   @media (max-width: 480px) {
     padding: 0.5rem 0.625rem;
+    flex-wrap: wrap;
 
     .shelf-count {
       font-size: 0.85rem;
+    }
+
+    .shelf-search {
+      max-width: 100%;
+      order: 1;
     }
   }
 }

--- a/booklore-ui/src/app/features/book/components/shelf-assigner/shelf-assigner.component.ts
+++ b/booklore-ui/src/app/features/book/components/shelf-assigner/shelf-assigner.component.ts
@@ -18,6 +18,9 @@ import {UserService} from '../../../settings/user-management/user.service';
 import {IconDisplayComponent} from '../../../../shared/components/icon-display/icon-display.component';
 import {IconSelection} from '../../../../shared/service/icon-picker.service';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
+import {InputText} from 'primeng/inputtext';
+import {IconField} from 'primeng/iconfield';
+import {InputIcon} from 'primeng/inputicon';
 
 @Component({
   selector: 'app-shelf-assigner',
@@ -30,7 +33,10 @@ import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
     AsyncPipe,
     FormsModule,
     IconDisplayComponent,
-    TranslocoDirective
+    TranslocoDirective,
+    InputText,
+    IconField,
+    InputIcon
   ]
 })
 export class ShelfAssignerComponent implements OnInit {
@@ -45,14 +51,25 @@ export class ShelfAssignerComponent implements OnInit {
   private userService = inject(UserService);
   private readonly t = inject(TranslocoService);
 
+  searchQuery = '';
+  private shelfSortField: 'name' | 'id' = 'name';
+  private shelfSortOrder: 'asc' | 'desc' = 'asc';
+
   shelfState$: Observable<ShelfState> = combineLatest([
     this.shelfService.shelfState$,
     this.userService.userState$
   ]).pipe(
-    map(([state, userState]) => ({
-      ...state,
-      shelves: state.shelves?.filter(s => s.userId === userState.user?.id) || []
-    }))
+    map(([state, userState]) => {
+      if (userState.user?.userSettings.sidebarShelfSorting) {
+        this.shelfSortField = this.validateSortField(userState.user.userSettings.sidebarShelfSorting.field);
+        this.shelfSortOrder = this.validateSortOrder(userState.user.userSettings.sidebarShelfSorting.order);
+      }
+      const filtered = state.shelves?.filter(s => s.userId === userState.user?.id) || [];
+      return {
+        ...state,
+        shelves: this.sortShelves(filtered)
+      };
+    })
   );
 
   book: Book = this.dynamicDialogConfig.data.book;
@@ -131,5 +148,35 @@ export class ShelfAssignerComponent implements OnInit {
     } else {
       return {type: 'PRIME_NG', value: `pi pi-${shelf.icon}`};
     }
+  }
+
+  filterShelves(shelves: Shelf[]): Shelf[] {
+    if (!this.searchQuery.trim()) {
+      return shelves;
+    }
+    const query = this.searchQuery.trim().toLowerCase();
+    return shelves.filter(s => s.name.toLowerCase().includes(query));
+  }
+
+  private sortShelves(shelves: Shelf[]): Shelf[] {
+    return [...shelves].sort((a, b) => {
+      const aVal = (a as unknown as Record<string, unknown>)[this.shelfSortField] ?? '';
+      const bVal = (b as unknown as Record<string, unknown>)[this.shelfSortField] ?? '';
+      let comparison = 0;
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        comparison = aVal.localeCompare(bVal);
+      } else if (typeof aVal === 'number' && typeof bVal === 'number') {
+        comparison = aVal - bVal;
+      }
+      return this.shelfSortOrder === 'asc' ? comparison : -comparison;
+    });
+  }
+
+  private validateSortField(field: string): 'name' | 'id' {
+    return field === 'id' ? 'id' : 'name';
+  }
+
+  private validateSortOrder(order: string): 'asc' | 'desc' {
+    return order === 'desc' ? 'desc' : 'asc';
   }
 }

--- a/booklore-ui/src/i18n/en/book.json
+++ b/booklore-ui/src/i18n/en/book.json
@@ -607,6 +607,7 @@
     "descriptionMulti": "Select shelves for {{ count }} book(s)",
     "descriptionSingle": "Organize \"{{ title }}\" into your shelves",
     "shelvesAvailable": "{{ count }} shelf(ves) available",
+    "searchPlaceholder": "Search shelves...",
     "emptyTitle": "No Shelves Available",
     "emptyDescription": "Create your first shelf to start organizing your books.<br/>Click the button below to get started.",
     "createShelf": "Create Shelf",

--- a/booklore-ui/src/i18n/es/book.json
+++ b/booklore-ui/src/i18n/es/book.json
@@ -607,6 +607,7 @@
         "descriptionMulti": "Seleccionar estantes para {{ count }} libro(s)",
         "descriptionSingle": "Organizar \"{{ title }}\" en tus estantes",
         "shelvesAvailable": "{{ count }} estante(s) disponible(s)",
+        "searchPlaceholder": "Buscar estantes...",
         "emptyTitle": "No hay estantes disponibles",
         "emptyDescription": "Crea tu primer estante para empezar a organizar tus libros.<br/>Haz clic en el botón de abajo para comenzar.",
         "createShelf": "Crear estante",


### PR DESCRIPTION
Shelves in the "Assign Books to Shelves" dialog now respect the user's sidebar shelf sorting preference (name/creation, asc/desc) instead of showing them in arbitrary API order. Also added a search input to quickly filter through shelves by name, which is handy for users with a lot of shelves.

Fixes #3276