### PR TITLE
Fix NPE when deleting authors (#3296)

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/AuthorMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/AuthorMetadataService.java
@@ -13,6 +13,7 @@ import org.booklore.model.dto.Library;
 import org.booklore.model.dto.request.AuthorMatchRequest;
 import org.booklore.model.dto.request.AuthorUpdateRequest;
 import org.booklore.model.entity.AuthorEntity;
+import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.enums.AuditAction;
 import org.booklore.model.enums.AuthorMetadataSource;
 import org.booklore.repository.AuthorRepository;
@@ -189,6 +190,13 @@ public class AuthorMetadataService {
             if (author == null) continue;
 
             String authorName = author.getName();
+
+            if (author.getBookMetadataEntityList() != null) {
+                for (BookMetadataEntity metadata : author.getBookMetadataEntityList()) {
+                    metadata.getAuthors().remove(author);
+                }
+            }
+
             fileService.deleteAuthorImages(authorId);
             authorRepository.delete(author);
 


### PR DESCRIPTION
Deleting an author was causing a NullPointerException because the DB cascade delete left gaps in the sort_order column of the author mapping table. Hibernate interprets those gaps as null elements in the ordered list, so any subsequent book fetch that streams over authors would blow up. Now we remove the author from each book's author list before deleting, letting Hibernate handle the reindexing properly.

Fixes #3296