### PR TITLE
Create /books and chown to booklore user in entrypoint.sh. Fix #3333

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,8 @@ if ! getent passwd "$USER_ID" >/dev/null 2>&1; then
     adduser -u "$USER_ID" -G "$(getent group "$GROUP_ID" | cut -d: -f1)" -S -D booklore
 fi
 
-# Ensure data and bookdrop directories exist and are writable by the target user
-mkdir -p /app/data /bookdrop
-chown "$USER_ID:$GROUP_ID" /app/data /bookdrop 2>/dev/null || true
+# Ensure data, bookdrop and books directories exist and are writable by the target user
+mkdir -p /app/data /bookdrop /books
+chown "$USER_ID:$GROUP_ID" /app/data /bookdrop /books 2>/dev/null || true
 
 exec su-exec "$USER_ID:$GROUP_ID" "$@"


### PR DESCRIPTION
## 📝 Description

`/books` folder is needed for libraries, but entrypoint.sh doesn't include it.

**Linked Issue:** Fixes #3333 

## 🏷️ Type of Change

- [X] Bug fix

## 🔧 Changes

In `entrypoint.sh`:

- Create `/books` folder
- `chown` it
- Add explanation in commented line

## 🧪 Testing

**Manual testing steps you performed:**

1. Created Dockerfile
```
FROM booklore/booklore:latest

COPY entrypoint.sh /usr/local/bin/entrypoint.sh
RUN chmod +x /usr/local/bin/entrypoint.sh
```

2. Created entrypoint.sh as pull request
3. Added build to docker-compose.yml
