### PR TITLE
fix: preserve OIDC client secret when saving config changes

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/booklore-api/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -70,6 +70,10 @@ public class AppSettingService {
             validateOidcForceOnlyMode(val);
         }
 
+        if (key == AppSettingKey.OIDC_PROVIDER_DETAILS) {
+            val = preserveOidcClientSecret(val);
+        }
+
         var setting = settingPersistenceHelper.appSettingsRepository.findByName(key.toString());
         if (setting == null) {
             setting = new AppSettingEntity();
@@ -85,6 +89,24 @@ public class AppSettingService {
             default -> AuditAction.SETTINGS_UPDATED;
         };
         auditService.log(action, "Updated setting: " + key);
+    }
+
+    private Object preserveOidcClientSecret(Object val) {
+        if (val instanceof Map<?, ?> incomingMap) {
+            Object secret = incomingMap.get("clientSecret");
+            if (secret == null || (secret instanceof String s && s.isBlank())) {
+                Map<String, String> settingsMap = getSettingsMap();
+                OidcProviderDetails existing = settingPersistenceHelper.getJsonSetting(
+                        settingsMap, AppSettingKey.OIDC_PROVIDER_DETAILS, OidcProviderDetails.class, null, false);
+                if (existing != null && existing.getClientSecret() != null && !existing.getClientSecret().isBlank()) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> mutableMap = new java.util.LinkedHashMap<>((Map<String, Object>) incomingMap);
+                    mutableMap.put("clientSecret", existing.getClientSecret());
+                    return mutableMap;
+                }
+            }
+        }
+        return val;
     }
 
     private void validateOidcForceOnlyMode(Object val) {


### PR DESCRIPTION
## Summary

When saving OIDC configuration changes, the client secret was silently deleted because the form loads with a blank secret field (correct for security) but saving overwrites the stored value with blank.

## Changes

Added `preserveOidcClientSecret()` in `AppSettingService` that intercepts `OIDC_PROVIDER_DETAILS` updates. If the incoming `clientSecret` is null or blank, the method reads the existing stored secret and merges it back into the update payload before saving.

The fix uses the existing `getJsonSetting()` helper to deserialize the stored OIDC details, keeping the code consistent with the rest of the settings service.

## Testing

- Save OIDC config with secret -> Refresh page -> Save again without changing secret -> Secret is preserved
- Save OIDC config with a new secret -> Secret is updated correctly
- Save OIDC config with explicitly empty secret -> Existing secret is preserved (not deleted)

Fixes #3330

This contribution was developed with AI assistance (Claude Code).